### PR TITLE
[HOTFIX] 프로필 이미지 NULL값으로 인한 작성한 답변 조회 에러 수정

### DIFF
--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -59,8 +59,12 @@ public class MemberServiceImpl implements MemberService {
     public MemberResponse.EditMemberInfo editMemberInfo(Member member, MemberRequest.EditMemberInfo request) {
         Member editedMember = findMember(member.getId());
 
+
+
         // 1. 이미지 업데이트
-        editedMember.updateProfileImage(request.getProfileImage());
+//        editedMember.updateProfileImage(request.getProfileImage());
+        // TODO : 추후 삭제 예정
+        editedMember.updateProfileImage("");
 
         // 2. 닉네임 업데이트
         if (memberRepository.countMemberByNickname(request.getNickname(), editedMember.getId()) > 0) throw new RestApiException(MemberErrorCode.EXIST_MEMBER_NICKNAME);
@@ -108,7 +112,8 @@ public class MemberServiceImpl implements MemberService {
     public MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage) {
         String sub = jwtService.getSub(signUpToken);
         String encryptedEmail = convertEmailToJwt(email);
-        Member member = memberMapper.createMember(sub, encryptedEmail, nickname, Role.ROLE_ACADEMIER, profileImage);
+        // TODO : 추후 profileImage 파라미터 수정 예정
+        Member member = memberMapper.createMember(sub, encryptedEmail, nickname, Role.ROLE_ACADEMIER, "");
         memberRepository.save(member);
         Long memberId = member.getId();
         String role = member.getRole().getName();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hotfix/v0.0.2/ProfileImageNullError -> master

### 변경 사항
- 프로필 이미지 null 값에 대한 임시 처리

### 테스트 결과
<img width="1434" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/21362256/69e06d7e-97da-410f-aa39-539d6e49f770">

