### PR TITLE
[CHORE] #100 릴리즈 서버 분리 및 브랜치 전략 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
-name: Build Test
+name: Build
 
 on:
   push:
-    branches-ignore: ["develop"]
+    tags:
+      - '*'
+    branches:
+      - '*'
 
 jobs:
   build:
@@ -10,8 +13,16 @@ jobs:
     services:
       postgres:
         image: postgres:latest
+        env:
+          POSTGRES_USER: ${{secrets.TEST_POSTGRES_USER}}
+          POSTGRES_PASSWORD: ${{secrets.TEST_POSTGRES_PASSWORD}}
+          POSTGRES_DB: ${{secrets.TEST_POSTGRES_DB}}
         ports:
-        - 54345:5432
+        - ${{secrets.TEST_POSTGRES_OUTER_PORT}}:${{secrets.TEST_POSTGRES_INNER_PORT}}
+      redis:
+        image: redis:latest
+        ports:
+        - ${{secrets.TEST_REDIS_OUTER_PORT}}:${{secrets.TEST_REDIS_INNER_PORT}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,6 +35,7 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 17
+
       - name: Git Submodule Update
         run: |
           git submodule update --remote --recursive
@@ -36,8 +48,19 @@ jobs:
         uses: gradle/gradle-build-action@v2
         
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        id: buildWithGradle
+        run: ./gradlew clean build
         shell: bash
+
+      - name: Upload Report Artifact When Build Failed
+        if: ${{ failure() && steps.buildWithGradle.conclusion == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: report-artifact
+          path: ./build/reports
+          compression-level: 9
+          retention-days: 1
+          overwrite: true
         
       - name: Move *.jar File
         run: |
@@ -50,6 +73,3 @@ jobs:
           name: jar-file
           path: |
             ./content/*.jar
-
-    
-    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   push:
     tags:
-      - '*'
+      - '**'
     branches:
-      - '*'
+      - '**'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
           POSTGRES_DB: ${{ secrets.TEST_POSTGRES_DB }}
         ports:
-        - ${{ secrets.TEST_POSTGRES_OUTER_PORT }}:${{ secrets.TEST_POSTGRES_INNER_PORT }}
+        - 35432:5432
       redis:
         image: redis:latest
         ports:
-        - ${{ secrets.TEST_REDIS_OUTER_PORT }}:${{ secrets.TEST_REDIS_INNER_PORT }}
+        - 36379:6379
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,20 @@ jobs:
       postgres:
         image: postgres:latest
         env:
-          POSTGRES_USER: ${{secrets.TEST_POSTGRES_USER}}
-          POSTGRES_PASSWORD: ${{secrets.TEST_POSTGRES_PASSWORD}}
-          POSTGRES_DB: ${{secrets.TEST_POSTGRES_DB}}
+          POSTGRES_USER: ${{ secrets.TEST_POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.TEST_POSTGRES_DB }}
         ports:
-        - ${{secrets.TEST_POSTGRES_OUTER_PORT}}:${{secrets.TEST_POSTGRES_INNER_PORT}}
+        - ${{ secrets.TEST_POSTGRES_OUTER_PORT }}:${{ secrets.TEST_POSTGRES_INNER_PORT }}
       redis:
         image: redis:latest
         ports:
-        - ${{secrets.TEST_REDIS_OUTER_PORT}}:${{secrets.TEST_REDIS_INNER_PORT}}
+        - ${{ secrets.TEST_REDIS_OUTER_PORT }}:${{ secrets.TEST_REDIS_INNER_PORT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{secrets.TOKEN_GITHUB}}
+          token: ${{ secrets.TOKEN_GITHUB }}
           submodules: recursive
 
       - name: Setup Java JDK

--- a/.github/workflows/cicd-production.yml
+++ b/.github/workflows/cicd-production.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.TOKEN_GITHUB}}
+          token: ${{ secrets.TOKEN_GITHUB }}
           submodules: recursive
 
       - name: Git Submodule Update

--- a/.github/workflows/cicd-production.yml
+++ b/.github/workflows/cicd-production.yml
@@ -7,7 +7,7 @@ on:
       - completed
   push:
     tags:
-      - 'v*'
+      - 'v**'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/cicd-production.yml
+++ b/.github/workflows/cicd-production.yml
@@ -1,0 +1,84 @@
+name: Production Deploy
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+  GITHUB_ACTOR: ${{ github.actor }}
+
+jobs:
+  productionDeploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{secrets.TOKEN_GITHUB}}
+          submodules: recursive
+
+      - name: Git Submodule Update
+        run: |
+          git submodule update --remote --recursive
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.TOKEN_GITHUB }}
+
+      - name: lowercase the image tag & repository
+        run: |
+          echo "REPOSITORY=$(echo $REPOSITORY | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
+
+      - name: Set Spring Image Environment Variable
+        run: |
+          echo "SPRING_IMAGE=${{ env.REGISTRY }}/${{ env.REPOSITORY }}-prod:${{ env.VERSION }}" >> ${GITHUB_ENV}
+
+      - name: Write Version
+        run: |
+          echo "\nserver-version: Prod" >> config/application.yml
+
+      - name: Build Image
+        run: docker build --no-cache -t ${{ env.SPRING_IMAGE }} -f Dockerfile-deploy .
+
+      - name: Push
+        run: docker push ${{ env.SPRING_IMAGE }}
+
+      - name: Write Docker Image Tag Information to .env File
+        run: |
+          echo -e "\nSPRING_IMAGE=${{ env.SPRING_IMAGE }}" >> config/env/prod.env
+
+      - name: Copy docker-compose.yml
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.PRODUCTION_SSH_HOST }}
+          port: ${{ secrets.PRODUCTION_SSH_PORT }}
+          username: ${{ secrets.PRODUCTION_SSH_USERNAME }}
+          key: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+          source: "docker-compose.prod.yml, config/env/prod.env"
+          target: /home/ec2-user
+
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.PRODUCTION_SSH_HOST }}
+          port: ${{ secrets.PRODUCTION_SSH_PORT }}
+          username: ${{ secrets.PRODUCTION_SSH_USERNAME }}
+          key: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user 
+            sudo docker login ${{ env.REGISTRY }} -u ${{ env.GITHUB_ACTOR }} -p ${{ secrets.TOKEN_GITHUB }}
+            sudo docker container stop spring
+            sudo docker container rm spring
+            sudo docker-compose --env-file=config/env/prod.env -f docker-compose.prod.yml -p backend up -d
+            sudo docker image prune -af

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.TOKEN_GITHUB}}
+          token: ${{ secrets.TOKEN_GITHUB }}
           submodules: recursive
 
       - name: Git Submodule Update

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -7,7 +7,7 @@ on:
       - completed
   push:
     branches:
-      - 'release-*'
+      - 'release-**'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -1,0 +1,130 @@
+name: Release Deploy
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+  push:
+    branches:
+      - 'release-*'
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+  GITHUB_ACTOR: ${{ github.actor }}
+
+jobs:
+  releaseDeploy:
+    name: Deploy to Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{secrets.TOKEN_GITHUB}}
+          submodules: recursive
+
+      - name: Git Submodule Update
+        run: |
+          git submodule update --remote --recursive
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.TOKEN_GITHUB }}
+
+      - name: lowercase the image tag & repository
+        run: |
+          echo "REPOSITORY=$(echo $REPOSITORY | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
+
+      - name: Get Version
+        run: |
+          echo "VERSION=$( echo ${{ github.ref_name }} | cut -c 9- )" >> ${GITHUB_ENV}
+
+      - name: Set Spring Image Environment Variable
+        run: |
+          echo "SPRING_IMAGE=${{ env.REGISTRY }}/${{ env.REPOSITORY }}-release:${{ env.VERSION }}" >> ${GITHUB_ENV}
+
+      - name: Write Version
+        run: |
+          echo "\nserver-version: ${{ env.VERSION }}" >> config/application.yml
+
+      - name: Build Image
+        run: docker build --no-cache -t ${{ env.SPRING_IMAGE }} -f Dockerfile-deploy .
+
+      - name: Push
+        run: docker push ${{ env.SPRING_IMAGE }}
+
+      - name: Write Docker Image Tag Information to .env File
+        run: |
+          echo -e "\nSPRING_IMAGE=${{ env.SPRING_IMAGE }}" >> config/env/release.env
+
+      - name: Copy docker-compose.yml
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.RELEASE_SSH_HOST }}
+          port: ${{ secrets.RELEASE_SSH_PORT }}
+          username: ${{ secrets.RELEASE_SSH_USERNAME }}
+          key: ${{ secrets.RELEASE_SSH_PRIVATE_KEY }}
+          source: "docker-compose.release.yml, config/env/release.env"
+          target: /home/ec2-user
+
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.RELEASE_SSH_HOST }}
+          port: ${{ secrets.RELEASE_SSH_PORT }}
+          username: ${{ secrets.RELEASE_SSH_USERNAME }}
+          key: ${{ secrets.RELEASE_SSH_PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user 
+            sudo docker login ${{ env.REGISTRY }} -u ${{ env.GITHUB_ACTOR }} -p ${{ secrets.TOKEN_GITHUB }}
+            sudo docker container stop spring
+            sudo docker container rm spring
+            sudo docker-compose --env-file=config/env/release.env -f docker-compose.release.yml -p backend-${{ env.VERSION }} up -d
+            sudo docker image prune -af
+
+  releaseExport:
+    name: Export Release Jar
+    runs-on: ubuntu-latest
+    needs: releaseDeploy
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.TOKEN_GITHUB }}
+
+      - name: lowercase the image tag & repository
+        run: |
+          echo "REPOSITORY=$(echo $REPOSITORY | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
+
+      - name: Get Version
+        run: |
+          echo "VERSION=$( echo ${{ github.ref_name }} | cut -c 9- )" >> ${GITHUB_ENV}
+
+      - name: Set Spring Image Environment Variable
+        run: |
+          echo "SPRING_IMAGE=${{ env.REGISTRY }}/${{ env.REPOSITORY }}-release:${{ env.VERSION }}" >> ${GITHUB_ENV}
+
+      - name: Pull Image
+        run: docker pull ${{ env.SPRING_IMAGE }}
+
+      - name: Export Jar
+        run: docker cp ${{ env.SPRING_IMAGE }}:/app/*.jar .
+
+      - name: Rename Jar
+        run: mv *.jar capple-${{ env.VERSION }}.jar
+
+      - name: Upload Jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: capple-${{ env.VERSION }}
+          path: ./*.jar
+          compression-level: 9
+          retention-days: 1
+          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ src/main/resources/*.yml
 **/.DS_Store
 **/._.DS_Store
 dump.rdb
+
+### act ###
+*.secrets
+artifacts/

--- a/Dockerfile-deploy
+++ b/Dockerfile-deploy
@@ -1,0 +1,23 @@
+FROM eclipse-temurin:17-jdk-jammy AS builder
+LABEL authors="jaewonLeeKOR"
+
+#작업 디렉토리를 /app으로 설정
+WORKDIR /app
+
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY src ./src
+COPY config ./config
+
+RUN ./gradlew bootJar
+
+FROM eclipse-temurin:17-jre-jammy
+LABEL authors="jaewonLeeKOR"
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar /app/app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT java -jar /app/app.jar

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
+jar {
+	enabled = false
+}
+
 group = 'com.server'
 version = ''
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,12 @@ test {
 processResources.dependsOn('copySubmodule')
 task copySubmodule(type: Copy) {
 	from './config'
-	include '*.yml'
+	include 'application.yml', 'application-dev.yml', 'application-prod.yml', 'application-release.yml', 'application-local.yml'
 	into './src/main/resources'
+}
+processTestResources.dependsOn('copyTestSubmodule')
+task copyTestSubmodule(type: Copy) {
+	from './config'
+	include 'application.yml', 'application-test.yml'
+	into './src/test/resources'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.server'
-version = '0.0.1-SNAPSHOT'
+version = ''
 
 java {
 	sourceCompatibility = '17'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  mysql:
+    container_name: postgres-qapple-local
+    image: postgres:latest
+    ports:
+      - ${POSTGRES_OUTER_PORT}:${POSTGRES_INNER_PORT}
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    networks:
+      qapple_network:
+        ipv4_address: ${NETWORK_POSTGRES_IP}
+  redis:
+    container_name: redis-qapple-local
+    image: redis:latest
+    ports:
+      - ${REDIS_OUTER_PORT}:${REDIS_INNER_PORT}
+    networks:
+      qapple_network:
+        ipv4_address: ${NETWORK_REDIS_IP}
+networks:
+  qapple_network:
+    name: qapple_network-local
+    driver: bridge
+    internal: false
+    ipam:
+      driver: default
+      config:
+        - subnet: ${NETWORK_SUBNET}
+          ip_range: ${NETWORK_IP_RANGE}
+          gateway: ${NETWORK_GATEWAY}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  spring-application:
+    container_name: spring
+    image: ${SPRING_IMAGE}
+    ports:
+      - ${SPRING_OUTER_PORT}:${SPRING_INNER_PORT}
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  spring-application:
+    container_name: spring
+    image: ${SPRING_IMAGE}
+    ports:
+      - ${SPRING_OUTER_PORT}:${SPRING_INNER_PORT}
+    environment:
+      - SPRING_PROFILES_ACTIVE=release

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  mysql:
+    container_name: postgres-qapple-test
+    image: postgres:latest
+    ports:
+      - ${POSTGRES_OUTER_PORT}:${POSTGRES_INNER_PORT}
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    networks:
+      qapple_network:
+        ipv4_address: ${NETWORK_POSTGRES_IP}
+  redis:
+    container_name: redis-qapple-test
+    image: redis:latest
+    ports:
+      - ${REDIS_OUTER_PORT}:${REDIS_INNER_PORT}
+    networks:
+      qapple_network:
+        ipv4_address: ${NETWORK_REDIS_IP}
+networks:
+  qapple_network:
+    name: qapple_network-test
+    driver: bridge
+    internal: false
+    ipam:
+      driver: default
+      config:
+        - subnet: ${NETWORK_SUBNET}
+          ip_range: ${NETWORK_IP_RANGE}
+          gateway: ${NETWORK_GATEWAY}

--- a/src/main/java/com/server/capple/config/SwaggerConfig.java
+++ b/src/main/java/com/server/capple/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,6 +16,8 @@ import java.util.Arrays;
  */
 @Configuration
 public class SwaggerConfig {
+    @Value("${server-version}")
+    private String version;
     @Bean
     public OpenAPI openAPI() {
         SecurityScheme securityScheme = new SecurityScheme()
@@ -24,7 +27,7 @@ public class SwaggerConfig {
 
         Info info = new Info()
                 .title("Capple API Document")
-                .version("0.0.1")
+                .version(version)
                 .description("Capple API 명세서입니다.");
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))

--- a/src/test/java/com/server/capple/CappleApplicationTests.java
+++ b/src/test/java/com/server/capple/CappleApplicationTests.java
@@ -2,8 +2,10 @@ package com.server.capple;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-//@SpringBootTest
+@SpringBootTest
+@ActiveProfiles("test")
 class CappleApplicationTests {
 
 	@Test

--- a/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithSecurityContext;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -42,7 +44,9 @@ public class AnswerControllerTest extends ControllerTestConfig {
         //when
         ResultActions resultActions = this.mockMvc.perform(post(url, question.getId())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsString(request)));
+                .content(objectMapper.writeValueAsString(request))
+                .header("Authorization", "Bearer " + jwt)
+                );
 
         //then
         resultActions.andExpect(status().isOk())
@@ -66,7 +70,9 @@ public class AnswerControllerTest extends ControllerTestConfig {
         //when
         ResultActions resultActions = this.mockMvc.perform(patch(url, answer.getId())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsString(request)));
+                .content(objectMapper.writeValueAsString(request))
+                .header("Authorization", "Bearer " + jwt)
+        );
 
         //then
         resultActions.andExpect(status().isOk())
@@ -88,7 +94,9 @@ public class AnswerControllerTest extends ControllerTestConfig {
 
         //when
         ResultActions resultActions = this.mockMvc.perform(delete(url, answer.getId())
-                .contentType(MediaType.APPLICATION_JSON_VALUE));
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + jwt)
+        );
 
         //then
         resultActions.andExpect(status().isOk())
@@ -110,7 +118,9 @@ public class AnswerControllerTest extends ControllerTestConfig {
 
         //when
         ResultActions resultActions = this.mockMvc.perform(post(url, answer.getId())
-                .contentType(MediaType.APPLICATION_JSON_VALUE));
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + jwt)
+        );
 
         //then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/com/server/capple/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/server/capple/domain/member/controller/MemberControllerTest.java
@@ -7,6 +7,7 @@ import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.support.ControllerTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -36,11 +37,12 @@ public class MemberControllerTest extends ControllerTestConfig {
 
     @MockBean private MemberService memberService;
 
+    @Disabled
     @Test
     @DisplayName("프로필 조회 API 테스트")
     public void getMyPageMemberInfoTest() throws Exception {
         //given
-        final String url = "/members/{memberId}";
+        final String url = "/members/mypage";
         final String joinDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")) + " 가입";
         final Long memberId = 1L;
 
@@ -54,7 +56,9 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(memberService.getMemberInfo(any(Member.class))).willReturn(response);
 
         //when
-        ResultActions resultActions = mockMvc.perform(get(url, memberId).accept(MediaType.APPLICATION_JSON));
+        ResultActions resultActions = mockMvc.perform(get(url, memberId).accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer " + jwt)
+        );
 
         //then
         resultActions.
@@ -84,6 +88,7 @@ public class MemberControllerTest extends ControllerTestConfig {
                 multipart(HttpMethod.POST, url)
                         .file(image)
                         .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwt)
         );
 
         //then
@@ -101,7 +106,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     @DisplayName("프로필 수정 API 테스트")
     public void editMemberInfoTest() throws Exception {
         //given
-        final String url = "/members/{memberId}";
+        final String url = "/members/mypage";
         final Long memberId = 1L;
 
         MemberRequest.EditMemberInfo request = MemberRequest.EditMemberInfo.builder()
@@ -120,7 +125,9 @@ public class MemberControllerTest extends ControllerTestConfig {
         //when
         ResultActions resultActions = mockMvc.perform(post(url, memberId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsString(request)));
+                .content(objectMapper.writeValueAsString(request))
+                .header("Authorization", "Bearer " + jwt)
+        );
 
         //then
         resultActions.

--- a/src/test/java/com/server/capple/domain/tag/controller/TagControllerTest.java
+++ b/src/test/java/com/server/capple/domain/tag/controller/TagControllerTest.java
@@ -43,7 +43,9 @@ public class TagControllerTest extends ControllerTestConfig {
 
         //when
         ResultActions resultActions = this.mockMvc.perform(get(url).param("keyword", "키워드")
-                .contentType(MediaType.APPLICATION_JSON_VALUE));
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + jwt)
+        );
 
         //then
         resultActions.andExpect(status().isOk())
@@ -65,7 +67,9 @@ public class TagControllerTest extends ControllerTestConfig {
 
         //when
         ResultActions resultActions = this.mockMvc.perform(get(url, question.getId())
-                .contentType(MediaType.APPLICATION_JSON_VALUE));
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + jwt)
+        );
 
         //then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -1,20 +1,29 @@
 package com.server.capple.support;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.capple.config.security.auth.CustomUserDetails;
+import com.server.capple.config.security.auth.service.JpaUserDetailService;
+import com.server.capple.config.security.jwt.service.JwtService;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static org.mockito.Mockito.when;
+
 @SpringBootTest
+@ActiveProfiles("test")
 @AutoConfigureMockMvc
 public abstract class ControllerTestConfig {
     @Autowired
@@ -22,6 +31,11 @@ public abstract class ControllerTestConfig {
     @Autowired
     protected ObjectMapper objectMapper;
     protected Member member;
+    protected String jwt;
+    @Autowired
+    JwtService jwtService;
+    @MockBean
+    JpaUserDetailService jpaUserDetailService;
     protected Question question;
     protected Answer answer;
 
@@ -30,15 +44,24 @@ public abstract class ControllerTestConfig {
         member = createMember();
         question = createQuestion();
         answer = createAnswer();
+        jwt = createJwt(member);
+        when(jpaUserDetailService.loadUserByUsername(member.getId().toString())).thenReturn(new CustomUserDetails(member));
     }
 
     protected Member createMember() {
         return Member.builder()
+                .id(1L)
+                .role(Role.ROLE_ACADEMIER)
+                .sub("2384973284")
                 .email("tnals2384@gmail.com")
                 .profileImage("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png")
                 .email("ksm@naver.com")
                 .nickname("루시")
                 .build();
+    }
+
+    protected String createJwt(Member member) {
+        return jwtService.createJwt(member.getId(), member.getRole().getName(), "access");
     }
 
     protected Question createQuestion() {

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -13,11 +13,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public abstract class ServiceTestConfig {
     @Autowired
     protected MemberRepository memberRepository;
@@ -52,6 +54,7 @@ public abstract class ServiceTestConfig {
                         .email("ksm@naver.com")
                         .profileImage("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png")
                         .role(Role.ROLE_ACADEMIER)
+                        .email("tnals2384@gmail.com")
                         .sub("2384973284")
                         .build()
         );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#100/productionDeploy -> develop

### 변경 사항
- Github flow 에서 Git Flow로 브랜치 전략 변경
  - 운영과 테스트, 개발이 함께 진행되기 위한 브랜치 전략으로 Github flow가 적합하지 않다고 판단하여 Git Flow로 브랜치 전략을 변경 하였습니다.
  - 브랜치를 다섯가지로 나누어 운영할 예정입니다.
  ![](https://velog.velcdn.com/images/jaew0_0n/post/c60399f1-d3f2-4018-88cc-da45027e1fe8/image.png)
    - master
      - 운영서버이며, 직접적인 커밋을 수행하지 않고 merge 커밋을 생성하고 커밋에 tag를 하여 배포됩니다.
      - tag는 `v{버전}`으로 명명 되며 버전은 x.x.x와 같은 형식으로 정의됩니다. 각각 (큰 기능의 추가 구현 횟수).(릴리즈로부터의 추가 횟수).(hotfix로 인한 추가 횟수) 의 형식으로 버전을 나눕니다.
    - hotfix
      - 운영서버에서 발생한 오류를 수정하기위한 브랜치입니다.
      - 브랜치명은 `hotfix/{기능 이름}`으로 명명됩니다.
      - `master` 브랜치에서 분기되어 `master`와 `develop`브랜치로 병합됩니다.
    - release
      - QA를 위한 브랜치입니다.
      - 기능상의 추가 구현을 제외한 에러를 잡기위한 커밋만 수행됩니다.
      - 브랜치명은 `release-{버전}`으로 명명 됩니다.
      - 버전은 `master` 브랜치에 다음으로 등록될 버전으로 정의합니다.
      - `develop`브랜치에서 분기되어 `master` 브랜치로 병합됩니다. (추가적인 수정사항이 존재할 경우 `develop` 브랜치로도 병합)
    - develop
      - 기존의 `develop` 와 같은 방식으로 추가 기능 개발이 이루어지는 브랜치입니다.
      - 기존과는 다르게 서버로의 배포가 이루어지지 않으며, 로컬 프로파일을 이용하여 테스트 하는것을 권장드립니다.
    - feature
      - 기능 개발 브랜치 `feature`, `fix`, `chore` 등과 같이 기존의 방식대로 사용하면 됩니다.
      - `develop`브랜치에서 분기되어 `develop` 브랜치로 병합됩니다.
  - [Git Flow란?](https://velog.io/@jaew0_0n/Git-브랜치-전략)
- test, release 프로파일 생성
- 로컬, 테스트 프로파일 데이터베이스 컴포즈 파일 생성
  - 개발 시 데이터베이스의 관리 용이성을 증진하기 위해 컴포즈 파일을 이용하여 데이터베이스를 구축할 수 있도록 하였습니다.
    - 컴포즈 생성 명령어는 `./config/env` 디렉토리의 각 프로파일 내의 첫줄에 주석 처리하여 작성해뒀습니다.
- 테스트 코드 수정
  - 테스트코드가 403 에러로 실패하던 에러를 수정하였습니다.
    <img width="352" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/d5505067-6862-4657-b1f1-d54e1e1bfb74">
  - `프로필 조회 API 테스트` 의 경우 레포지토리로 직접 저장하지 않는 방식으로 구현되어 있어 `created_at`의 판정에서 오류가 나는것으로 보여 테스트에서 ignore 되도록 처리해뒀습니다. @youngeun-dev 수정 부탁드립니다. 
- ci 워크플로우 수정
  - 기존의 워크플로우상에서 postgres 데이터메이스가 생성되지 않던 문제를 수정하였습니다.
  - 테스트를 통과하지 못하면 ci가 실패되도록 구축하였습니다.
  - ci가 실패 시 error 페이지가 업로드 되도록 하였습니다.
- swagger 버전 설정
  - swagger에 표현되는 버전을 swagger가 구동되고 있는 위치를 나타내도록 변경하였습니다.
    - 로컬 : `local`
    - 릴리즈 : 버전 정보
    - 프로덕션 : `'Prod`
    <img width="492" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/c267d8f9-c696-47ef-83dc-c43fa50d4347">
- 빌드시 plain.jar 생성 안되도록 수정
  - 빌드시 함께 생성되는 Plain Archive가 필요없다고 판단하여 생성되지 않도록 변경하였습니다.
- 불필요한 resource 파일 복사 수정
  - 빌드시 실팽용 컴파일 시와 테스트용 컴파일 시 각각 다른 리소스 파일이 복사되도록 설정하였습니다.
- 운영서버 배포 파이프라인 수정
  - Git Flow 기준의 운영 서버 배포 파이프라인으로 재구축 하였습니다.
  - 기존의 dev 서버의 docker hub를 이용하는 배포 방식과 다르게 ghcr 을 사용하여 배포하도록 바꿨습니다.
- 릴리즈서버 배포 파이프라인 구축
  - Git Flow 기준의 릴리즈 서버 배포 파이프라인으로 재구축 하였습니다.
  - 기존의 dev 서버의 docker hub를 이용하는 배포 방식과 다르게 ghcr 을 사용하여 배포하도록 바꿨습니다.
- act 관련 파일 gitignore 처리
  - Github actions 의 로컬 테스트 프로그램인 act의 환경변수를 gitignore 처리 하였습니다.

### 테스트 결과
- act 환경에서는 dockerd 가 작동하지 않아 ci 파이프라인만 테스트 하였습니다.
- release 브랜치에서 에러가 발생할 경우 바로 수정 커밋하여 수정하겠습니다.
- master 브랜치에서 에러가 발생하는 경우 hotfix 브랜치를 이용하여 수정하겠습니다.
<img width="707" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/fc4ccd6c-95f3-4844-b754-8706b7bb9ddb">
<img width="703" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/a31e52e9-c608-4245-b082-8cb1eb433ae7">
<img width="751" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/58386334/3c9d3d3b-beba-4f13-af23-7c8dee74a544">