### PR TITLE
[FEAT] 애플 소셜 로그인, 회원가입, 토큰 생성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,12 @@ dependencies {
 	implementation 'io.github.openfeign.form:feign-form:3.8.0'
 //	feign jackson
     implementation 'io.github.openfeign:feign-jackson:13.1'
+//    jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+//	암호화
+	implementation 'org.bouncycastle:bcpkix-jdk15on:1.56'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2023.0.0")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -34,6 +38,18 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+//	feign : Http Client Tool
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'io.github.openfeign.form:feign-form:3.8.0'
+//	feign jackson
+    implementation 'io.github.openfeign:feign-jackson:13.1'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 test {

--- a/src/main/java/com/server/capple/CappleApplication.java
+++ b/src/main/java/com/server/capple/CappleApplication.java
@@ -3,12 +3,14 @@ package com.server.capple;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaAuditing
 @EnableFeignClients
+@EnableConfigurationProperties
 public class CappleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/server/capple/CappleApplication.java
+++ b/src/main/java/com/server/capple/CappleApplication.java
@@ -3,10 +3,12 @@ package com.server.capple;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaAuditing
+@EnableFeignClients
 public class CappleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/server/capple/config/feign/AppleFeignClientConfig.java
+++ b/src/main/java/com/server/capple/config/feign/AppleFeignClientConfig.java
@@ -1,0 +1,22 @@
+package com.server.capple.config.feign;
+
+import feign.Logger;
+import feign.form.spring.SpringFormEncoder;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.context.annotation.Bean;
+
+import feign.codec.Encoder;
+import org.springframework.web.client.RestTemplate;
+
+public class AppleFeignClientConfig {
+    @Bean
+    public Encoder multipartFormEncoder() {
+        return new SpringFormEncoder(new SpringEncoder(() -> new HttpMessageConverters(new RestTemplate().getMessageConverters())));
+    }
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+}

--- a/src/main/java/com/server/capple/config/security/AuthMember.java
+++ b/src/main/java/com/server/capple/config/security/AuthMember.java
@@ -1,0 +1,14 @@
+package com.server.capple.config.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'annoymousUser' ? null : member")
+public @interface AuthMember {
+}

--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.server.capple.config.security;
+
+import com.server.capple.config.security.jwt.filter.JwtFilter;
+import com.server.capple.config.security.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtService jwtService;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//    csrf disable
+        http
+            .csrf((auth) -> auth.disable());
+//    Form login disable
+        http
+            .formLogin((auth) -> auth.disable());
+//    http basic disable
+        http
+            .httpBasic((auth) -> auth.disable());
+//    경로별 인가 //TODO Role 분리 필요
+        http
+            .authorizeHttpRequests((auth) -> auth
+//                .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/api-docs/**").permitAll()
+//                .requestMatchers("/member/sign-in","/member/sign-up", "/member/local-sign-in", "/token/**").permitAll()
+//                .requestMatchers("/answers/question/**").hasAnyRole(ROLE_VISITOR.getName(), ROLE_DEVELOPER.getName(), ROLE_ADMIN.getName())
+//                .requestMatchers("**").hasRole(ROLE_DEVELOPER.name())
+//                .requestMatchers("/member/sign-up", "/member/local-sign-up").hasAnyRole(ROLE_VISITOR.name(),ROLE_ADMIN.name())
+//                .requestMatchers("/admin/**").hasRole(ROLE_ADMIN.name())
+                .anyRequest().permitAll());
+//                .anyRequest().authenticated());
+        http
+            .addFilterBefore(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class);
+//    세션 설정
+        http
+            .sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}

--- a/src/main/java/com/server/capple/config/security/auth/CustomUserDetails.java
+++ b/src/main/java/com/server/capple/config/security/auth/CustomUserDetails.java
@@ -1,0 +1,55 @@
+package com.server.capple.config.security.auth;
+
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+    @Bean
+    public final Member getMember() {
+        return member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() { //TODO Authority 관련 설정 추가 필요
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getSub();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getSub();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/server/capple/config/security/auth/service/JpaUserDetailService.java
+++ b/src/main/java/com/server/capple/config/security/auth/service/JpaUserDetailService.java
@@ -1,0 +1,22 @@
+package com.server.capple.config.security.auth.service;
+
+import com.server.capple.config.security.auth.CustomUserDetails;
+import com.server.capple.domain.member.repository.MemberRepository;
+import com.server.capple.global.exception.RestApiException;
+import com.server.capple.global.exception.errorCode.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JpaUserDetailService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+    @Override
+    public CustomUserDetails loadUserByUsername(String userId) {
+        return memberRepository.findById(Long.valueOf(userId))
+            .map(CustomUserDetails::new).orElseThrow(
+                () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND)
+            );
+    }
+}

--- a/src/main/java/com/server/capple/config/security/jwt/dto/JwtProperties.java
+++ b/src/main/java/com/server/capple/config/security/jwt/dto/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.server.capple.config.security.jwt.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    private String jwt_secret;
+    private Long refresh_expired_time;
+    private Long access_expired_time;
+}

