### PR TITLE
[FEAT] 로그인 시 클라이언트 에러 핸들링 및 반환 데이터 정의

### DIFF
--- a/src/main/java/com/server/capple/config/security/oauth/apple/client/AppleAuthClient.java
+++ b/src/main/java/com/server/capple/config/security/oauth/apple/client/AppleAuthClient.java
@@ -3,12 +3,13 @@ package com.server.capple.config.security.oauth.apple.client;
 import com.server.capple.config.feign.AppleFeignClientConfig;
 import com.server.capple.config.security.oauth.apple.dto.request.IdTokenRequest;
 import com.server.capple.config.security.oauth.apple.dto.response.AppleSocialTokenResponse;
+import feign.FeignException;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @FeignClient(name = "appleAuthClient", url = "https://appleid.apple.com/auth", configuration = AppleFeignClientConfig.class)
 public interface AppleAuthClient {
     @PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    AppleSocialTokenResponse generateAndValidateToken(IdTokenRequest request);
+    AppleSocialTokenResponse generateAndValidateToken(IdTokenRequest request) throws FeignException;
 }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -7,8 +7,12 @@ import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.global.common.BaseResponse;
+import com.server.capple.global.exception.errorCode.AppleOauthError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -58,6 +62,28 @@ public class MemberController {
             "기존에 존재하는 사용자라면 isMember가 true로 반환되며, accessToken과 refreshToken이 반환됩니다." +
             "새로운 사용자라면 isMember가 false로 반환되며, refreshToken의 위치에 signUpToken이 반환됩니다.")
     @GetMapping("/sign-in")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "회원 검증 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberResponse.SignInResponse.class))),
+        @ApiResponse(responseCode = "400", description = "로그인 데이터/형식 오류", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "403", description = "인증서버 접근 권한 오류", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "404", description = "서버 내 인증서버 클라이언트 오류", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "애플 인증서버 내부 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AppleOauthError.class), examples = {
+            @ExampleObject(name = "OAUTH005", value = """
+                {
+                  "timeStamp": "2024-04-05T07:55:47.289412",
+                  "code": "OAUTH005",
+                  "message": "애플 인증서버 내부 오류입니다."
+                }
+                """, description = "애플 인증서버측의 오류입니다. 다시 시도해주세요."),
+            @ExampleObject(name = "GLOBAL005", value = """
+                {
+                  "timeStamp": "2024-04-05T07:55:47.289412",
+                    "code": "GLOBAL005",
+                    "message": "서버 에러, 관리자에게 문의해주세요."
+                }
+                """, description = "서버측의 애플 서버 접근 클라언트 관련 문제로 서버 관리자에게 문의해주세요."),
+        })),
+    })
     public BaseResponse<MemberResponse.SignInResponse> login(@RequestParam String code) {
         return BaseResponse.onSuccess(memberService.signIn(code));
     }

--- a/src/main/java/com/server/capple/global/exception/errorCode/AppleOauthError.java
+++ b/src/main/java/com/server/capple/global/exception/errorCode/AppleOauthError.java
@@ -1,0 +1,30 @@
+package com.server.capple.global.exception.errorCode;
+
+import com.server.capple.global.exception.ErrorCode;
+import com.server.capple.global.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AppleOauthError implements ErrorCodeInterface {
+    BAD_REQUEST("OAUTH001", "잘못된 데이터 이거나 잘못된 형식의 접근입니다.",HttpStatus.BAD_REQUEST)
+    ,FORBIDDEN("OAUTH003", "애플 인증서버 접근 권한이 없습니다.",HttpStatus.FORBIDDEN)
+    ,NOT_FOUND("OAUTH004", "애플 인증서버 요청 클라이언트 오류입니다.",HttpStatus.NOT_FOUND)
+    ,INTERNAL_SERVER_ERROR("OAUTH005", "애플 인증서버 내부 오류입니다.",HttpStatus.INTERNAL_SERVER_ERROR)
+    ,
+    ;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.builder()
+            .code(code)
+            .message(message)
+            .httpStatus(httpStatus)
+            .build();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#83/apple-login-error-handling -> develop

### 변경 사항
- 로그인 실패 시 반환 에러 재정의
- 로그인 반환 에러 스웨거 적용

### 테스트 결과
<img width="1278" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/13113208-562d-4612-9db4-f0186ec1551a">

