### PR TITLE
[FIX] QuestionHeart, AnswerHeart Redis로 저장하도록 수정

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/entity/AnswerHeart.java
+++ b/src/main/java/com/server/capple/domain/answer/entity/AnswerHeart.java
@@ -1,27 +1,20 @@
 package com.server.capple.domain.answer.entity;
 
-import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.question.entity.Question;
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @Builder
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
+@RedisHash("AnswerHeart")
 public class AnswerHeart {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "answer_id", nullable = false)
-    private Answer answer;
+    private Long answerId;
+    private Long memberId;
 
 }

--- a/src/main/java/com/server/capple/domain/answer/entity/AnswerHeart.java
+++ b/src/main/java/com/server/capple/domain/answer/entity/AnswerHeart.java
@@ -1,10 +1,10 @@
 package com.server.capple.domain.answer.entity;
 
-import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter
@@ -13,6 +13,7 @@ import org.springframework.data.redis.core.RedisHash;
 @AllArgsConstructor
 @RedisHash("AnswerHeart")
 public class AnswerHeart {
+
     @Id
     private Long answerId;
     private Long memberId;

--- a/src/main/java/com/server/capple/domain/question/entity/QuestionHeart.java
+++ b/src/main/java/com/server/capple/domain/question/entity/QuestionHeart.java
@@ -1,26 +1,20 @@
 package com.server.capple.domain.question.entity;
 
-import com.server.capple.domain.member.entity.Member;
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @Builder
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
+@RedisHash("QuestionHeart")
 public class QuestionHeart {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id", nullable = false)
-    private Question question;
+    private Long questionId;
+    private Long memberId;
 
 }

--- a/src/main/java/com/server/capple/domain/question/entity/QuestionHeart.java
+++ b/src/main/java/com/server/capple/domain/question/entity/QuestionHeart.java
@@ -1,6 +1,6 @@
 package com.server.capple.domain.question.entity;
 
-import jakarta.persistence.Id;
+import org.springframework.data.annotation.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/server/capple/domain/tag/Tag.java
+++ b/src/main/java/com/server/capple/domain/tag/Tag.java
@@ -1,6 +1,6 @@
 package com.server.capple.domain.tag;
 
-import jakarta.persistence.Id;
+import org.springframework.data.annotation.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/server/capple/domain/tag/Tag.java
+++ b/src/main/java/com/server/capple/domain/tag/Tag.java
@@ -1,9 +1,11 @@
 package com.server.capple.domain.tag;
 
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
 
 import java.time.LocalDateTime;
 
@@ -11,11 +13,14 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@RedisHash("tag")
 public class Tag {
+    @Id
+    private Long id;
 
     private String name;
     private int usageCount;
-    private String answerId;
-    private String questionId;
+    private Long answerId;
+    private Long questionId;
     private LocalDateTime createAt;
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#10/heart-redis-setting -> develop

### 변경 사항
questionHeart, answerHeart를 레디스 DB에 저장하도록 엔티티를 수정하였습니다.

### 테스트 결과