--- a/src/main/java/com/server/capple/config/security/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/server/capple/config/security/jwt/filter/JwtFilter.java
@@ -1,0 +1,47 @@
+package com.server.capple.config.security.jwt.filter;
+
+import com.server.capple.config.security.jwt.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+//        토큰 추출
+        String authorization = request.getHeader("Authorization");
+//        토큰이 유형 검증
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+//        토큰 분리
+        String token = authorization.split(" ")[1];
+//        토큰 만료 여부 확인
+        if (jwtService.isExpired(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+//        토큰에서 tokenType 추출
+        String tokenType = jwtService.getTokenType(token);
+        if(tokenType == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        if(!tokenType.equals("signUp")) {//TODO Authentication 관련 설정 추가 필요
+            Authentication authentication = jwtService.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
+++ b/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
@@ -1,0 +1,18 @@
+package com.server.capple.config.security.jwt.service;
+
+import com.server.capple.domain.member.dto.MemberResponse;
+import com.server.capple.domain.member.entity.Role;
+import org.springframework.security.core.Authentication;
+
+public interface JwtService {
+    String createJwt(Long memberId, String role, String tokenType);
+    String createSignUpAccessJwt(String sub);
+    Authentication getAuthentication(String token);
+    String getSub(String token);
+    String getTokenType(String token);
+    Integer getMemberId(String token);
+    String getRole(String token);
+    Boolean isExpired(String token);
+    Boolean checkJwt(String token);
+    MemberResponse.Tokens refreshTokens(Long memberId, Role role);
+}

--- a/src/main/java/com/server/capple/config/security/jwt/service/JwtServiceImpl.java
+++ b/src/main/java/com/server/capple/config/security/jwt/service/JwtServiceImpl.java
@@ -1,0 +1,113 @@
+package com.server.capple.config.security.jwt.service;
+
+import com.server.capple.config.security.auth.CustomUserDetails;
+import com.server.capple.config.security.auth.service.JpaUserDetailService;
+import com.server.capple.config.security.jwt.dto.JwtProperties;
+import com.server.capple.domain.member.dto.MemberResponse;
+import com.server.capple.domain.member.entity.Role;
+import com.server.capple.domain.member.mapper.TokensMapper;
+import com.server.capple.global.exception.RestApiException;
+import com.server.capple.global.exception.errorCode.AuthErrorCode;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtServiceImpl implements JwtService{
+    private SecretKey secretKey;
+    private final JwtProperties jwtProperties;
+    private final JpaUserDetailService userDetailService;
+    private final TokensMapper tokensMapper;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = new SecretKeySpec(jwtProperties.getJwt_secret().getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS512.key().build().getAlgorithm());
+    }
+
+    public String createJwt(Long memberId, String role, String tokenType) {
+        Long expiredTime = 0L;
+        if (tokenType == "refresh") {
+            expiredTime = jwtProperties.getRefresh_expired_time();
+        } else if (tokenType == "access") {
+            expiredTime = jwtProperties.getAccess_expired_time();
+        } else {
+            throw new RestApiException(AuthErrorCode.INVALID_TOKEN_TYPE);
+        }
+        return Jwts.builder()
+            .claim("tokenType", tokenType)
+            .claim("memberId", memberId)
+            .claim("role", role)
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis() + expiredTime))
+            .signWith(SignatureAlgorithm.HS512, secretKey)
+            .compact();
+    }
+
+    public String createSignUpAccessJwt(String sub) {
+        Long expiredTime = jwtProperties.getRefresh_expired_time();
+        return Jwts.builder()
+            .claim("tokenType", "signUp")
+            .claim("sub", sub)
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis() + expiredTime))
+            .signWith(SignatureAlgorithm.HS512, secretKey)
+            .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        CustomUserDetails userDetails = userDetailService.loadUserByUsername(Long.toString(getMemberId(token)));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String getSub(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("sub", String.class);
+    }
+
+    public String getTokenType(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
+    }
+
+    public Integer getMemberId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Integer.class);
+    }
+
+    public String getRole(String token) { //TODO 인가 관련 추가 구현 필요
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public Boolean checkJwt(String token) { //TODO 토큰 유효성 검증 로직 수정 필요
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new RestApiException(AuthErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new RestApiException(AuthErrorCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new RestApiException(AuthErrorCode.UNSUPPORTED_TOKEN);
+        } catch (SignatureException e) {
+            throw new RestApiException(AuthErrorCode.WRONG_TOKEN_SIGNITURE);
+        } catch (IllegalArgumentException e) {
+            throw new RestApiException(AuthErrorCode.EMPTY_TOKEN);
+        }
+    }
+
+    public MemberResponse.Tokens refreshTokens(Long memberId, Role role) {
+        String accessToken = createJwt(memberId, role.getName(), "access");
+        String refreshToken = createJwt(memberId, role.getName(), "refresh");
+        return tokensMapper.toTokens(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/client/AppleAuthClient.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/client/AppleAuthClient.java
@@ -1,0 +1,14 @@
+package com.server.capple.config.security.oauth.apple.client;
+
+import com.server.capple.config.feign.AppleFeignClientConfig;
+import com.server.capple.config.security.oauth.apple.dto.request.IdTokenRequest;
+import com.server.capple.config.security.oauth.apple.dto.response.AppleSocialTokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(name = "appleAuthClient", url = "https://appleid.apple.com/auth", configuration = AppleFeignClientConfig.class)
+public interface AppleAuthClient {
+    @PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    AppleSocialTokenResponse generateAndValidateToken(IdTokenRequest request);
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/dto/AppleIdTokenPayload.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/dto/AppleIdTokenPayload.java
@@ -1,0 +1,18 @@
+package com.server.capple.config.security.oauth.apple.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AppleIdTokenPayload {
+    private String iss; // 발급자
+    private String aud;
+    private String exp; // 만료 시간
+    private String iat; // 발급 시간
+    private String sub; // 사용자 고유 번호
+    private String c_hash; // 해시값
+    private String nonce;
+    private String auth_time; // 인증 시간
+    private String nonce_supported; // nonce 지원 여부
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/dto/request/IdTokenRequest.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/dto/request/IdTokenRequest.java
@@ -1,0 +1,24 @@
+package com.server.capple.config.security.oauth.apple.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class IdTokenRequest {
+    @JsonProperty("client_id")
+    private String client_id;
+    @JsonProperty("client_secret")
+    private String client_secret;
+    @JsonProperty("code")
+    private String code;
+    @JsonProperty("grant_type")
+    private String grant_type;
+    @JsonProperty("refresh_token")
+    private String refresh_token;
+    @JsonProperty("redirect_uri")
+    private String redirect_uri;
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/dto/response/AppleSocialTokenResponse.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/dto/response/AppleSocialTokenResponse.java
@@ -1,0 +1,18 @@
+package com.server.capple.config.security.oauth.apple.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class AppleSocialTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+    @JsonProperty("id_token")
+    private String idToken;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("token_type")
+    private String tokenType;
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/mapper/IdTokensRequestMapper.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/mapper/IdTokensRequestMapper.java
@@ -1,0 +1,26 @@
+package com.server.capple.config.security.oauth.apple.mapper;
+
+import com.server.capple.config.security.oauth.apple.dto.request.IdTokenRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdTokensRequestMapper {
+    public IdTokenRequest toIdTokenRequestByCode(String clientId, String clientSecret, String code, String grantType, String redirectUri) {
+        return IdTokenRequest.builder()
+            .client_id(clientId)
+            .client_secret(clientSecret)
+            .code(code)
+            .grant_type(grantType)
+            .redirect_uri(redirectUri)
+            .build();
+    }
+    public IdTokenRequest toIdTokenRequestByRefreshToken(String clientId, String clientSecret, String refreshToken, String grantType, String redirectUri) {
+        return IdTokenRequest.builder()
+            .client_id(clientId)
+            .client_secret(clientSecret)
+            .refresh_token(refreshToken)
+            .grant_type(grantType)
+            .redirect_uri(redirectUri)
+            .build();
+    }
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/service/AppleAuthService.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/service/AppleAuthService.java
@@ -1,0 +1,7 @@
+package com.server.capple.config.security.oauth.apple.service;
+
+import com.server.capple.config.security.oauth.apple.dto.AppleIdTokenPayload;
+
+public interface AppleAuthService {
+    AppleIdTokenPayload get(String authorizationCode);
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/service/AppleAuthServiceImpl.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/service/AppleAuthServiceImpl.java
@@ -1,0 +1,73 @@
+package com.server.capple.config.security.oauth.apple.service;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.capple.config.security.oauth.apple.client.AppleAuthClient;
+import com.server.capple.config.security.oauth.apple.dto.response.AppleSocialTokenResponse;
+import com.server.capple.config.security.oauth.apple.mapper.IdTokensRequestMapper;
+import com.server.capple.config.security.oauth.apple.dto.AppleIdTokenPayload;
+import com.server.capple.config.security.oauth.apple.vo.AppleProperties;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.stereotype.Service;
+
+import java.security.PrivateKey;
+import java.security.Security;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class AppleAuthServiceImpl implements AppleAuthService {
+    private final AppleAuthClient appleAuthClient;
+    private final AppleProperties appleProperties;
+    private final IdTokensRequestMapper idTokensRequestMapper;
+    public AppleIdTokenPayload get(String authorizationCode) {
+        AppleSocialTokenResponse response = appleAuthClient.generateAndValidateToken(idTokensRequestMapper.toIdTokenRequestByCode(appleProperties.getClient_id(), generateClientSecret(), authorizationCode, appleProperties.getGrant_type(), appleProperties.getRedirect_uri()));
+        String idToken = response.getIdToken();
+        return decodePayload(idToken, AppleIdTokenPayload.class);
+    }
+
+    private String generateClientSecret() {
+        LocalDateTime expiration = LocalDateTime.now().plusMinutes(5);
+        return Jwts.builder()
+            .setHeaderParam("alg", "ES256")
+            .setHeaderParam("kid", appleProperties.getKey_id())
+            .setIssuer(appleProperties.getTeam_id())
+            .setIssuedAt(new Date(System.currentTimeMillis()))
+            .setExpiration(java.sql.Timestamp.valueOf(expiration))
+            .setAudience(appleProperties.getAudience())
+            .setSubject(appleProperties.getClient_id())
+            .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+            .compact();
+    }
+
+    private PrivateKey getPrivateKey() {
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+        try {
+            byte[] privateKeyBytes = Base64.getDecoder().decode(appleProperties.getPrivate_key());
+            PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKeyBytes);
+            return converter.getPrivateKey(privateKeyInfo);
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting private key from String", e);
+        }
+    }
+
+    private static <T> T decodePayload(String token, Class<T> targetClass) {
+        String[] tokenParts = token.split("\\.");
+        String payloadJWT = tokenParts[1];
+        Base64.Decoder decoder = Base64.getUrlDecoder();
+        String payload = new String(decoder.decode(payloadJWT));
+        ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        try {
+            return objectMapper.readValue(payload, targetClass);
+        } catch (Exception e) {
+            throw new RuntimeException("Error decoding token payload", e);
+        }
+    }
+}

--- a/src/main/java/com/server/capple/config/security/oauth/apple/vo/AppleProperties.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/vo/AppleProperties.java
@@ -1,0 +1,24 @@
+package com.server.capple.config.security.oauth.apple.vo;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "apple-auth")
+@Getter
+@Setter
+public class AppleProperties {
+    private String grant_type;
+    private String audience;
+    private String auth_token_url;
+    private String public_key_url;
+    private String redirect_uri;
+    private String website_url;
+    private String client_id;
+    private String team_id;
+    private String key_id;
+    private String private_key;
+    private String iss;
+}

--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.answer.controller;
 
+import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.service.AnswerService;
@@ -26,7 +27,7 @@ public class AnswerController {
     @Operation(summary = "답변 생성 API", description = " 답변 생성 API 입니다." +
             "pathvariable 으로 questionId를 주세요.")
     @PostMapping("/question/{questionId}")
-    public BaseResponse<AnswerResponse.AnswerId> createAnswer(Member member, @PathVariable(value = "questionId") Long questionId,
+    public BaseResponse<AnswerResponse.AnswerId> createAnswer(@AuthMember Member member, @PathVariable(value = "questionId") Long questionId,
                                                               @RequestBody @Valid AnswerRequest request) {
         return BaseResponse.onSuccess(answerService.createAnswer(member, questionId, request));
     }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -49,4 +49,13 @@ public class MemberController {
     public BaseResponse<MemberResponse.SignInResponse> login(@RequestParam String code) {
         return BaseResponse.onSuccess(memberService.signIn(code));
     }
+
+    @Operation(summary = "회원가입 API", description = "회원가입 API 입니다." +
+        "로컬 로그인 또는 소셜 로그인으로 생성한 token을 이용해 회원가입을 진행합니다." +
+        "body에 로그인 실패시 반환 받은 signUpToken, 이메일, 닉네임, 프로필 이미지를 입력해주세요. 프로필 이미지는 필수가 아닙니다." +
+        "회원가입 성공시 accessToken과 refreshToken이 반환됩니다.")
+    @PostMapping("/sign-up")
+    public BaseResponse<MemberResponse.Tokens> signUp(@RequestBody MemberRequest.signUp request) {
+        return BaseResponse.onSuccess(memberService.signUp(request.getSignUpToken(), request.getEmail(), request.getNickname(), request.getProfileImage()));
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -58,4 +58,12 @@ public class MemberController {
     public BaseResponse<MemberResponse.Tokens> signUp(@RequestBody MemberRequest.signUp request) {
         return BaseResponse.onSuccess(memberService.signUp(request.getSignUpToken(), request.getEmail(), request.getNickname(), request.getProfileImage()));
     }
+
+    @Operation(summary = "테스트용 로컬 로그인 API", description = "테스트용 로컬 로그인 API 입니다." +
+        "쿼리 파라미터를 이용해 테스트용 아이디를 입력해주세요." +
+        "refreshToken의 위치에 signUpToken이 반환됩니다.")
+    @GetMapping("/local-sign-in")
+    public BaseResponse<MemberResponse.SignInResponse> localLogin(@RequestParam String testId) {
+        return BaseResponse.onSuccess(memberService.localSignIn(testId));
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -40,4 +40,13 @@ public class MemberController {
                                                                       @RequestBody @Valid MemberRequest.EditMemberInfo request) {
         return BaseResponse.onSuccess(memberService.editMemberInfo(memberId, request));
     }
+
+    @Operation(summary = "로그인 API", description = "로그인 API 입니다. " +
+        "쿼리 파라미터를 이용해 애플 인증서버에서 받아온 code를 입력해주세요." +
+        "기존에 존재하는 사용자라면 isMember가 true로 반환되며, accessToken과 refreshToken이 반환됩니다." +
+        "새로운 사용자라면 isMember가 false로 반환되며, refreshToken의 위치에 signUpToken이 반환됩니다.")
+    @GetMapping("/sign-in")
+    public BaseResponse<MemberResponse.SignInResponse> login(@RequestParam String code) {
+        return BaseResponse.onSuccess(memberService.signIn(code));
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/controller/TokenController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/TokenController.java
@@ -1,0 +1,27 @@
+package com.server.capple.domain.member.controller;
+
+import com.server.capple.config.security.AuthMember;
+import com.server.capple.config.security.jwt.service.JwtService;
+import com.server.capple.domain.member.dto.MemberResponse;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "토큰 API", description = "토큰 API")
+@RequestMapping("/token")
+public class TokenController {
+    private final JwtService jwtService;
+
+    @Operation(summary = "토큰 재발급 API", description = "토큰 재발급 API 입니다.")
+    @GetMapping("/refresh")
+    public BaseResponse<MemberResponse.Tokens> refreshTokens(@AuthMember Member member) {
+        return BaseResponse.onSuccess(jwtService.refreshTokens(member.getId(), member.getRole()));
+    }
+}

--- a/src/main/java/com/server/capple/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/server/capple/domain/member/dto/MemberRequest.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 
 public class MemberRequest {
@@ -15,6 +17,17 @@ public class MemberRequest {
     public static class EditMemberInfo {
         @Size(min=2, max=20, message="닉네임은 2~20자로 입력해주세요.")
         @NotBlank(message="닉네임을 입력해주세요.")
+        private String nickname;
+        private String profileImage;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class signUp {
+        private String signUpToken;
+        private String email;
         private String nickname;
         private String profileImage;
     }

--- a/src/main/java/com/server/capple/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/server/capple/domain/member/dto/MemberResponse.java
@@ -29,4 +29,19 @@ public class MemberResponse {
     public static class ProfileImage {
         private String imageUrl;
     }
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Tokens {
+        private String accessToken;
+        private String refreshToken;
+    }
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class SignInResponse {
+        private String accessToken;
+        private String refreshToken;
+        private Boolean isMember;
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/entity/Member.java
+++ b/src/main/java/com/server/capple/domain/member/entity/Member.java
@@ -25,6 +25,12 @@ public class Member extends BaseEntity {
     private String email;
 
     @Column(nullable = false)
+    private String sub;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     private String profileImage;
 
     public void updateNickname(String nickname) {

--- a/src/main/java/com/server/capple/domain/member/entity/Role.java
+++ b/src/main/java/com/server/capple/domain/member/entity/Role.java
@@ -1,0 +1,16 @@
+package com.server.capple.domain.member.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+    ROLE_VISITOR("ROLE_VISITOR")
+    ,ROLE_ADMIN("ROLE_ADMIN")
+    ,ROLE_ACADEMIER("ROLE_ACADEMIER")
+    ,ROLE_DEVELOPER("ROLE_DEVELOPER")
+    ;
+    private final String name;
+    Role(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
@@ -22,4 +22,12 @@ public class MemberMapper {
                 .profileImage(profileImage)
                 .build();
     };
+
+    public MemberResponse.SignInResponse toSignInResponse(String accessToken, String refreshToken, Boolean isMember) {
+        return MemberResponse.SignInResponse.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .isMember(isMember)
+            .build();
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
@@ -1,6 +1,8 @@
 package com.server.capple.domain.member.mapper;
 
 import com.server.capple.domain.member.dto.MemberResponse;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -28,6 +30,16 @@ public class MemberMapper {
             .accessToken(accessToken)
             .refreshToken(refreshToken)
             .isMember(isMember)
+            .build();
+    }
+
+    public Member createMember(String sub, String email, String nickName, Role role, String profileImage) {
+        return Member.builder()
+            .sub(sub)
+            .email(email)
+            .nickname(nickName)
+            .role(role)
+            .profileImage(profileImage)
             .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/member/mapper/TokensMapper.java
+++ b/src/main/java/com/server/capple/domain/member/mapper/TokensMapper.java
@@ -1,0 +1,14 @@
+package com.server.capple.domain.member.mapper;
+
+import com.server.capple.domain.member.dto.MemberResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokensMapper {
+    public MemberResponse.Tokens toTokens(String accessToken, String refreshToken) {
+        return MemberResponse.Tokens.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build();
+    }
+}

--- a/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
@@ -14,5 +14,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT COUNT(*) FROM Member m WHERE m.nickname = :nickname and m.id != :memberId and m.deletedAt is null")
     Long countMemberByNickname(@Param("nickname") String nickname, @Param("memberId") Long memberId);
 
-
+    Optional<Member> findBySub(String sub);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -13,4 +13,5 @@ public interface MemberService {
     MemberResponse.ProfileImage uploadImage(MultipartFile image);
     MemberResponse.SignInResponse signIn(String authorizationCode);
     MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage);
+    MemberResponse.SignInResponse localSignIn(String testId);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -11,4 +11,5 @@ public interface MemberService {
     Member findMember(Long memberId);
     MemberResponse.EditMemberInfo editMemberInfo(Long memberId, MemberRequest.EditMemberInfo request);
     MemberResponse.ProfileImage uploadImage(MultipartFile image);
+    MemberResponse.SignInResponse signIn(String authorizationCode);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -12,4 +12,5 @@ public interface MemberService {
     MemberResponse.EditMemberInfo editMemberInfo(Long memberId, MemberRequest.EditMemberInfo request);
     MemberResponse.ProfileImage uploadImage(MultipartFile image);
     MemberResponse.SignInResponse signIn(String authorizationCode);
+    MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -105,4 +105,18 @@ public class MemberServiceImpl implements MemberService {
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
         return tokensMapper.toTokens(accessToken, refreshToken);
     }
+
+    @Override
+    public MemberResponse.SignInResponse localSignIn(String testId) {
+        Optional<Member> optionalMember = memberRepository.findBySub(testId);
+        if (optionalMember.isEmpty()) {
+            String signUpToken = jwtService.createSignUpAccessJwt(testId);
+            return memberMapper.toSignInResponse(null, signUpToken, false);
+        }
+        Long memberId = optionalMember.get().getId();
+        String role = optionalMember.get().getRole().getName();
+        String accessToken = jwtService.createJwt(memberId, role, "access");
+        String refreshToken = jwtService.createJwt(memberId, role, "refresh");
+        return memberMapper.toSignInResponse(accessToken, refreshToken, true);
+    }
 }

--- a/src/main/java/com/server/capple/global/exception/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/server/capple/global/exception/errorCode/AuthErrorCode.java
@@ -1,0 +1,32 @@
+package com.server.capple.global.exception.errorCode;
+
+import com.server.capple.global.exception.ErrorCode;
+import com.server.capple.global.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCodeInterface {
+    INVALID_TOKEN("AUTH001", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED)
+    ,EXPIRED_TOKEN("AUTH002", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED)
+    ,UNSUPPORTED_TOKEN("AUTH003", "지원되지 않는 토큰입니다.", HttpStatus.UNAUTHORIZED)
+    ,WRONG_TOKEN_SIGNITURE("AUTH004", "토큰의 서명이 잘못됐습니다.", HttpStatus.UNAUTHORIZED)
+    ,EMPTY_TOKEN("AUTH005", "토큰이 비어있습니다.", HttpStatus.UNAUTHORIZED)
+    ,INVALID_TOKEN_TYPE("AUTH006", "유효하지 않은 토큰 타입입니다.", HttpStatus.UNAUTHORIZED)
+    ,
+    ;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.builder()
+            .code(code)
+            .message(message)
+            .httpStatus(httpStatus)
+            .build();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#3/spring-security-> develop

### 변경 사항
- 애플 소셜 로그인 API 구현
- 테스트용 로그인 API 구현
- 회원가입 API 구현
- 만료 전 토큰을 이용해 토큰 재생성 API 구현

#### 추가 구현 요구 사항 및 문제점
- 로그인 시 중복체크는 하고 있지만 회원가입 시 이메일과 닉네임에 대한 중복체크를 진해하고 있지 않습니다.
- 토큰 재생성 시 기존에 사용하던 토큰을 비활성화 하는 기능은 레디스 데이터베이스를 이용하여 추후 구현할 예정입니다.
- 현재는 리프레시 토큰과 액세스 토큰 두 토큰 모두를 이용해 API 접근이 가능하며 추후 리프레시 토큰은 토큰 재성성 만을 위해 사용할 예정입니다.
- 인가에 대한 구현이 되어있지 않습니다. 추후 구현 예정입니다.

### 테스트 결과
- 테스트 코드는 작성하지 못하였고 토큰 생성과 토큰을 이용해 사용자 정보를 받아오는 작업이 가능했습니다.
