### PR TITLE
[REFACTOR] 회원가입, 인가 관련 기능 리팩터링

### DIFF
--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -2,9 +2,11 @@ package com.server.capple.config.security;
 
 import com.server.capple.config.security.jwt.filter.JwtFilter;
 import com.server.capple.config.security.jwt.service.JwtService;
+import com.server.capple.domain.member.entity.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -45,14 +47,14 @@ public class SecurityConfig {
 //    경로별 인가 //TODO Role 분리 필요
         http
             .authorizeHttpRequests((auth) -> auth
-//                .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/api-docs/**").permitAll()
-//                .requestMatchers("/member/sign-in","/member/sign-up", "/member/local-sign-in", "/token/**").permitAll()
-//                .requestMatchers("/answers/question/**").hasAnyRole(ROLE_VISITOR.getName(), ROLE_DEVELOPER.getName(), ROLE_ADMIN.getName())
-//                .requestMatchers("**").hasRole(ROLE_DEVELOPER.name())
-//                .requestMatchers("/member/sign-up", "/member/local-sign-up").hasAnyRole(ROLE_VISITOR.name(),ROLE_ADMIN.name())
-//                .requestMatchers("/admin/**").hasRole(ROLE_ADMIN.name())
-                .anyRequest().permitAll());
-//                .anyRequest().authenticated());
+                .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/api-docs/**").permitAll()
+                .requestMatchers("/members/sign-in","/members/sign-up", "/members/local-sign-in", "/token/**", "/members/check-nickname", "/members/generate-email-jwt").permitAll()
+                .requestMatchers("/admin/**").hasRole(Role.ROLE_ADMIN.getName())
+                .requestMatchers("/answers","/answers/**").authenticated()
+                .requestMatchers("/members","/members/**").authenticated()
+                .requestMatchers("/tags","/tags/**").authenticated()
+                .requestMatchers("/questions","/questions/**").authenticated()
+                .anyRequest().denyAll());
         http
             .addFilterBefore(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class);
 //    세션 설정

--- a/src/main/java/com/server/capple/config/security/auth/CustomUserDetails.java
+++ b/src/main/java/com/server/capple/config/security/auth/CustomUserDetails.java
@@ -3,9 +3,11 @@ package com.server.capple.config.security.auth;
 import com.server.capple.domain.member.entity.Member;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.List;
 
 public class CustomUserDetails implements UserDetails {
 
@@ -19,8 +21,8 @@ public class CustomUserDetails implements UserDetails {
     }
 
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() { //TODO Authority 관련 설정 추가 필요
-        return null;
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(member.getRole().toString()));
     }
 
     @Override

--- a/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
+++ b/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.Authentication;
 
 public interface JwtService {
     String createJwt(Long memberId, String role, String tokenType);
+    String createJwtFromEmail(String email);
     String createSignUpAccessJwt(String sub);
     Authentication getAuthentication(String token);
     String getSub(String token);

--- a/src/main/java/com/server/capple/config/security/jwt/service/JwtServiceImpl.java
+++ b/src/main/java/com/server/capple/config/security/jwt/service/JwtServiceImpl.java
@@ -52,6 +52,15 @@ public class JwtServiceImpl implements JwtService{
             .compact();
     }
 
+    @Override
+    public String createJwtFromEmail(String email) {
+        SecretKey emailSecretKey = new SecretKeySpec((jwtProperties.getJwt_secret()+email).getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS512.key().build().getAlgorithm());
+        return Jwts.builder()
+            .setAudience("capple")
+            .signWith(SignatureAlgorithm.HS512, emailSecretKey)
+            .compact();
+    }
+
     public String createSignUpAccessJwt(String sub) {
         Long expiredTime = jwtProperties.getRefresh_expired_time();
         return Jwts.builder()

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -97,4 +97,12 @@ public class MemberController {
     public BaseResponse<Boolean> checkNickname(@RequestParam String nickname) {
         return BaseResponse.onSuccess(memberService.checkNickname(nickname));
     }
+
+    @Operation(summary = "이메일 중복 체크", description = "이메일 중복 체크 API 입니다." +
+        "쿼리 파라미터를 이용해 이메일을 입력해주세요." +
+        "중복 이메일일 경우 true, 중복되지 않은 이메일일 경우 false가 반환됩니다.")
+    @GetMapping("/email/check")
+    public BaseResponse<Boolean> checkEmail(@RequestParam String email) {
+        return BaseResponse.onSuccess(memberService.checkEmail(email));
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.member.dto.MemberRequest;
 import com.server.capple.domain.member.dto.MemberResponse;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -79,5 +80,13 @@ public class MemberController {
     @GetMapping("/resign")
     public BaseResponse<MemberResponse.MemberId> resignMember(@AuthMember Member member) {
         return BaseResponse.onSuccess(memberService.resignMember(member));
+    }
+
+    @Operation(summary = "사용자 자격 변경", description = "사용자 자격 변경 API 입니다." +
+        "쿼리 파라미터를 이용해 변경할 role을 입력해주세요." +
+        "Role은 \"ROLE_ACADEMIER\", \"ROLE_ADMIN\" 중 하나로 입력해주세요.")
+    @GetMapping("/role/change")
+    public BaseResponse<MemberResponse.Tokens> changeRole(@AuthMember Member member, Role role) {
+        return BaseResponse.onSuccess(memberService.changeRole(member.getId(), role));
     }
 }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -89,4 +89,12 @@ public class MemberController {
     public BaseResponse<MemberResponse.Tokens> changeRole(@AuthMember Member member, Role role) {
         return BaseResponse.onSuccess(memberService.changeRole(member.getId(), role));
     }
+
+    @Operation(summary = "닉네임 중복 체크", description = "닉네임 중복 체크 API 입니다." +
+        "쿼리 파라미터를 이용해 닉네임을 입력해주세요." +
+        "중복 닉네임일 경우 true, 중복되지 않은 닉네임일 경우 false가 반환됩니다.")
+    @GetMapping("/nickname/check")
+    public BaseResponse<Boolean> checkNickname(@RequestParam String nickname) {
+        return BaseResponse.onSuccess(memberService.checkNickname(nickname));
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/entity/Member.java
+++ b/src/main/java/com/server/capple/domain/member/entity/Member.java
@@ -40,6 +40,7 @@ public class Member extends BaseEntity {
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
     }
+    public void updateRole(Role role) {this.role = role;}
 
     public void resignMember() {
         this.nickname = "알 수 없음";

--- a/src/main/java/com/server/capple/domain/member/entity/Role.java
+++ b/src/main/java/com/server/capple/domain/member/entity/Role.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum Role {
-    ROLE_VISITOR("ROLE_VISITOR")
-    ,ROLE_ADMIN("ROLE_ADMIN")
-    ,ROLE_ACADEMIER("ROLE_ACADEMIER")
-    ,ROLE_DEVELOPER("ROLE_DEVELOPER")
+    ROLE_VISITOR("VISITOR")
+    ,ROLE_ADMIN("ADMIN")
+    ,ROLE_ACADEMIER("ACADEMIER")
+    ,ROLE_DEVELOPER("DEVELOPER")
     ;
     private final String name;
     Role(String name) {

--- a/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
@@ -23,4 +23,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySub(@Param("sub") String sub);
 
     boolean existsMemberByNickname(String nickname);
+
+    boolean existsMemberByEmail(String email);
 }

--- a/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
@@ -21,4 +21,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query(value = "SELECT m FROM Member m WHERE m.sub = :sub and m.deletedAt is null")
     Optional<Member> findBySub(@Param("sub") String sub);
+
+    boolean existsMemberByNickname(String nickname);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -19,4 +19,5 @@ public interface MemberService {
     MemberResponse.Tokens changeRole(Long memberId, Role role);
     MemberResponse.MemberId resignMember (Member member);
     Boolean checkNickname(String nickname);
+    Boolean checkEmail(String email);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -18,4 +18,5 @@ public interface MemberService {
     MemberResponse.SignInResponse localSignIn(String testId);
     MemberResponse.Tokens changeRole(Long memberId, Role role);
     MemberResponse.MemberId resignMember (Member member);
+    Boolean checkNickname(String nickname);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.server.capple.domain.member.service;
 import com.server.capple.domain.member.dto.MemberRequest;
 import com.server.capple.domain.member.dto.MemberResponse;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -15,5 +16,6 @@ public interface MemberService {
     MemberResponse.SignInResponse signIn(String authorizationCode);
     MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage);
     MemberResponse.SignInResponse localSignIn(String testId);
+    MemberResponse.Tokens changeRole(Long memberId, Role role);
     MemberResponse.MemberId resignMember (Member member);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -153,4 +153,8 @@ public class MemberServiceImpl implements MemberService {
     public Boolean checkEmail(String email) {
         return memberRepository.existsMemberByEmail(email);
     }
+
+    private String convertEmailToJwt(String email) {
+        return jwtService.createJwtFromEmail(email);
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -143,4 +143,9 @@ public class MemberServiceImpl implements MemberService {
         resignedMember.resignMember();
         return memberMapper.toMemberId(member);
     }
+
+    @Override
+    public Boolean checkNickname(String nickname) {
+        return memberRepository.existsMemberByNickname(nickname);
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -127,6 +127,16 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
+    public MemberResponse.Tokens changeRole(Long memberId, Role role) {
+        Member member = findMember(memberId);
+        member.updateRole(role);
+        String accessToken = jwtService.createJwt(memberId, role.getName(), "access");
+        String refreshToken = jwtService.createJwt(memberId, role.getName(), "refresh");
+        return tokensMapper.toTokens(accessToken, refreshToken);
+    }
+
+    @Override
+    @Transactional
     public MemberResponse.MemberId resignMember(Member member) {
         Member resignedMember = memberRepository.findById(member.getId()).orElseThrow(
                 () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -148,4 +148,9 @@ public class MemberServiceImpl implements MemberService {
     public Boolean checkNickname(String nickname) {
         return memberRepository.existsMemberByNickname(nickname);
     }
+
+    @Override
+    public Boolean checkEmail(String email) {
+        return memberRepository.existsMemberByEmail(email);
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#46/security-refactor -> develop

### 변경 사항
- 회원가입 시 이메일 중복체크
- 이메일 암호화 메서드
  - jwt의 암호화 키값에 이메일을 섞어 claim 상에서 email을 발견할 수 없도록 하였습니다.
  - 암호화는 가능하지만 복호화는 어려움
  - 이메일이 같은 값을 경우 jwt 값이 같으므로 중복 체크 또한 가능
- 닉네임 중복체크
- 인가에 대한 구현
  - `/admin` 로 시작하는 엔드포인트는 ADMIN role을 가진 사용자만 사용할 수 있습니다.
  - 로그인, 회원가입, 토큰 재생성, 닉네임 중복체크, 이메일 중복 체크는 토큰 없이 접근 가능하도록 하였습니다.
- Role 변경 API
  - ADMIN 과 ACADEMIER 두개로 나눴습니다.

### 테스트 결과
- 테스트 코드 작성 없이 수행으로 검증하였습니다. 추후 테스트 코드 작성할 예정입니다.
