### PR TITLE
Feat: #90 이메일 인증 화이트 리스트 기능 구현

### DIFF
--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
             .authorizeHttpRequests((auth) -> auth
                 .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/api-docs/**").permitAll()
                 .requestMatchers("/members/sign-in","/members/sign-up", "/members/local-sign-in", "/token/**", "/members/email/check", "/members/nickname/check", "/members/email/certification", "/members/email/certification/check").permitAll()
-                .requestMatchers("/admin/**").hasRole(Role.ROLE_ADMIN.getName())
+                .requestMatchers("/admin/**", "/members/email/whitelist/register").hasRole(Role.ROLE_ADMIN.getName())
                 .requestMatchers("/answers","/answers/**").authenticated()
                 .requestMatchers("/members","/members/**").authenticated()
                 .requestMatchers("/tags","/tags/**").authenticated()

--- a/src/main/java/com/server/capple/domain/mail/repository/MailWhitelistRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/mail/repository/MailWhitelistRedisRepository.java
@@ -1,0 +1,30 @@
+package com.server.capple.domain.mail.repository;
+
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class MailWhitelistRedisRepository implements Serializable {
+    public static final String EMAIL_WHITE_LIST_KEY = "mailWhitelist-";
+
+    @Resource(name = "redisTemplate")
+    private ValueOperations<String, Boolean> valueOperations;
+
+    public Boolean save(String email, Long whitelistDurationMinutes) {
+        String key = EMAIL_WHITE_LIST_KEY + email;
+        Duration timeoutDuration = Duration.ofMinutes(whitelistDurationMinutes);
+        valueOperations.set(key, true, timeoutDuration);
+        return true;
+    }
+
+    public Boolean existsByEmail(String email) {
+        String key = EMAIL_WHITE_LIST_KEY + email;
+        return valueOperations.get(key) != null;
+    }
+}

--- a/src/main/java/com/server/capple/domain/mail/service/MailService.java
+++ b/src/main/java/com/server/capple/domain/mail/service/MailService.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.mail.service;
 
 public interface MailService {
     Boolean snedMailAddressCerticationMail(String receiver);
+    Boolean saveMailWhitelist(String email, Long whitelistDurationMinutes);
     Boolean checkMailDomain(String emailAddress);
     Boolean checkEmailCertificationCode(String email, String certificationCode);
 }

--- a/src/main/java/com/server/capple/domain/mail/service/MailServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/mail/service/MailServiceImpl.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.mail.service;
 
 import com.server.capple.config.security.jwt.service.JwtService;
 import com.server.capple.domain.mail.repository.MailRedisRepository;
+import com.server.capple.domain.mail.repository.MailWhitelistRedisRepository;
 import com.server.capple.domain.mail.vo.MailDomain;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.MailErrorCode;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class MailServiceImpl implements MailService {
     private final MailUtil mailUtil;
     private final MailRedisRepository mailRedisRepository;
+    private final MailWhitelistRedisRepository mailWhitelistRedisRepository;
     private final JwtService jwtService;
 
     @Override
@@ -23,7 +25,15 @@ public class MailServiceImpl implements MailService {
     }
 
     @Override
+    public Boolean saveMailWhitelist(String email, Long whitelistDurationMinutes) {
+        return mailWhitelistRedisRepository.save(email, whitelistDurationMinutes);
+    }
+
+    @Override
     public Boolean checkMailDomain(String emailAddress) {
+        if (mailWhitelistRedisRepository.existsByEmail(emailAddress)) {
+            return true;
+        }
         String domainAddress = emailAddress.split("@")[1];
         return MailDomain.isExistDomain(domainAddress);
     }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -170,4 +170,21 @@ public class MemberController {
     ) {
         return BaseResponse.onSuccess(memberService.checkCertCode(signUpToken, email, certCode));
     }
+
+    @Operation(summary = "메일 인증 화이트 리스트 등록 API", description = "메일 인증 화이트 리스트 등록 API 입니다.<br>" +
+        "쿼리 파라미터를 이용해 화이트 리스트에 등록할 이메일 주소와 등록 기간(분)을 입역해주세요.<br>" +
+        "등록에 성공할 경우 true가 반환됩니다.<br>" +
+        "관리자 권한을 가진 토큰을 이용해야 해당 API를 사용할 수 있습니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "화이트 리스트 등록 성공"),
+        @ApiResponse(responseCode = "403", description = "화이트 리스트 등록 실패, 관리자 권한 필요."),
+    })
+    @GetMapping("/email/whitelist/register")
+    public BaseResponse<Boolean> registerEmailWhitelist(
+        @Parameter(description = "화이트 리스트 등록할 이메일")
+        @RequestParam String mail,
+        @Parameter(description = "화이트 리스트 등록 기간 (분)")
+        @RequestParam Long whitelistDurationMinutes) {
+        return BaseResponse.onSuccess(memberService.registerEmailWhitelist(mail, whitelistDurationMinutes));
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -20,6 +20,7 @@ public interface MemberService {
     MemberResponse.MemberId resignMember (Member member);
     Boolean checkNickname(String nickname);
     Boolean checkEmail(String email);
+    Boolean registerEmailWhitelist(String email, Long whitelistDurationMinutes);
     Boolean sendCertMail(String signUpToken, String email);
     Boolean checkCertCode(String signUpToken, String email, String certCode);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -166,6 +166,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public Boolean registerEmailWhitelist(String email, Long whitelistDurationMinutes) {
+        return mailService.saveMailWhitelist(email, whitelistDurationMinutes);
+    }
+
+    @Override
     public Boolean sendCertMail(String signUpToken, String email) {
         // 토큰 만료 체크
         if (jwtService.isExpired(signUpToken)) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#90/emailVerificationWhitelist -> develop

### 변경 사항
- 레디스를 이용하여 이메일 인증 시 도메인 검증을 거치지 않는 화이트 리스트를 구현하였습니다.
- 만료시간을 이용하여 화이트 리스트의 데이터가 삭제되도록 하였습니다.
- 화이트 리스트 생성 API는 관리자 권한을 가진 액세스 토큰을 이용해서만 사용 가능합니다.

### 테스트 결과
화이트 리스트 생성 (권한 없는 토큰)
<img width="1211" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/6f162b4f-63fe-4b87-8404-fb567b86cce7">
화이트 리스트 생성 (관리자 권한 토큰)
<img width="1208" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/78f28525-3c29-4d65-9e28-c95da6e473a1">
