### PR TITLE
[FEAT]: #71 이메일 암호화 적용

### DIFF
--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -102,7 +102,8 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage) {
         String sub = jwtService.getSub(signUpToken);
-        Member member = memberMapper.createMember(sub, email, nickname, Role.ROLE_ACADEMIER, profileImage);
+        String encryptedEmail = convertEmailToJwt(email);
+        Member member = memberMapper.createMember(sub, encryptedEmail, nickname, Role.ROLE_ACADEMIER, profileImage);
         memberRepository.save(member);
         Long memberId = member.getId();
         String role = member.getRole().getName();
@@ -151,7 +152,8 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Boolean checkEmail(String email) {
-        return memberRepository.existsMemberByEmail(email);
+        String encryptedEmail = convertEmailToJwt(email);
+        return memberRepository.existsMemberByEmail(encryptedEmail);
     }
 
     private String convertEmailToJwt(String email) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#71/encrypt-email -> develop

### 변경 사항
- 기존의 이메일 암호화 메서드를 회원가입, 이메일 체크 로직에 적용

### 테스트 결과
- 이메일아 jwt 형식으로 잘 저장됨을 확인하였습니다.
<img width="1402" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/f2067f56-d100-4415-8242-981793fc22eb">
<img width="1124" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/b15e04ed-ecd6-4451-ab9c-8a800dcd5c0a">
- 이메일 중복체크 로직도 잘 동작됨을 확인하였습니다.
<img width="1403" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/8db983d6-e357-4296-af61-bbe1d76ad289">