### PR TITLE
[FIX] 질문 모아보기 상태에 따른 리턴값 수정

### DIFF
--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.question.repository;
 
 import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -12,14 +13,17 @@ import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    @Query("select q from Question q where q.id = :questionId and q.deletedAt is null")
+    @Query("SELECT q FROM Question q WHERE q.id = :questionId")
     Optional<Question> findById(@Param("questionId") Long questionId);
 
     // QuestionStatus에 따라 livedAt에 가장 최신인 Question을 가져오는 쿼리
-    @Query("SELECT q FROM Question q WHERE q.questionStatus = :questionStatus AND q.deletedAt IS NULL ORDER BY q.livedAt DESC LIMIT 1")
+    @Query("SELECT q FROM Question q WHERE q.questionStatus = :questionStatus ORDER BY q.livedAt DESC LIMIT 1")
     Optional<Question> findByQuestionOrderByLivedAt();
 
     Optional<Question> findFirstByOrderByLivedAtDesc();
 
     Optional<List<Question>> findAllByOrderByCreatedAtDesc();
+
+    @Query("SELECT q FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' ORDER BY q.livedAt")
+    Optional<List<Question>> findAllByQuestionStatusIsLiveAndOldByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -17,8 +17,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     Optional<Question> findById(@Param("questionId") Long questionId);
 
     // QuestionStatus에 따라 livedAt에 가장 최신인 Question을 가져오는 쿼리
-    @Query("SELECT q FROM Question q WHERE q.questionStatus = :questionStatus ORDER BY q.livedAt DESC LIMIT 1")
-    Optional<Question> findByQuestionOrderByLivedAt();
+    @Query("SELECT q FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' ORDER BY q.livedAt DESC LIMIT 1")
+    Optional<Question> findByQuestionStatusIsLiveAndOldOrderByLivedAt();
 
     Optional<Question> findFirstByOrderByLivedAtDesc();
 

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -49,7 +49,7 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public QuestionInfos getQuestions(Member member) {
-        return questionMapper.toQuestionInfos(questionRepository.findAllByOrderByCreatedAtDesc().orElseThrow(()
+        return questionMapper.toQuestionInfos(questionRepository.findAllByQuestionStatusIsLiveAndOldByOrderByCreatedAtDesc().orElseThrow(()
                 -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND))
                         .stream()
                         .map(question -> questionMapper.toQuestionInfo(question, String.join(" ", tagRedisRepository.getTagsByQuestion(question.getId())), answerRepository.existsByQuestionAndMember(question, member)))

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -39,7 +39,7 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public QuestionSummary getMainQuestion(Member member) {
-        Question mainQuestion = questionRepository.findFirstByOrderByLivedAtDesc().orElseThrow(()
+        Question mainQuestion = questionRepository.findByQuestionStatusIsLiveAndOldOrderByLivedAt().orElseThrow(()
                 -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         boolean isAnswered = answerRepository.existsByQuestionAndMember(mainQuestion, member);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#58/FixGetQuestionListAPI -> develop

### 변경 사항
- 질문 상태(OLD, LIVE)에 따른 질문 모아보기 조회 API 수정
- - 질문 상태(OLD, LIVE)에 따른 메인질문 조회 API 수정

### 테스트 결과
![image](https://github.com/Team-Capple/Capple-Server/assets/21362256/3272fa0f-2f76-4a85-97b4-3fcfa9f2198e)
![image](https://github.com/Team-Capple/Capple-Server/assets/21362256/52b32317-04bf-43af-8210-0754855d60a6)

