### PR TITLE
[FEAT] S3 고아 이미지 삭제 기능 추가

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -69,4 +69,10 @@ public class AnswerController {
         return BaseResponse.onSuccess(answerService.toggleAnswerHeart(member, answerId));
     }
 
+    @Operation(summary = "답변 좋아요/취소 API", description = " 답변 좋아요/취소 API 입니다." +
+            "pathvariable 으로 answerId를 주세요.")
+    @PostMapping("/{memberId}")
+    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberAnswer(@PathVariable Long memberId) {
+        return BaseResponse.onSuccess(answerService.getMemberAnswer(memberId));
+    }
 }

--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -72,15 +72,15 @@ public class AnswerController {
 
     @Operation(summary = "작성한 답변 조회 API", description = " 작성한 답변 조회 API 입니다." +
             "pathvariable 으로 memeberId를 주세요.")
-    @PostMapping("/{memberId}")
-    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberAnswer(@PathVariable Long memberId) {
+    @GetMapping("/{memberId}/")
+    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberAnswer(@PathVariable(value = "memberId") Long memberId) {
         return BaseResponse.onSuccess(answerService.getMemberAnswer(memberId));
     }
 
     @Operation(summary = "좋아한 답변 조회 API", description = " 좋아한 답변 조회 API 입니다." +
             "pathvariable 으로 memeberId를 주세요.")
-    @PostMapping("/{memberId}/heart")
-    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberHeartAnswer(@PathVariable Long memberId) {
+    @GetMapping("/{memberId}/heart")
+    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberHeartAnswer(@PathVariable(value = "memberId") Long memberId) {
         return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(memberId));
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -69,10 +69,17 @@ public class AnswerController {
         return BaseResponse.onSuccess(answerService.toggleAnswerHeart(member, answerId));
     }
 
-    @Operation(summary = "답변 좋아요/취소 API", description = " 답변 좋아요/취소 API 입니다." +
-            "pathvariable 으로 answerId를 주세요.")
+    @Operation(summary = "작성한 답변 조회 API", description = " 작성한 답변 조회 API 입니다." +
+            "pathvariable 으로 memeberId를 주세요.")
     @PostMapping("/{memberId}")
     public BaseResponse<AnswerResponse.MemberAnswerList> getMemberAnswer(@PathVariable Long memberId) {
         return BaseResponse.onSuccess(answerService.getMemberAnswer(memberId));
+    }
+
+    @Operation(summary = "좋아한 답변 조회 API", description = " 좋아한 답변 조회 API 입니다." +
+            "pathvariable 으로 memeberId를 주세요.")
+    @PostMapping("/{memberId}/heart")
+    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberHeartAnswer(@PathVariable Long memberId) {
+        return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(memberId));
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/dto/AnswerResponse.java
+++ b/src/main/java/com/server/capple/domain/answer/dto/AnswerResponse.java
@@ -35,4 +35,22 @@ public class AnswerResponse {
         private Long answerId;
         private Boolean isLiked;
     }
+
+
+    @Getter
+    @Builder
+    public static class MemberAnswerInfo {
+        private Long questionId;
+        private String nickname;
+        private String profileImage;
+        private String content;
+        private String tags;
+        private int heartCount;
+        private String writeAt;
+    }
+
+    @AllArgsConstructor
+    public static class MemberAnswerList {
+        private List<MemberAnswerInfo> memberAnswerInfos;
+    }
 }

--- a/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
@@ -1,11 +1,15 @@
 package com.server.capple.domain.answer.mapper;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
+
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -33,6 +37,22 @@ public class AnswerMapper {
                 .content(answer.getContent())
                 .tags(answer.getTags())
                 .build();
+    }
+
+    public MemberAnswerInfo toMemberAnswerInfo(Answer answer, int heartCount) {
+        return MemberAnswerInfo.builder()
+                .questionId(answer.getQuestion().getId())
+                .nickname(answer.getMember().getNickname())
+                .profileImage(answer.getMember().getProfileImage())
+                .content(answer.getContent())
+                .tags(answer.getTags())
+                .heartCount(heartCount)
+                .writeAt(answer.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .build();
+    }
+
+    public MemberAnswerList toMemberAnswerList(List<MemberAnswerInfo> memberAnswerInfos) {
+        return new MemberAnswerList(memberAnswerInfos);
     }
 
 }

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerHeartRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerHeartRedisRepository.java
@@ -32,4 +32,9 @@ public class AnswerHeartRedisRepository implements Serializable {
             return FALSE;
         }
     }
+
+    public int getAnswerHeartsCount(Long answerId) {
+        String key = ANSWER_HEART_KEY_PREFIX + answerId.toString();
+        return setOperations.members(key).size();
+    }
 }

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerHeartRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerHeartRedisRepository.java
@@ -2,10 +2,14 @@ package com.server.capple.domain.answer.repository;
 
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Repository;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -36,5 +40,20 @@ public class AnswerHeartRedisRepository implements Serializable {
     public int getAnswerHeartsCount(Long answerId) {
         String key = ANSWER_HEART_KEY_PREFIX + answerId.toString();
         return setOperations.members(key).size();
+    }
+
+    public Set<Integer> getMemberHeartsAnswer(Long memberId) {
+        String member = MEMBER_KEY_PREFIX + memberId.toString();
+        ScanOptions option = ScanOptions.scanOptions().match("*").build();
+
+        Cursor<String> cursor = setOperations.scan(member, option);
+        Set<Integer> memberHeartAnswerIds = new HashSet<>();
+
+        while(cursor.hasNext()){
+            String value = cursor.next();
+            Integer answerId = Integer.parseInt(value.replace(ANSWER_HEART_KEY_PREFIX, ""));
+            memberHeartAnswerIds.add(answerId);
+        }
+        return memberHeartAnswerIds;
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.answer.repository;
 
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.Member;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -22,4 +23,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             @Param("questionId") Long questionId,
             @Param("keyword") String keyword,
             Pageable pageable);
+
+    @Query("SELECT a FROM Answer a WHERE a.member = :member and a.deletedAt is null ORDER BY a.createdAt DESC")
+    Optional<List<Answer>> findByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.answer.service;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
@@ -20,4 +21,6 @@ public interface AnswerService {
     AnswerResponse.AnswerLike toggleAnswerHeart(Member loginMember, Long answerId);
 
     AnswerList getAnswerList(Long questionId, String keyword, Pageable pageable);
+
+    MemberAnswerList getMemberAnswer(Long memberId);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
@@ -23,4 +23,6 @@ public interface AnswerService {
     AnswerList getAnswerList(Long questionId, String keyword, Pageable pageable);
 
     MemberAnswerList getMemberAnswer(Long memberId);
+
+    MemberAnswerList getMemberHeartAnswer(Long memberId);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -3,7 +3,6 @@ package com.server.capple.domain.answer.service;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
-import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.mapper.AnswerMapper;
@@ -25,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -158,6 +156,16 @@ public class AnswerServiceImpl implements AnswerService {
         return answerMapper.toMemberAnswerList(
                 answers.stream()
                         .map(answer -> answerMapper.toMemberAnswerInfo(answer, answerHeartRedisRepository.getAnswerHeartsCount(answer.getId())))
+                        .toList()
+        );
+    }
+
+    @Override
+    public MemberAnswerList getMemberHeartAnswer(Long memberId) {
+        return answerMapper.toMemberAnswerList(
+                answerHeartRedisRepository.getMemberHeartsAnswer(memberId)
+                        .stream()
+                        .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer(Long.valueOf((answerId))), answerHeartRedisRepository.getAnswerHeartsCount(Long.valueOf(answerId))))
                         .toList()
         );
     }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -2,6 +2,8 @@ package com.server.capple.domain.answer.service;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.mapper.AnswerMapper;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -147,6 +150,18 @@ public class AnswerServiceImpl implements AnswerService {
         }
 
     }
