### PR TITLE
[FIX] 질문 Tag 저장 방식 변경

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -65,7 +65,7 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public AnswerResponse.AnswerId updateAnswer(Member loginMember, Long answerId, AnswerRequest request) {
         Answer answer = findAnswer(answerId);
-        Question question = answer.getQuestion();
+        Question question = questionService.findQuestion(answer.getQuestion().getId());
         checkPermission(loginMember, answer);
 
         //rdb에 태그 update

--- a/src/main/java/com/server/capple/domain/question/dao/QuestionInfoInterface.java
+++ b/src/main/java/com/server/capple/domain/question/dao/QuestionInfoInterface.java
@@ -1,0 +1,10 @@
+package com.server.capple.domain.question.dao;
+
+import com.server.capple.domain.question.entity.Question;
+
+import java.util.Optional;
+
+public interface QuestionInfoInterface {
+    Question getQuestion();
+    Boolean getIsAnsweredByMember();
+}

--- a/src/main/java/com/server/capple/domain/question/entity/Question.java
+++ b/src/main/java/com/server/capple/domain/question/entity/Question.java
@@ -36,13 +36,19 @@ public class Question extends BaseEntity {
 
     private LocalDateTime livedAt;
 
+    private String popularTags;
+
 
     //question Status를 바꾸는 함수
     public void setQuestionStatus(QuestionStatus questionStatus) {
         this.questionStatus = questionStatus;
 
-        if(questionStatus.equals(QuestionStatus.LIVE))
+        if (questionStatus.equals(QuestionStatus.LIVE))
             this.livedAt = LocalDateTime.now();
+    }
+
+    public void setPopularTags(String popularTags) {
+        this.popularTags = popularTags;
     }
 
 }

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -1,14 +1,19 @@
 package com.server.capple.domain.question.repository;
 
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.question.dao.QuestionInfoInterface;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
 import io.lettuce.core.dynamic.annotation.Param;
+
 import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
@@ -20,10 +25,12 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     @Query("SELECT q FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' ORDER BY q.livedAt DESC LIMIT 1")
     Optional<Question> findByQuestionStatusIsLiveAndOldOrderByLivedAt();
 
-    Optional<Question> findFirstByOrderByLivedAtDesc();
 
-    Optional<List<Question>> findAllByOrderByCreatedAtDesc();
+    @Query("SELECT q AS question, (a IS NOT NULL) AS isAnsweredByMember " +
+            "FROM Question q LEFT JOIN Answer a ON q = a.question AND a.member = :member " +
+            "WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' " +
+            "ORDER BY q.livedAt DESC")
+    List<QuestionInfoInterface> findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(@Param("member") Member member);
 
-    @Query("SELECT q FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' ORDER BY q.livedAt DESC")
-    Optional<List<Question>> findAllByQuestionStatusIsLiveAndOldByOrderByCreatedAtDesc();
 }
+

