### PR TITLE
[FEAT] 인기키워드 조회 API, Question Status 변경 Schedular 작성

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -72,7 +72,7 @@ public class AnswerController {
 
     @Operation(summary = "작성한 답변 조회 API", description = " 작성한 답변 조회 API 입니다." +
             "pathvariable 으로 memeberId를 주세요.")
-    @GetMapping("/{memberId}/")
+    @GetMapping("/{memberId}")
     public BaseResponse<AnswerResponse.MemberAnswerList> getMemberAnswer(@PathVariable(value = "memberId") Long memberId) {
         return BaseResponse.onSuccess(answerService.getMemberAnswer(memberId));
     }

--- a/src/main/java/com/server/capple/domain/question/entity/Question.java
+++ b/src/main/java/com/server/capple/domain/question/entity/Question.java
@@ -33,10 +33,16 @@ public class Question extends BaseEntity {
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @Builder.Default
     private List<Answer> answers = new ArrayList<>();
+
     private LocalDateTime livedAt;
 
+
+    //question Status를 바꾸는 함수
     public void setQuestionStatus(QuestionStatus questionStatus) {
         this.questionStatus = questionStatus;
+
+        if(questionStatus.equals(QuestionStatus.LIVE))
+            this.livedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/server/capple/domain/question/entity/Question.java
+++ b/src/main/java/com/server/capple/domain/question/entity/Question.java
@@ -3,11 +3,11 @@ package com.server.capple.domain.question.entity;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.global.common.BaseEntity;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,5 +34,9 @@ public class Question extends BaseEntity {
     @Builder.Default
     private List<Answer> answers = new ArrayList<>();
     private LocalDateTime livedAt;
+
+    public void setQuestionStatus(QuestionStatus questionStatus) {
+        this.questionStatus = questionStatus;
+    }
 
 }

--- a/src/main/java/com/server/capple/domain/question/repository/AdminQuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/AdminQuestionRepository.java
@@ -1,7 +1,11 @@
 package com.server.capple.domain.question.repository;
 
 import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AdminQuestionRepository extends JpaRepository<Question, Long> {
+    Optional<Question> findByQuestionStatus(QuestionStatus questionStatus);
 }

--- a/src/main/java/com/server/capple/domain/question/repository/AdminQuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/AdminQuestionRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AdminQuestionRepository extends JpaRepository<Question, Long> {
-    Optional<Question> findByQuestionStatus(QuestionStatus questionStatus);
+    Optional<Question> findFirstByQuestionStatus(QuestionStatus questionStatus);
 }

--- a/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
@@ -1,0 +1,21 @@
+package com.server.capple.domain.question.scheduler;
+
+import com.server.capple.domain.question.service.AdminQuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionScheduler {
+    private final AdminQuestionService adminQuestionService;
+    @Scheduled(cron = "0 7,18 0 * * *") //매일 오전 7시에, 오후 6시에
+    public void setLiveQuestion() {
+        adminQuestionService.setLiveQuestion();
+    }
+
+    @Scheduled(cron = "0 1,14 0 * * *") //매일 오전 1시에, 오후 14시에
+    public void closeLiveQuestion() {
+        adminQuestionService.closeLiveQuestion();
+    }
+}

--- a/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
@@ -2,20 +2,28 @@ package com.server.capple.domain.question.scheduler;
 
 import com.server.capple.domain.question.service.AdminQuestionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class QuestionScheduler {
     private final AdminQuestionService adminQuestionService;
-    @Scheduled(cron = "0 7,18 0 * * *") //매일 오전 7시에, 오후 6시에
+    //초 분 시 일 월 요일
+    @Scheduled(cron = "0 0 7,18 * * *") //매일 오전 7시에, 오후 6시에
     public void setLiveQuestion() {
+
         adminQuestionService.setLiveQuestion();
+        log.info("live question이 등록되었습니다.");
     }
 
-    @Scheduled(cron = "0 1,14 0 * * *") //매일 오전 1시에, 오후 14시에
+    @Scheduled(cron = "0 0 1,14 * * *") //매일 오전 1시에, 오후 14시에
     public void closeLiveQuestion() {
+
         adminQuestionService.closeLiveQuestion();
+        log.info("live question이 닫혔습니다.");
+
     }
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionService.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionService.java
@@ -9,4 +9,7 @@ public interface AdminQuestionService {
 
     QuestionId deleteQuestion(Long questionId);
 
+    QuestionId setLiveQuestion();
+    QuestionId closeLiveQuestion();
+
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
@@ -3,6 +3,7 @@ package com.server.capple.domain.question.service;
 import com.server.capple.domain.question.dto.request.QuestionRequest.QuestionCreate;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionId;
 import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
 import com.server.capple.domain.question.mapper.QuestionMapper;
 import com.server.capple.domain.question.repository.AdminQuestionRepository;
 import com.server.capple.global.exception.RestApiException;
@@ -35,5 +36,23 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
 
         return new QuestionId(question.getId());
 
+    }
+
+    public QuestionId setLiveQuestion() {
+        Question newQuestion = adminQuestionRepository.findByQuestionStatus(QuestionStatus.PENDING)
+                .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_PENDING_NOT_FOUND));
+
+        newQuestion.setQuestionStatus(QuestionStatus.LIVE);
+
+        return new QuestionId(newQuestion.getId());
+
+    }
+
+    public QuestionId closeLiveQuestion() {
+        Question question = adminQuestionRepository.findByQuestionStatus(QuestionStatus.LIVE)
+                .orElseThrow( () -> new RestApiException(QuestionErrorCode.QUESTION_LIVE_NOT_FOUND));
+        question.setQuestionStatus(QuestionStatus.OLD);
+
+        return new QuestionId(question.getId());
     }
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
@@ -38,8 +38,9 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
 
     }
 
+    @Transactional
     public QuestionId setLiveQuestion() {
-        Question newQuestion = adminQuestionRepository.findByQuestionStatus(QuestionStatus.PENDING)
+        Question newQuestion = adminQuestionRepository.findFirstByQuestionStatus(QuestionStatus.PENDING)
                 .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_PENDING_NOT_FOUND));
 
         newQuestion.setQuestionStatus(QuestionStatus.LIVE);
