### PR TITLE
[CHORE] 메일 인증 지원 도메인 변경

### DIFF
--- a/src/main/java/com/server/capple/domain/mail/vo/MailDomain.java
+++ b/src/main/java/com/server/capple/domain/mail/vo/MailDomain.java
@@ -4,7 +4,8 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum MailDomain {
-    POSTECH("postech.ac.kr"),
+    POSTECH_APPLE_DEVELOPER_ACADEMY("pos.idserve.net"),
+//    POSTECH("postech.ac.kr"),
     ;
 
     private final String domain;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기능 변경

### 반영 브랜치
chore/#79/mail-domain-change -> develop

### 변경 사항
- 인증 메일 도메인을 `pos.idserve.net`로 변경하였습니다.