+
+    @Override
+    public MemberAnswerList getMemberAnswer(Long memberId) {
+        Member member = memberService.findMember(memberId);
+        List<Answer> answers = answerRepository.findByMember(member).orElse(null);
+        return answerMapper.toMemberAnswerList(
+                answers.stream()
+                        .map(answer -> answerMapper.toMemberAnswerInfo(answer, answerHeartRedisRepository.getAnswerHeartsCount(answer.getId())))
+                        .toList()
+        );
+    }
+
 
     //로그인된 유저와 작성자가 같은지 체크
     private void checkPermission(Member loginMember, Answer answer) {

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -40,4 +40,10 @@ public class MemberController {
                                                                       @RequestBody @Valid MemberRequest.EditMemberInfo request) {
         return BaseResponse.onSuccess(memberService.editMemberInfo(memberId, request));
     }
+
+    @Operation(summary = "미사용 이미지 삭제 API", description = " 미사용 이미지 API 입니다.")
+    @DeleteMapping("/image")
+    public BaseResponse<MemberResponse.DeleteProfileImages> deleteOrphanageImages() {
+        return BaseResponse.onSuccess(memberService.deleteOrphanageImages());
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/server/capple/domain/member/dto/MemberResponse.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 
 public class MemberResponse {
 
@@ -28,5 +30,11 @@ public class MemberResponse {
     @Getter
     public static class ProfileImage {
         private String imageUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class DeleteProfileImages {
+        private List<String> DeleteImages;
     }
 }

--- a/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -14,5 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT COUNT(*) FROM Member m WHERE m.nickname = :nickname and m.id != :memberId and m.deletedAt is null")
     Long countMemberByNickname(@Param("nickname") String nickname, @Param("memberId") Long memberId);
 
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM Member m WHERE m.profileImage = :image)")
+    boolean existMemberProfileImage(@Param("image") String image);
 
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -11,4 +11,6 @@ public interface MemberService {
     Member findMember(Long memberId);
     MemberResponse.EditMemberInfo editMemberInfo(Long memberId, MemberRequest.EditMemberInfo request);
     MemberResponse.ProfileImage uploadImage(MultipartFile image);
+
+    MemberResponse.DeleteProfileImages deleteOrphanageImages();
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -28,10 +28,6 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
-    // 기본 프로필 이미지
-    // todo: 기본 프로필 디자인 작업 완료 시 변경
-    private static final String DEFAULT_PROFILE_IMAGE = "https://capple-bucket.s3.ap-northeast-2.amazonaws.com/capple_default_image.png";
-
     private final MemberRepository memberRepository;
     private final MemberMapper memberMapper;
     private final S3ImageComponent s3ImageComponent;
@@ -59,12 +55,11 @@ public class MemberServiceImpl implements MemberService {
     public MemberResponse.EditMemberInfo editMemberInfo(Long memberId, MemberRequest.EditMemberInfo request) {
         Member member = findMember(memberId);
 
-        // 이전 이미지 버킷에서 삭제
-        s3ImageComponent.deleteImage(member.getProfileImage());
-
         // 1. 이미지 업데이트
-        String imageUrl = Optional.ofNullable(request.getProfileImage()).orElse(DEFAULT_PROFILE_IMAGE);
-        member.updateProfileImage(imageUrl);
+        String profileImage = request.getProfileImage();
+        if (profileImage != null) {
+            member.updateProfileImage(profileImage);
+        }
 
         // 2. 닉네임 업데이트
         if (memberRepository.countMemberByNickname(request.getNickname(), memberId) > 0) throw new RestApiException(MemberErrorCode.EXIST_MEMBER_NICKNAME);

--- a/src/main/java/com/server/capple/global/utils/S3ImageComponent.java
+++ b/src/main/java/com/server/capple/global/utils/S3ImageComponent.java
@@ -2,7 +2,9 @@ package com.server.capple.global.utils;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.S3ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -65,5 +69,20 @@ public class S3ImageComponent {
      */
     public void deleteImage(String fileUrl) {
         amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileUrl.split("/", 4)[3]));
+    }
+
+    public List<String> findAllImageUrls(){
+        List<String> imageUrls = new ArrayList<>();
+
+        // 버킷 이미지 전체 조회
+        List<S3ObjectSummary> objectSummaries = amazonS3.listObjects(bucket).getObjectSummaries();
+
+        // imageUrl 추출
+        for (S3ObjectSummary objectSummary : objectSummaries) {
+            String imageUrl = amazonS3.getUrl(bucket, objectSummary.getKey()).toString();
+            imageUrls.add(imageUrl);
+        }
+
+        return imageUrls;
     }
 }


### PR DESCRIPTION
### 이슈 번호 
- #26

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#26/delete-orphanage-images -> develop

### 변경 사항
1. 프로필 이미지에 사용되지 않는 이미지를 S3 버킷에서 삭제하는 기능을 추가했습니다.

### 테스트 결과
# 아직 테스트 진행 X 아직 보지마세요 !!!!!

