### PR TITLE
[FEAT] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -74,4 +74,10 @@ public class MemberController {
     public BaseResponse<MemberResponse.SignInResponse> localLogin(@RequestParam String testId) {
         return BaseResponse.onSuccess(memberService.localSignIn(testId));
     }
+
+    @Operation(summary = "회원탈퇴 API", description = "회원탈퇴 API 입니다.")
+    @GetMapping("/deleteMember")
+    public BaseResponse<MemberResponse.MemberId> resignMember(@AuthMember Member member) {
+        return BaseResponse.onSuccess(memberService.resignMember(member));
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/server/capple/domain/member/dto/MemberResponse.java
@@ -53,4 +53,11 @@ public class MemberResponse {
         private String refreshToken;
         private Boolean isMember;
     }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class MemberId {
+        private Long memberId;
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/entity/Member.java
+++ b/src/main/java/com/server/capple/domain/member/entity/Member.java
@@ -10,7 +10,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLRestriction("deleted_at is null")
+//@SQLRestriction("deleted_at is null")
 public class Member extends BaseEntity {
 
     @Id
@@ -36,5 +36,10 @@ public class Member extends BaseEntity {
 
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    public void resignMember() {
+        this.nickname = "알 수 없음";
+        delete();
     }
 }

--- a/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
@@ -40,4 +40,10 @@ public class MemberMapper {
             .profileImage(profileImage)
             .build();
     }
+
+    public MemberResponse.MemberId toMemberId(Member member) {
+        return MemberResponse.MemberId.builder()
+                .memberId(member.getId())
+                .build();
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
@@ -10,13 +10,15 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findById(Long memberId);
+    @Query(value = "SELECT m FROM Member m WHERE m.id = :memberId and m.deletedAt is null")
+    Optional<Member> findById(@Param("memberId") Long memberId);
 
     @Query("SELECT COUNT(*) FROM Member m WHERE m.nickname = :nickname and m.id != :memberId and m.deletedAt is null")
     Long countMemberByNickname(@Param("nickname") String nickname, @Param("memberId") Long memberId);
 
-    @Query(value = "SELECT EXISTS(SELECT 1 FROM Member m WHERE m.profileImage = :image)")
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM Member m WHERE m.profileImage = :image and m.deletedAt is null)")
     boolean existMemberProfileImage(@Param("image") String image);
 
-    Optional<Member> findBySub(String sub);
+    @Query(value = "SELECT m FROM Member m WHERE m.sub = :sub and m.deletedAt is null")
+    Optional<Member> findBySub(@Param("sub") String sub);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -15,4 +15,6 @@ public interface MemberService {
     MemberResponse.SignInResponse signIn(String authorizationCode);
     MemberResponse.Tokens signUp(String signUpToken, String nickname, String profileImage);
     MemberResponse.SignInResponse localSignIn(String testId);
+
+    MemberResponse.MemberId resignMember (Member member);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -128,7 +128,7 @@ public class MemberServiceImpl implements MemberService {
     public MemberResponse.MemberId resignMember(Member member) {
         Member resignedMember = memberRepository.findById(member.getId()).orElseThrow(
                 () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
-        resignedMember.delete();
+        resignedMember.resignMember();
         return memberMapper.toMemberId(member);
     }
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -122,4 +122,13 @@ public class MemberServiceImpl implements MemberService {
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
         return memberMapper.toSignInResponse(accessToken, refreshToken, true);
     }
+
+    @Override
+    @Transactional
+    public MemberResponse.MemberId resignMember(Member member) {
+        Member resignedMember = memberRepository.findById(member.getId()).orElseThrow(
+                () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        resignedMember.delete();
+        return memberMapper.toMemberId(member);
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#47/DeleteMember -> develop

### 변경 사항
- 회원 탈퇴 API 구현
- 회원 탈퇴시 해당 사용자가 삭제됨으로 인한 답변이 불러와지지 않는 오류 해결 및 알 수 없음으로 닉네임 변경 기능 구현

### 테스트 결과
<img width="1460" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/21362256/1742604d-e4d6-41a5-aabf-5a7860eb7b38">