--- a/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
@@ -24,6 +24,7 @@ public class QuestionScheduler {
     public void closeLiveQuestion() {
         //question을 닫고, rdb에 popular tags 저장
         adminQuestionService.savePopularTags(adminQuestionService.closeLiveQuestion().getQuestionId());
+
         log.info("live question이 닫혔습니다.");
 
     }

--- a/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class QuestionScheduler {
     private final AdminQuestionService adminQuestionService;
+
     //초 분 시 일 월 요일
     @Scheduled(cron = "0 0 7,18 * * *") //매일 오전 7시에, 오후 6시에
     public void setLiveQuestion() {
@@ -21,8 +22,8 @@ public class QuestionScheduler {
 
     @Scheduled(cron = "0 0 1,14 * * *") //매일 오전 1시에, 오후 14시에
     public void closeLiveQuestion() {
-
-        adminQuestionService.closeLiveQuestion();
+        //question을 닫고, rdb에 popular tags 저장
+        adminQuestionService.savePopularTags(adminQuestionService.closeLiveQuestion().getQuestionId());
         log.info("live question이 닫혔습니다.");
 
     }

--- a/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
@@ -15,17 +15,15 @@ public class QuestionScheduler {
     //초 분 시 일 월 요일
     @Scheduled(cron = "0 0 7,18 * * *") //매일 오전 7시에, 오후 6시에
     public void setLiveQuestion() {
-
         adminQuestionService.setLiveQuestion();
         log.info("live question이 등록되었습니다.");
     }
 
     @Scheduled(cron = "0 0 1,14 * * *") //매일 오전 1시에, 오후 14시에
     public void closeLiveQuestion() {
-        //question을 닫고, rdb에 popular tags 저장
+        //question을 닫고, rgb popular tags 저장
         adminQuestionService.savePopularTags(adminQuestionService.closeLiveQuestion().getQuestionId());
 
         log.info("live question이 닫혔습니다.");
-
     }
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionService.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionService.java
@@ -12,4 +12,6 @@ public interface AdminQuestionService {
     QuestionId setLiveQuestion();
     QuestionId closeLiveQuestion();
 
+    void savePopularTags(Long questionId);
+
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
@@ -6,18 +6,23 @@ import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
 import com.server.capple.domain.question.mapper.QuestionMapper;
 import com.server.capple.domain.question.repository.AdminQuestionRepository;
+import com.server.capple.domain.tag.service.TagService;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.QuestionErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AdminQuestionServiceImpl implements AdminQuestionService {
 
     private final AdminQuestionRepository adminQuestionRepository;
+    private final QuestionService questionService;
     private final QuestionMapper questionMapper;
+    private final TagService tagService;
 
     @Override
     public QuestionId createQuestion(QuestionCreate request) {
@@ -29,8 +34,7 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
     @Override
     @Transactional
     public QuestionId deleteQuestion(Long questionId) {
-        Question question = adminQuestionRepository.findById(questionId).orElseThrow(()
-                -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND));
+        Question question = questionService.findQuestion(questionId);
 
         question.delete();
 
@@ -56,5 +60,13 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
         question.setQuestionStatus(QuestionStatus.OLD);
 
         return new QuestionId(question.getId());
+    }
+
+    @Transactional
+    public void savePopularTags(Long questionId) {
+        Question question = questionService.findQuestion(questionId);
+        List<String> tags = tagService.getTagsByQuestion(questionId, 3).getTags();
+
+        question.setPopularTags(String.join(" ", tags) + " ");
     }
 }

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -1,12 +1,9 @@
 package com.server.capple.domain.question.service;
 
-import com.server.capple.config.security.AuthMember;
-import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.repository.AnswerRepository;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.question.dto.response.QuestionResponse;
-import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfos;
+import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.mapper.QuestionMapper;
 import com.server.capple.domain.question.repository.QuestionRepository;
@@ -17,10 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,7 +21,6 @@ public class QuestionServiceImpl implements QuestionService {
     private final QuestionRepository questionRepository;
     private final TagRedisRepository tagRedisRepository;
     private final AnswerRepository answerRepository;
-
     private final QuestionMapper questionMapper;
 
     @Override
@@ -50,9 +42,11 @@ public class QuestionServiceImpl implements QuestionService {
     @Override
     public QuestionInfos getQuestions(Member member) {
         return questionMapper.toQuestionInfos(questionRepository.findAllByQuestionStatusIsLiveAndOldByOrderByCreatedAtDesc().orElseThrow(()
-                -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND))
-                        .stream()
-                        .map(question -> questionMapper.toQuestionInfo(question, String.join(" ", tagRedisRepository.getTagsByQuestion(question.getId())), answerRepository.existsByQuestionAndMember(question, member)))
-                        .toList());
+                        -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND))
+                .stream()
+                .map(question -> questionMapper.toQuestionInfo(question,
+                        String.join(" ", tagRedisRepository.getTagsByQuestion(question.getId(), 7)),
+                        answerRepository.existsByQuestionAndMember(question, member)))
+                .toList());
     }
 }

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -5,21 +5,25 @@ import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfos;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
 import com.server.capple.domain.question.mapper.QuestionMapper;
 import com.server.capple.domain.question.repository.QuestionRepository;
 import com.server.capple.domain.tag.repository.TagRedisRepository;
+import com.server.capple.domain.tag.service.TagService;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.QuestionErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.server.capple.domain.question.entity.QuestionStatus.*;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class QuestionServiceImpl implements QuestionService {
     private final QuestionRepository questionRepository;
-    private final TagRedisRepository tagRedisRepository;
+    private final TagService tagService;
     private final AnswerRepository answerRepository;
     private final QuestionMapper questionMapper;
 
@@ -44,9 +48,13 @@ public class QuestionServiceImpl implements QuestionService {
         return questionMapper.toQuestionInfos(questionRepository.findAllByQuestionStatusIsLiveAndOldByOrderByCreatedAtDesc().orElseThrow(()
                         -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND))
                 .stream()
-                .map(question -> questionMapper.toQuestionInfo(question,
-                        String.join(" ", tagRedisRepository.getTagsByQuestion(question.getId(), 7)),
-                        answerRepository.existsByQuestionAndMember(question, member)))
-                .toList());
+                .map(question -> {
+                    String tags = question.getQuestionStatus().equals(LIVE) ?
+                            String.join(" ", tagService.getTagsByQuestion(question.getId(),3).getTags()) :
+                            question.getPopularTags().trim();
+
+                    return questionMapper.toQuestionInfo(question, tags,
+                        answerRepository.existsByQuestionAndMember(question, member));
+                }).toList());
     }
 }

--- a/src/main/java/com/server/capple/domain/tag/controller/TagController.java
+++ b/src/main/java/com/server/capple/domain/tag/controller/TagController.java
@@ -16,17 +16,17 @@ public class TagController {
     private final TagService tagService;
 
     @Operation(summary = "키워드 검색 API", description = " 키워드 검색 API 입니다." +
-            "request param 으로 keyword를 주세요." )
+            "request param 으로 keyword를 주세요.")
     @GetMapping("/search")
     public BaseResponse<TagResponse.TagInfos> searchTag(@RequestParam(name = "keyword") String keyword) {
         return BaseResponse.onSuccess(tagService.searchTags(keyword));
     }
 
     @Operation(summary = "이 질문 답변에 사람들이 많이 쓴 키워드 조회 API", description = " 이 질문에 대해 사람들이 많이 쓴 키워드를 조회합니다." +
-            "path variable 으로 questionId를 주세요." )
+            "path variable 으로 questionId를 주세요.")
     @GetMapping("/{questionId}")
     public BaseResponse<TagResponse.TagInfos> getPopularTagsByQuestion(@PathVariable(name = "questionId") Long questionId) {
-        return BaseResponse.onSuccess(tagService.getTagsByQuestion(questionId));
+        return BaseResponse.onSuccess(tagService.getTagsByQuestion(questionId, 7));
     }
 
 

