### PR TITLE
[HOTFIX] 스케줄러 에러 핸들러 추가

### DIFF
--- a/src/main/java/com/server/capple/config/SchedulerConfig.java
+++ b/src/main/java/com/server/capple/config/SchedulerConfig.java
@@ -1,0 +1,30 @@
+package com.server.capple.config;
+
+import com.server.capple.global.exception.RestApiException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.util.ErrorHandler;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(1); //스케줄러 쓰레드 개수 (질문 관리에서만 사용)
+        threadPoolTaskScheduler.setErrorHandler(new SchedulerErrorHandler());
+        threadPoolTaskScheduler.initialize();
+
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+
+    @Slf4j
+    public static class SchedulerErrorHandler implements ErrorHandler {
+        @Override
+        public void handleError(Throwable t) {
+            log.warn(String.format("[%s] %s", ((RestApiException) t).getErrorCode().getCode(), ((RestApiException) t).getErrorCode().getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hotfix/schedulerErrorHandler -> master

### 변경 사항
- 스케줄러에서 발생하던 에러가 핸들링 되지 않고 있던 오류를 수정하였습니다.
- 스케줄러의 Configuration 파일을 생성하였습니다.
  - 스케줄러의 스레드 개수를 1개로 정의하였습니다.
    - 질문의 상태 변화에서만 사용하고 있기 때문에 다수의 스레드를 사용할 필요가 없다고 생각했습니다.
  - 스케줄러 에러 핸들러를 설정하였습니다.
    - 커스텀 에러 클래스인 `RestApiException`이 발생한다는 가정 하에서 `WARN` 로그가 기록되도록 설정했습니다.
    - 로그에는 커스텀 에러의 `code`와 `message`가 기록됩니다.

### 테스트 결과
- 기존의 에러 발생 로그입니다.
```
  Hibernate: select q1_0.id,q1_0.content,q1_0.created_at,q1_0.deleted_at,q1_0.lived_at,q1_0.popular_tags,q1_0.question_status,q1_0.updated_at from question q1_0 where (q1_0.deleted_at is null) and q1_0.question_status=? order by q1_0.id fetch first ? rows only
2024-04-21T18:00:00.109+09:00 ERROR 7 --- [   scheduling-1] o.s.s.s.TaskUtils$LoggingErrorHandler    : Unexpected error occurred in scheduled task

com.server.capple.global.exception.RestApiException: null
	at com.server.capple.domain.question.service.AdminQuestionServiceImpl.lambda$setLiveQuestion$0(AdminQuestionServiceImpl.java:48) ~[!/:]
	at java.base/java.util.Optional.orElseThrow(Unknown Source) ~[na:na]
	at com.server.capple.domain.question.service.AdminQuestionServiceImpl.setLiveQuestion(AdminQuestionServiceImpl.java:48) ~[!/:]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:351) ~[spring-aop-6.1.3.jar!/:6.1.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196) ~[spring-aop-6.1.3.jar!/:6.1.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-6.1.3.jar!/:6.1.3]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765) ~[spring-aop-6.1.3.jar!/:6.1.3]
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123) ~[spring-tx-6.1.3.jar!/:6.1.3]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:385) ~[spring-tx-6.1.3.jar!/:6.1.3]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119) ~[spring-tx-6.1.3.jar!/:6.1.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.1.3.jar!/:6.1.3]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765) ~[spring-aop-6.1.3.jar!/:6.1.3]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:717) ~[spring-aop-6.1.3.jar!/:6.1.3]
	at com.server.capple.domain.question.service.AdminQuestionServiceImpl$$SpringCGLIB$$0.setLiveQuestion(<generated>) ~[!/:]
	at com.server.capple.domain.question.scheduler.QuestionScheduler.setLiveQuestion(QuestionScheduler.java:18) ~[!/:]
...
```
- 에러 핸들링된 에러의 로그입니다.
```
Hibernate: select q1_0.id,q1_0.content,q1_0.created_at,q1_0.deleted_at,q1_0.lived_at,q1_0.popular_tags,q1_0.question_status,q1_0.updated_at from question q1_0 where (q1_0.deleted_at is null) and q1_0.question_status=? order by q1_0.id fetch first ? rows only
2024-04-21T18:11:00.434+09:00  WARN 16137 --- [TaskScheduler-1] .c.SchedulerConfig$SchedulerErrorHandler : [QUESTION003] QUESTION 상태가 PENDING인 질문이 없습니다.
Hibernate: select q1_0.id,q1_0.content,q1_0.created_at,q1_0.deleted_at,q1_0.lived_at,q1_0.popular_tags,q1_0.question_status,q1_0.updated_at from question q1_0 where (q1_0.deleted_at is null) and q1_0.question_status=? order by q1_0.id fetch first ? rows only
2024-04-21T18:11:30.089+09:00  WARN 16137 --- [TaskScheduler-1] .c.SchedulerConfig$SchedulerErrorHandler : [QUESTION002] QUESTION 상태가 LIVE인 질문이 없습니다
```