### PR TITLE
fix: #43 id가 가장 빠른 Question을 return하도록 수정

### DIFF
--- a/src/main/java/com/server/capple/domain/question/repository/AdminQuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/AdminQuestionRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AdminQuestionRepository extends JpaRepository<Question, Long> {
-    Optional<Question> findFirstByQuestionStatus(QuestionStatus questionStatus);
+    Optional<Question> findFirstByQuestionStatusOrderByIdAsc(QuestionStatus questionStatus);
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
@@ -40,7 +40,7 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
 
     @Transactional
     public QuestionId setLiveQuestion() {
-        Question newQuestion = adminQuestionRepository.findFirstByQuestionStatus(QuestionStatus.PENDING)
+        Question newQuestion = adminQuestionRepository.findFirstByQuestionStatusOrderByIdAsc(QuestionStatus.PENDING)
                 .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_PENDING_NOT_FOUND));
 
         newQuestion.setQuestionStatus(QuestionStatus.LIVE);
@@ -51,7 +51,7 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
 
     @Transactional
     public QuestionId closeLiveQuestion() {
-        Question question = adminQuestionRepository.findFirstByQuestionStatus(QuestionStatus.LIVE)
+        Question question = adminQuestionRepository.findFirstByQuestionStatusOrderByIdAsc(QuestionStatus.LIVE)
                 .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_LIVE_NOT_FOUND));
         question.setQuestionStatus(QuestionStatus.OLD);
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature#43/polular-keyword-> develop

### 변경 사항
live질문 open 시 question id가 빠른 것부터 live로 설정

### 테스트 결과