@@ -48,9 +49,10 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
 
     }
 
+    @Transactional
     public QuestionId closeLiveQuestion() {
-        Question question = adminQuestionRepository.findByQuestionStatus(QuestionStatus.LIVE)
-                .orElseThrow( () -> new RestApiException(QuestionErrorCode.QUESTION_LIVE_NOT_FOUND));
+        Question question = adminQuestionRepository.findFirstByQuestionStatus(QuestionStatus.LIVE)
+                .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_LIVE_NOT_FOUND));
         question.setQuestionStatus(QuestionStatus.OLD);
 
         return new QuestionId(question.getId());

--- a/src/main/java/com/server/capple/domain/tag/controller/TagController.java
+++ b/src/main/java/com/server/capple/domain/tag/controller/TagController.java
@@ -29,4 +29,11 @@ public class TagController {
         return BaseResponse.onSuccess(tagService.getTagsByQuestion(questionId));
     }
 
+
+    @Operation(summary = "사람들이 많이 쓴 키워드 조회 API", description = "질문에 상관없이 인기 키워드를 조회합니다.")
+    @GetMapping()
+    public BaseResponse<TagResponse.TagInfos> getPopularTags() {
+        return BaseResponse.onSuccess(tagService.getPopularTags());
+    }
+
 }

--- a/src/main/java/com/server/capple/domain/tag/scheduler/TagScheduler.java
+++ b/src/main/java/com/server/capple/domain/tag/scheduler/TagScheduler.java
@@ -8,11 +8,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class TagScheduler {
     private final TagRedisRepository tagRedisRepository;
 
-    @Scheduled(cron = "0 4 0 * * *") //매일 새벽 4시에 실행
+    @Scheduled(cron = "0 0 4 * * *") //매일 새벽 4시에 실행
     public void decreaseTagCount() {
         tagRedisRepository.decreaseTagCount();
+        log.info("전 날 사용된 tag의 count를 50% 감소시켰습니다.");
+
     }
 }

