### PR TITLE
[REFACTOR] 화이트리스트 고정 인증코드 방식 변경 및 화이트리스트 저장시 이메일 암호화 변경

### DIFF
--- a/src/main/java/com/server/capple/domain/mail/service/MailService.java
+++ b/src/main/java/com/server/capple/domain/mail/service/MailService.java
@@ -1,8 +1,9 @@
 package com.server.capple.domain.mail.service;
 
 public interface MailService {
-    Boolean snedMailAddressCerticationMail(String receiver);
+    Boolean sendMailAddressCertificationMail(String receiver, Boolean isWhiteList);
     Boolean saveMailWhitelist(String email, Long whitelistDurationMinutes);
+    Boolean checkWhiteList(String emailAddress);
     Boolean checkMailDomain(String emailAddress);
     Boolean checkEmailCertificationCode(String email, String certificationCode);
 }

--- a/src/main/java/com/server/capple/domain/mail/service/MailServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/mail/service/MailServiceImpl.java
@@ -18,22 +18,26 @@ public class MailServiceImpl implements MailService {
     private final JwtService jwtService;
 
     @Override
-    public Boolean snedMailAddressCerticationMail(String email) {
-        String certCode = mailUtil.snedMailAddressCerticationMail(email);
+    public Boolean sendMailAddressCertificationMail(String email, Boolean isWhiteList) {
+        String certCode = mailUtil.sendMailAddressCertificationMail(email, isWhiteList);
         String emailJwt = jwtService.createJwtFromEmail(email);
         return mailRedisRepository.save(emailJwt, certCode);
     }
 
     @Override
     public Boolean saveMailWhitelist(String email, Long whitelistDurationMinutes) {
-        return mailWhitelistRedisRepository.save(email, whitelistDurationMinutes);
+        String emailJwt = jwtService.createJwtFromEmail(email);
+        return mailWhitelistRedisRepository.save(emailJwt, whitelistDurationMinutes);
+    }
+
+    @Override
+    public Boolean checkWhiteList(String emailAddress) {
+        String emailJwt = jwtService.createJwtFromEmail(emailAddress);
+        return mailWhitelistRedisRepository.existsByEmail(emailJwt);
     }
 
     @Override
     public Boolean checkMailDomain(String emailAddress) {
-        if (mailWhitelistRedisRepository.existsByEmail(emailAddress)) {
-            return true;
-        }
         String domainAddress = emailAddress.split("@")[1];
         return MailDomain.isExistDomain(domainAddress);
     }

--- a/src/main/java/com/server/capple/domain/mail/service/MailUtil.java
+++ b/src/main/java/com/server/capple/domain/mail/service/MailUtil.java
@@ -6,5 +6,5 @@ public interface MailUtil {
         return emailAddress.matches(emailRegex);
     }
 
-    String snedMailAddressCerticationMail(String receiver);
+    String sendMailAddressCertificationMail(String receiver, Boolean isWhiteList);
 }

--- a/src/main/java/com/server/capple/domain/mail/service/MailUtilImpl.java
+++ b/src/main/java/com/server/capple/domain/mail/service/MailUtilImpl.java
@@ -5,6 +5,7 @@ import com.server.capple.global.exception.errorCode.MailErrorCode;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -16,10 +17,13 @@ import org.thymeleaf.context.Context;
 public class MailUtilImpl implements MailUtil {
     private final JavaMailSender javaMailSender;
     private final TemplateEngine templateEngine;
+    @Value("${mail.white-list-cert-code}")
+    private String whiteListCertCode;
 
     @Override
-    public String snedMailAddressCerticationMail(String receiver) {
+    public String sendMailAddressCertificationMail(String receiver, Boolean isWhiteList) {
         String certCode = generateCertCode();
+        if(isWhiteList) certCode = whiteListCertCode;
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         try {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -180,8 +180,9 @@ public class MemberServiceImpl implements MemberService {
         if (!MailUtil.emailAddressFormVerification(email)) {
             throw new RestApiException(MailErrorCode.INVALID_EMAIL_FORM);
         }
+        Boolean isWhiteList = mailService.checkWhiteList(email);
         // 지원 도메인 체크
-        if (!mailService.checkMailDomain(email)) {
+        if (!isWhiteList && !mailService.checkMailDomain(email)) {
             throw new RestApiException(MailErrorCode.NOT_SUPPORTED_EMAIL_DOMAIN);
         }
         // 이메일 암호화
@@ -191,7 +192,7 @@ public class MemberServiceImpl implements MemberService {
             throw new RestApiException(MailErrorCode.DUPLICATE_EMAIL);
         }
         // 이메일 발송
-        return mailService.snedMailAddressCerticationMail(email);
+        return mailService.sendMailAddressCertificationMail(email, isWhiteList);
     }
 
     @Override


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/#92/certCodeGenerate -> develop

### 변경 사항
- 화이트리스트 고정 인증코드 방식 변경
  - 고정암호는 환경변수로 관리
- 화이트리스트 저장시 이메일 암호화 변경

### 테스트 결과
- 기존의 화이트리스트의 이메일이 노출되는 키값 방식에서 다음과 같이 암호화되도록 변경하였습니다.
  <img width="283" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/b734faec-570e-44ef-8b4a-f0bea9ee6ba8">