--- a/src/main/java/com/server/capple/domain/tag/repository/TagRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/tag/repository/TagRedisRepository.java
@@ -52,7 +52,7 @@ public class TagRedisRepository implements Serializable {
     private void decreaseTagCount(String key, String tag) {
         Double count = zSetOperations.score(key, tag);
 
-        if(count == null)
+        if (count == null)
             throw new RestApiException(TagErrorCode.TAG_NOT_FOUND);
 
         if (count == 1.0)
@@ -61,15 +61,15 @@ public class TagRedisRepository implements Serializable {
             zSetOperations.incrementScore(key, tag, -1.0);
     }
 
-    //해당 question 답변에 많이 쓰인 태그 7개 조회
-    public Set<String> getTagsByQuestion(Long questionId) {
+    //해당 question 답변에 많이 쓰인 태그 size에 따라 조회
+    public Set<String> getTagsByQuestion(Long questionId, int size) {
         String question = questionId.toString();
-        return zSetOperations.reverseRange(QUESTION_TAGS_KEY_PREFIX + question, 0, 7);
+        return zSetOperations.reverseRange(QUESTION_TAGS_KEY_PREFIX + question, 0, size - 1);
     }
 
     //현재 인기 태그 3개 조회
     public Set<String> getPopularTags() {
-        return zSetOperations.reverseRange(TAGS_KEY, 0, 3);
+        return zSetOperations.reverseRange(TAGS_KEY, 0, 2);
     }
 
     //기존의 count를 50%로 줄임 (스케줄러 사용)

--- a/src/main/java/com/server/capple/domain/tag/service/TagService.java
+++ b/src/main/java/com/server/capple/domain/tag/service/TagService.java
@@ -17,8 +17,10 @@ public interface TagService {
 
     void updateTags(List<String> addedTags, List<String> removedTags);
 
-    TagResponse.TagInfos getTagsByQuestion(Long questionId);
+    TagResponse.TagInfos getTagsByQuestion(Long questionId, int size);
+
     TagResponse.TagInfos getPopularTags();
+
     void findOrCreateTag(String tagName);
 
     TagResponse.TagInfos searchTags(String keyword);

--- a/src/main/java/com/server/capple/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/tag/service/TagServiceImpl.java
@@ -21,7 +21,6 @@ public class TagServiceImpl implements TagService {
     private final TagRedisRepository tagRedisRepository;
     private final TagRepository tagRepository;
     private final TagMapper tagMapper;
-    private final QuestionService questionService;
 
     //전체 tag 저장, count update
     @Override
@@ -32,17 +31,12 @@ public class TagServiceImpl implements TagService {
     //질문 별 tag 저장, count update
     @Override
     public void saveQuestionTags(Long questionId, List<String> tags) {
-        //question id가 유효한지 검증을 위해
-        questionService.findQuestion(questionId);
         tagRedisRepository.saveQuestionTags(questionId, tags);
     }
 
     //질문 사용된 tags list 조회 (count 높은 순으로)
     @Override
     public TagResponse.TagInfos getTagsByQuestion(Long questionId, int size) {
-        //question id가 유효한지 검증을 위해
-        questionService.findQuestion(questionId);
-
         Set<String> typedTuples = tagRedisRepository.getTagsByQuestion(questionId, size);
         return new TagResponse.TagInfos(new ArrayList<>(typedTuples));
     }
@@ -78,7 +72,6 @@ public class TagServiceImpl implements TagService {
         saveQuestionTags(questionId, addedTags);
         deleteQuestionTags(questionId, removedTags);
     }
-
 
     @Override
     @Transactional

--- a/src/main/java/com/server/capple/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/tag/service/TagServiceImpl.java
@@ -39,11 +39,11 @@ public class TagServiceImpl implements TagService {
 
     //질문 사용된 tags list 조회 (count 높은 순으로)
     @Override
-    public TagResponse.TagInfos getTagsByQuestion(Long questionId) {
+    public TagResponse.TagInfos getTagsByQuestion(Long questionId, int size) {
         //question id가 유효한지 검증을 위해
         questionService.findQuestion(questionId);
 
-        Set<String> typedTuples = tagRedisRepository.getTagsByQuestion(questionId);
+        Set<String> typedTuples = tagRedisRepository.getTagsByQuestion(questionId, size);
         return new TagResponse.TagInfos(new ArrayList<>(typedTuples));
     }
 

--- a/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
@@ -33,7 +33,7 @@ public class AnswerServiceTest extends ServiceTestConfig {
         //when
         Long answerId = answerService.createAnswer(member, liveQuestion.getId(), request).getAnswerId();
         Answer answer = answerService.findAnswer(answerId);
-        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId()).getTags();
+        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId(), 7).getTags();
 
         //then
         assertEquals("나는 와플을 좋아하는 사람이 좋아", answer.getContent());
@@ -64,7 +64,7 @@ public class AnswerServiceTest extends ServiceTestConfig {
         //then
         assertEquals("나는 동그랗고 와플 좋아하는 사람이 좋아", answer.getContent());
         assertEquals("#동그라미 #와플 #동글 ", answer.getTags());
-        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId()).getTags();
+        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId(), 7).getTags();
 
         assertEquals(3, tags.size());
         assertTrue(tags.contains("#와플"));
@@ -86,7 +86,7 @@ public class AnswerServiceTest extends ServiceTestConfig {
         Answer answer = answerService.findAnswer(answerId);
 
         //then
-        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId()).getTags();
+        List<String> tags = tagService.getTagsByQuestion(liveQuestion.getId(), 7).getTags();
 
         assertEquals(0, tags.size());
         assertNotNull(answer.getDeletedAt());

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -1,5 +1,7 @@
 package com.server.capple.domain.question.service;
 
+import com.server.capple.domain.answer.dto.AnswerRequest;
+import com.server.capple.domain.answer.service.AnswerService;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
@@ -8,6 +10,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -18,11 +23,13 @@ public class QuestionServiceTest extends ServiceTestConfig {
     private AdminQuestionService adminQuestionService;
     @Autowired
     private QuestionService questionService;
+    @Autowired
+    private AnswerService answerService;
 
     @Test
     @DisplayName("set Live Question 테스트")
     @Transactional
-    public void setLiveQuestionTest()  {
+    public void setLiveQuestionTest() {
         //given & when
         QuestionResponse.QuestionId questionId = adminQuestionService.setLiveQuestion();
         Question question = questionService.findQuestion(questionId.getQuestionId());
@@ -41,7 +48,33 @@ public class QuestionServiceTest extends ServiceTestConfig {
         Question question = questionService.findQuestion(questionId.getQuestionId());
 
         //then
-        assertEquals(question.getContent(),"아카데미 러너 중 가장 마음에 드는 유형이 있나요?");
+        assertEquals(question.getContent(), "아카데미 러너 중 가장 마음에 드는 유형이 있나요?");
         assertEquals(question.getQuestionStatus(), QuestionStatus.OLD);
     }
+
+    @Test
+    @DisplayName("save popular tags 테스트")
+    @Transactional
+    public void savePopularTags() {
+
+        //given
+        AnswerRequest request = AnswerRequest.builder()
+                .answer("인기 태그 테스트")
+                .tags(List.of("#태그1", "#태그2", "#바나나와플", "#태그3", "#태그4", "#태그5", "#태그6"))
+                .build();
+        AnswerRequest request2 = AnswerRequest.builder()
+                .answer("나는 와플이랑 바나나를 좋아하는 사람이 좋아")
+                .tags(List.of("#바나나", "#와플", "#바나나와플"))
+                .build();
+        answerService.createAnswer(member, liveQuestion.getId(), request);
+        answerService.createAnswer(member, liveQuestion.getId(), request2);
+
+        //when
+        adminQuestionService.savePopularTags(liveQuestion.getId());
+        List<String> popularTags = Arrays.stream(liveQuestion.getPopularTags().split(" ")).toList();
+        //then
+        assertEquals(popularTags.get(0), "#바나나와플");
+        assertEquals(popularTags.size(), 3);
+    }
+
 }

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -72,6 +72,7 @@ public class QuestionServiceTest extends ServiceTestConfig {
         //when
         adminQuestionService.savePopularTags(liveQuestion.getId());
         List<String> popularTags = Arrays.stream(liveQuestion.getPopularTags().split(" ")).toList();
+
         //then
         assertEquals(popularTags.get(0), "#바나나와플");
         assertEquals(popularTags.size(), 3);

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -3,6 +3,7 @@ package com.server.capple.domain.question.service;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.service.AnswerService;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
+import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
 import com.server.capple.support.ServiceTestConfig;
@@ -76,6 +77,21 @@ public class QuestionServiceTest extends ServiceTestConfig {
         //then
         assertEquals(popularTags.get(0), "#바나나와플");
         assertEquals(popularTags.size(), 3);
+    }
+
+    @Test
+    @DisplayName("save popular tags 테스트")
+    @Transactional
+    public void getQuestionsTest() {
+        //given & when
+        List<QuestionInfo> questionInfos = questionService.getQuestions(member).getQuestionInfos();
+
+        //then
+        assertEquals(questionInfos.size(),2);
+        assertEquals(questionInfos.get(0).getQuestionStatus(), QuestionStatus.LIVE);
+        assertEquals(questionInfos.get(0).getIsAnswered(),true);
+        assertEquals(questionInfos.get(1).getIsAnswered(), false);
+        assertEquals(questionInfos.get(1).getTag(),"#쌀국수 #와플 #아메리카노");
     }
 
 }

--- a/src/test/java/com/server/capple/domain/tag/controller/TagControllerTest.java
+++ b/src/test/java/com/server/capple/domain/tag/controller/TagControllerTest.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.tag.controller;
 
+import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.domain.tag.dto.TagResponse;
 import com.server.capple.domain.tag.service.TagService;
 import com.server.capple.support.ControllerTestConfig;
@@ -9,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
@@ -27,9 +29,12 @@ public class TagControllerTest extends ControllerTestConfig {
 
     @MockBean
     private TagService tagService;
+    @MockBean
+    private MemberService memberService;
 
     @Test
     @DisplayName("Tag 검색 테스트")
+    @WithMockUser(username = "user")
     public void searchTagsTest() throws Exception {
         //given
         final String url = "/tags/search";
@@ -50,11 +55,13 @@ public class TagControllerTest extends ControllerTestConfig {
 
     @Test
     @DisplayName("이 질문 답변에 사람들이 많이 쓴 키워드 조회 테스트")
+    @WithMockUser(username = "user")
     public void getPopularTagsTest() throws Exception {
         //given
         final String url = "/tags/{questionId}";
         TagResponse.TagInfos response = TagResponse.TagInfos.builder().tags(List.of("#와플", "#바나나")).build();
-        doReturn(response).when(tagService).getTagsByQuestion(any(Long.class));
+        doReturn(member).when(memberService).findMember(any(Long.class));
+        doReturn(response).when(tagService).getTagsByQuestion(any(Long.class), any(Integer.class));
 
         //when
         ResultActions resultActions = this.mockMvc.perform(get(url, question.getId())

--- a/src/test/java/com/server/capple/domain/tag/controller/TagControllerTest.java
+++ b/src/test/java/com/server/capple/domain/tag/controller/TagControllerTest.java
@@ -60,7 +60,7 @@ public class TagControllerTest extends ControllerTestConfig {
         //given
         final String url = "/tags/{questionId}";
         TagResponse.TagInfos response = TagResponse.TagInfos.builder().tags(List.of("#와플", "#바나나")).build();
-        doReturn(member).when(memberService).findMember(any(Long.class));
+
         doReturn(response).when(tagService).getTagsByQuestion(any(Long.class), any(Integer.class));
 
         //when

--- a/src/test/java/com/server/capple/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/server/capple/domain/tag/service/TagServiceTest.java
@@ -50,7 +50,7 @@ public class TagServiceTest extends ServiceTestConfig {
         //when
         answerService.createAnswer(member, liveQuestion.getId(), request);
         answerService.createAnswer(member, liveQuestion.getId(), request2);
-        TagResponse.TagInfos tags = tagService.getTagsByQuestion(liveQuestion.getId());
+        TagResponse.TagInfos tags = tagService.getTagsByQuestion(liveQuestion.getId(), 7);
 
         //then
         assertEquals("#와플", tags.getTags().get(0));

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -36,6 +36,7 @@ public abstract class ControllerTestConfig {
         return Member.builder()
                 .email("tnals2384@gmail.com")
                 .profileImage("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png")
+                .email("ksm@naver.com")
                 .nickname("루시")
                 .build();
     }

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @SpringBootTest
@@ -28,6 +29,7 @@ public abstract class ServiceTestConfig {
     protected Member member;
     protected Question liveQuestion;
     protected Question pendingQuestion;
+    protected Question oldQuestion;
     protected Answer answer;
 
     @Autowired
@@ -38,6 +40,7 @@ public abstract class ServiceTestConfig {
         member = createMember();
         liveQuestion = createLiveQuestion();
         pendingQuestion = createPendingQuestion();
+        oldQuestion = createOldQuestion();
         answer = createAnswer();
         redisTemplate.getConnectionFactory().getConnection().flushAll();
     }
@@ -59,6 +62,18 @@ public abstract class ServiceTestConfig {
                 Question.builder()
                         .content("아카데미 러너 중 가장 마음에 드는 유형이 있나요?")
                         .questionStatus(QuestionStatus.LIVE)
+                        .livedAt(LocalDateTime.now())
+                        .build()
+        );
+    }
+
+    protected Question createOldQuestion() {
+        return questionRepository.save(
+                Question.builder()
+                        .content("오늘 뭐 먹을 거에요?")
+                        .questionStatus(QuestionStatus.OLD)
+                        .livedAt(LocalDateTime.of(2024,04,01, 00,00,00))
+                        .popularTags("#쌀국수 #와플 #아메리카노")
                         .build()
         );
     }

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -37,7 +37,7 @@ public abstract class ServiceTestConfig {
     public void setUp() {
         member = createMember();
         liveQuestion = createLiveQuestion();
-        pendingQuestion =createPendingQuestion();
+        pendingQuestion = createPendingQuestion();
         answer = createAnswer();
         redisTemplate.getConnectionFactory().getConnection().flushAll();
     }
@@ -46,6 +46,7 @@ public abstract class ServiceTestConfig {
         return memberRepository.save(
                 Member.builder()
                         .nickname("루시")
+                        .email("ksm@naver.com")
                         .profileImage("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png")
                         .role(Role.ROLE_ACADEMIER)
                         .sub("2384973284")


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/#99/FixQuestionTagSave -> develop

### 변경 사항

스케줄러로 인해 LIVE 질문이 닫히면 RDB Question 테이블 tags column에 인기 태그 3개 저장
애초에 question zset이 만들어질 때 expired 기한을 7시간으로 하여 생성 (라이브 닫히면 자동으로 사라짐)

질문 목록 조회 시
OLD 질문 -> RDB Question tags에서 태그 반환
LIVE 질문 -> 레디스 question-tag zset에서 인기 태그 3개 반환
tags 필드는 String으로 '태그1 태그2 태그3'과 같이 저장합니다. (수정될 일 X)

### 테스트 결과
<img width="542" alt="스크린샷 2024-04-17 오후 4 12 53" src="https://github.com/Team-Capple/Capple-Server/assets/83461362/7156e7b9-1856-48d5-9266-c0d799dd6793">
zset 만료는 로그로 확인하였습니다!