--- a/src/main/java/com/server/capple/domain/tag/scheduler/TagScheduler.java
+++ b/src/main/java/com/server/capple/domain/tag/scheduler/TagScheduler.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class TagScheduler {
     private final TagRedisRepository tagRedisRepository;
 

--- a/src/main/java/com/server/capple/domain/tag/scheduler/TagScheduler.java
+++ b/src/main/java/com/server/capple/domain/tag/scheduler/TagScheduler.java
@@ -12,9 +12,8 @@ import org.springframework.stereotype.Component;
 public class TagScheduler {
     private final TagRedisRepository tagRedisRepository;
 
-    @Scheduled(cron = "0 0 0 * * *") //매일 밤 12시에 실행
+    @Scheduled(cron = "0 4 0 * * *") //매일 새벽 4시에 실행
     public void decreaseTagCount() {
         tagRedisRepository.decreaseTagCount();
-        System.out.println("success");
     }
 }

--- a/src/main/java/com/server/capple/domain/tag/service/TagService.java
+++ b/src/main/java/com/server/capple/domain/tag/service/TagService.java
@@ -18,7 +18,7 @@ public interface TagService {
     void updateTags(List<String> addedTags, List<String> removedTags);
 
     TagResponse.TagInfos getTagsByQuestion(Long questionId);
-
+    TagResponse.TagInfos getPopularTags();
     void findOrCreateTag(String tagName);
 
     TagResponse.TagInfos searchTags(String keyword);

--- a/src/main/java/com/server/capple/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/tag/service/TagServiceImpl.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.tag.service;
 
+import com.server.capple.domain.question.service.QuestionService;
 import com.server.capple.domain.tag.dto.TagResponse;
 import com.server.capple.domain.tag.entity.Tag;
 import com.server.capple.domain.tag.mapper.TagMapper;
@@ -20,6 +21,7 @@ public class TagServiceImpl implements TagService {
     private final TagRedisRepository tagRedisRepository;
     private final TagRepository tagRepository;
     private final TagMapper tagMapper;
+    private final QuestionService questionService;
 
     //전체 tag 저장, count update
     @Override
@@ -30,13 +32,26 @@ public class TagServiceImpl implements TagService {
     //질문 별 tag 저장, count update
     @Override
     public void saveQuestionTags(Long questionId, List<String> tags) {
+        //question id가 유효한지 검증을 위해
+        questionService.findQuestion(questionId);
         tagRedisRepository.saveQuestionTags(questionId, tags);
     }
 
     //질문 사용된 tags list 조회 (count 높은 순으로)
     @Override
     public TagResponse.TagInfos getTagsByQuestion(Long questionId) {
+        //question id가 유효한지 검증을 위해
+        questionService.findQuestion(questionId);
+
         Set<String> typedTuples = tagRedisRepository.getTagsByQuestion(questionId);
+        return new TagResponse.TagInfos(new ArrayList<>(typedTuples));
+    }
+
+
+    //인기 태그 조회
+    @Override
+    public TagResponse.TagInfos getPopularTags() {
+        Set<String> typedTuples = tagRedisRepository.getPopularTags();
         return new TagResponse.TagInfos(new ArrayList<>(typedTuples));
     }
 

--- a/src/main/java/com/server/capple/global/exception/errorCode/QuestionErrorCode.java
+++ b/src/main/java/com/server/capple/global/exception/errorCode/QuestionErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum QuestionErrorCode implements ErrorCodeInterface {
-    QUESTION_NOT_FOUND("QUESTION001", "질문이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+    QUESTION_NOT_FOUND("QUESTION001", "질문이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    QUESTION_LIVE_NOT_FOUND("QUESTION002", "QUESTION 상태가 LIVE인 질문이 없습니다",HttpStatus.NOT_FOUND),
+    QUESTION_PENDING_NOT_FOUND("QUESTION003", "QUESTION 상태가 PENDING인 질문이 없습니다.", HttpStatus.NOT_FOUND)
+    ;
     private final String code;
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/server/capple/global/exception/errorCode/TagErrorCode.java
+++ b/src/main/java/com/server/capple/global/exception/errorCode/TagErrorCode.java
@@ -1,0 +1,27 @@
+package com.server.capple.global.exception.errorCode;
+
+import com.server.capple.global.exception.ErrorCode;
+import com.server.capple.global.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TagErrorCode implements ErrorCodeInterface {
+
+    TAG_NOT_FOUND("TAG001", "TAG가 존재하지 않습니다.",HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.builder()
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
@@ -31,9 +31,9 @@ public class AnswerServiceTest extends ServiceTestConfig {
         AnswerRequest request = getAnswerRequest();
 
         //when
-        Long answerId = answerService.createAnswer(member, question.getId(), request).getAnswerId();
+        Long answerId = answerService.createAnswer(member, liveQuestion.getId(), request).getAnswerId();
         Answer answer = answerService.findAnswer(answerId);
-        List<String> tags = tagService.getTagsByQuestion(question.getId()).getTags();
+        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId()).getTags();
 
         //then
         assertEquals("나는 와플을 좋아하는 사람이 좋아", answer.getContent());
@@ -50,7 +50,7 @@ public class AnswerServiceTest extends ServiceTestConfig {
     public void updateAnswerTest() {
         //given
         AnswerRequest request = getAnswerRequest();
-        Long answerId = answerService.createAnswer(member, question.getId(), request).getAnswerId();
+        Long answerId = answerService.createAnswer(member, liveQuestion.getId(), request).getAnswerId();
 
         AnswerRequest updateRequest = AnswerRequest.builder()
                 .answer("나는 동그랗고 와플 좋아하는 사람이 좋아")
@@ -64,7 +64,7 @@ public class AnswerServiceTest extends ServiceTestConfig {
         //then
         assertEquals("나는 동그랗고 와플 좋아하는 사람이 좋아", answer.getContent());
         assertEquals("#동그라미 #와플 #동글 ", answer.getTags());
-        List<String> tags = tagService.getTagsByQuestion(question.getId()).getTags();
+        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId()).getTags();
 
         assertEquals(3, tags.size());
         assertTrue(tags.contains("#와플"));
@@ -79,14 +79,14 @@ public class AnswerServiceTest extends ServiceTestConfig {
     public void deleteAnswerTest() {
         //given
         AnswerRequest request = getAnswerRequest();
-        Long answerId = answerService.createAnswer(member, question.getId(), request).getAnswerId();
+        Long answerId = answerService.createAnswer(member, liveQuestion.getId(), request).getAnswerId();
 
         //when
         answerService.deleteAnswer(member, answerId);
         Answer answer = answerService.findAnswer(answerId);
 
         //then
-        List<String> tags = tagService.getTagsByQuestion(question.getId()).getTags();
+        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId()).getTags();
 
         assertEquals(0, tags.size());
         assertNotNull(answer.getDeletedAt());

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -1,0 +1,47 @@
+package com.server.capple.domain.question.service;
+
+import com.server.capple.domain.question.dto.response.QuestionResponse;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
+import com.server.capple.support.ServiceTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Question 서비스의 ")
+public class QuestionServiceTest extends ServiceTestConfig {
+
+    @Autowired
+    private AdminQuestionService adminQuestionService;
+    @Autowired
+    private QuestionService questionService;
+
+    @Test
+    @DisplayName("set Live Question 테스트")
+    @Transactional
+    public void setLiveQuestionTest()  {
+        //given & when
+        QuestionResponse.QuestionId questionId = adminQuestionService.setLiveQuestion();
+        Question question = questionService.findQuestion(questionId.getQuestionId());
+
+        //then
+        assertEquals(question.getContent(), "가장 좋아하는 음식은 무엇인가요?");
+        assertEquals(question.getQuestionStatus(), QuestionStatus.LIVE);
+    }
+
+    @Test
+    @DisplayName("close Live Question 테스트")
+    @Transactional
+    public void closeLiveQuestionTest() {
+        //given & when
+        QuestionResponse.QuestionId questionId = adminQuestionService.closeLiveQuestion();
+        Question question = questionService.findQuestion(questionId.getQuestionId());
+
+        //then
+        assertEquals(question.getContent(),"아카데미 러너 중 가장 마음에 드는 유형이 있나요?");
+        assertEquals(question.getQuestionStatus(), QuestionStatus.OLD);
+    }
+}

--- a/src/test/java/com/server/capple/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/server/capple/domain/tag/service/TagServiceTest.java
@@ -28,7 +28,7 @@ public class TagServiceTest extends ServiceTestConfig {
         //given
         String keyword = "와플";
         AnswerRequest request = getAnswerRequest();
-        answerService.createAnswer(member, question.getId(), request);
+        answerService.createAnswer(member, liveQuestion.getId(), request);
 
         //when
         TagResponse.TagInfos tags = tagService.searchTags(keyword);
@@ -48,9 +48,9 @@ public class TagServiceTest extends ServiceTestConfig {
                 .build();
 
         //when
-        answerService.createAnswer(member, question.getId(), request);
-        answerService.createAnswer(member, question.getId(), request2);
-        TagResponse.TagInfos tags = tagService.getTagsByQuestion(question.getId());
+        answerService.createAnswer(member, liveQuestion.getId(), request);
+        answerService.createAnswer(member, liveQuestion.getId(), request2);
+        TagResponse.TagInfos tags = tagService.getTagsByQuestion(liveQuestion.getId());
 
         //then
         assertEquals("#와플", tags.getTags().get(0));

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -4,6 +4,7 @@ import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.repository.AnswerRepository;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.member.repository.MemberRepository;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
@@ -25,7 +26,8 @@ public abstract class ServiceTestConfig {
     protected AnswerRepository answerRepository;
 
     protected Member member;
-    protected Question question;
+    protected Question liveQuestion;
+    protected Question pendingQuestion;
     protected Answer answer;
 
     @Autowired
@@ -34,7 +36,8 @@ public abstract class ServiceTestConfig {
     @BeforeEach
     public void setUp() {
         member = createMember();
-        question = createQuestion();
+        liveQuestion = createLiveQuestion();
+        pendingQuestion =createPendingQuestion();
         answer = createAnswer();
         redisTemplate.getConnectionFactory().getConnection().flushAll();
     }
@@ -45,11 +48,13 @@ public abstract class ServiceTestConfig {
                         .email("tnals2384@gmail.com")
                         .nickname("루시")
                         .profileImage("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png")
+                        .role(Role.ROLE_ACADEMIER)
+                        .sub("2384973284")
                         .build()
         );
     }
 
-    protected Question createQuestion() {
+    protected Question createLiveQuestion() {
         return questionRepository.save(
                 Question.builder()
                         .content("아카데미 러너 중 가장 마음에 드는 유형이 있나요?")
@@ -58,11 +63,20 @@ public abstract class ServiceTestConfig {
         );
     }
 
+    protected Question createPendingQuestion() {
+        return questionRepository.save(
+                Question.builder()
+                        .content("가장 좋아하는 음식은 무엇인가요?")
+                        .questionStatus(QuestionStatus.PENDING)
+                        .build()
+        );
+    }
+
     protected Answer createAnswer() {
         return answerRepository.save(Answer.builder()
                 .content("나는 무자비한 사람이 좋아")
                 .tags("#무자비 #와플 ")
-                .question(question)
+                .question(liveQuestion)
                 .member(member)
                 .build()
         );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#43/popular keyword -> develop

### 변경 사항
1. 인기 키워드 조회 API를 추가하였습니다. (현재 사용될 축소화된 서비스에서는 사용되지 않는 기능입니다.)
2. 스케줄러를 통해 QuestionStatus를 변경시켜 LIVE 질문을 올리고, 닫도록 하였습니다.
 - 매일 오전 7시에, 오후 6시에 LIVE 질문 올리기
 - 매일 오전 1시에, 오후 14시에 LIVE 질문 내리기
 
### 테스트 결과
질문 올리기와 내리기 서비스 test결과입니다.
스케줄러를 사용하기 때문에 로그를 통해 스케줄러 실행 확인이 가능하도록 하였습니다.
<img width="562" alt="스크린샷 2024-03-17 오후 8 20 57" src="https://github.com/Team-Capple/Capple-Server/assets/83461362/bba0a7df-175f-45bd-8ec1-90f0b84d99ec">

