### PR TITLE
[REFACTOR] 좋아한 답변 조회 수정 + 마이페이지 테스트 코드 작성

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -151,6 +151,7 @@ public class AnswerServiceImpl implements AnswerService {
 
     }
 
+    // 유저가 작성한 답변 조회
     @Override
     public MemberAnswerList getMemberAnswer(Member member) {
         List<Answer> answers = answerRepository.findByMember(member).orElse(null);
@@ -161,12 +162,13 @@ public class AnswerServiceImpl implements AnswerService {
         );
     }
 
+    // 유저가 좋아한 답변 조회
     @Override
     public MemberAnswerList getMemberHeartAnswer(Member member) {
         return answerMapper.toMemberAnswerList(
                 answerHeartRedisRepository.getMemberHeartsAnswer(member.getId())
                         .stream()
-                        .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer(Long.valueOf((answerId))), answerHeartRedisRepository.getAnswerHeartsCount(Long.valueOf(answerId))))
+                        .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer((answerId)), answerHeartRedisRepository.getAnswerHeartsCount(answerId)))
                         .toList()
         );
     }

--- a/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
@@ -11,11 +11,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.test.context.support.WithSecurityContext;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -129,5 +128,52 @@ public class AnswerControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
                 .andExpect(jsonPath("$.result.answerId").value(1L))
                 .andExpect(jsonPath("$.result.isLiked").value(Boolean.TRUE));
+    }
+
+    @Test
+    @DisplayName("작성한 답변 목록 조회 API 테스트")
+    public void getMyPageMemberAnswerTest() throws Exception {
+        //given
+        final String url = "/answers";
+        AnswerResponse.MemberAnswerList response = getMemberAnswerList();
+        given(answerService.getMemberAnswer(any(Member.class))).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwt)
+        );
+
+        //then
+        resultActions.
+                andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+                .andExpect(jsonPath("$.result.memberAnswerInfos[0].nickname").value("루시"))
+                .andExpect(jsonPath("$.result.memberAnswerInfos[0].content").value("나는 무자비한 사람이 좋아"))
+                .andExpect(jsonPath("$.result.memberAnswerInfos[0].tags").value("#무자비 #와플 "));
+    }
+
+    @Test
+    @DisplayName("좋아한 답변 목록 조회 API 테스트")
+    public void getMyPageMemberHeartAnswerTest() throws Exception {
+        //given
+        final String url = "/answers/heart";
+        AnswerResponse.MemberAnswerList response = getMemberAnswerList();
+        given(answerService.getMemberHeartAnswer(any(Member.class))).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwt)
+        );
+
+        //then
+        resultActions.
+                andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+                .andExpect(jsonPath("$.result.memberAnswerInfos[0].heartCount").value(1))
+                .andExpect(jsonPath("$.result.memberAnswerInfos[0].answerId").value(1));
     }
 }

--- a/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
@@ -108,4 +108,29 @@ public class AnswerServiceTest extends ServiceTestConfig {
         assertEquals(Boolean.FALSE, answerLike2.getIsLiked());
 
     }
+
+    @Test
+    @DisplayName("작성한 Answer 목록 조회 테스트")
+    @Transactional
+    public void getMemberAnswerTest() {
+        //when
+        AnswerResponse.MemberAnswerList memberAnswer = answerService.getMemberAnswer(member);
+        //then
+        assertEquals(memberAnswer.getMemberAnswerInfos().get(0).getContent(), "나는 무자비한 사람이 좋아");
+    }
+
+    @Test
+    @DisplayName("좋아한 Answer 목록 조회 테스트")
+    @Transactional
+    public void getMemberHeartAnswerTest() {
+        //given
+        answerService.toggleAnswerHeart(member, answer.getId());
+
+        //when
+        AnswerResponse.MemberAnswerList memberHeartAnswer = answerService.getMemberHeartAnswer(member);
+
+        //then
+        assertEquals(memberHeartAnswer.getMemberAnswerInfos().get(0).getTags(), "#무자비 #와플 ");
+        assertEquals(memberHeartAnswer.getMemberAnswerInfos().get(0).getHeartCount(), 1);
+    }
 }

--- a/src/test/java/com/server/capple/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/server/capple/domain/member/controller/MemberControllerTest.java
@@ -7,7 +7,6 @@ import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.support.ControllerTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,7 +36,6 @@ public class MemberControllerTest extends ControllerTestConfig {
 
     @MockBean private MemberService memberService;
 
-    @Disabled
     @Test
     @DisplayName("프로필 조회 API 테스트")
     public void getMyPageMemberInfoTest() throws Exception {
@@ -69,8 +67,6 @@ public class MemberControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.result.nickname").value("루시"))
                 .andExpect(jsonPath("$.result.profileImage").value("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png"))
                 .andExpect(jsonPath("$.result.joinDate").value(joinDate));
-
-        verify(memberService).getMemberInfo(member);
     }
 
     @Test

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -5,6 +5,7 @@ import com.server.capple.config.security.auth.CustomUserDetails;
 import com.server.capple.config.security.auth.service.JpaUserDetailService;
 import com.server.capple.config.security.jwt.service.JwtService;
 import com.server.capple.domain.answer.dto.AnswerRequest;
+import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.entity.Role;
@@ -87,5 +88,19 @@ public abstract class ControllerTestConfig {
                 .answer("나는 와플을 좋아하는 사람이 좋아")
                 .tags(List.of("#와플유니버시티", "#와플"))
                 .build();
+    }
+
+    protected AnswerResponse.MemberAnswerList getMemberAnswerList () {
+        List<AnswerResponse.MemberAnswerInfo> memberAnswerInfos = List.of(AnswerResponse.MemberAnswerInfo.builder()
+                .questionId(answer.getQuestion().getId())
+                .answerId(answer.getId())
+                .nickname(answer.getMember().getNickname())
+                .profileImage(answer.getMember().getProfileImage())
+                .content(answer.getContent())
+                .tags(answer.getTags())
+                .heartCount(1)
+                .build());
+
+        return new AnswerResponse.MemberAnswerList(memberAnswerInfos);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 이슈번호
- close #123 

### 반영 브랜치
ex) test/#123/mypage -> develop

### 변경 사항
#### 1. 마이페이지 테스트 코드 작성
- 프로필 조회 테스트 수정
- 작성한 답변 조회 테스트 추가
- 좋아한 답변 조회 테스트 추가 

#### 2.  좋아요 누른 답변 조회가 동작되고 있지 않아 해당 로직 수정했습니다.
 `redisTemplate.keys()`를 사용하고자 기존에 사용하던 SetOperations<>를 RedisTemplate<>으로 변경했습니다.
```java
   // [AnswerHeartRedisRepository]
   
   // @Resource(name = "redisTemplate")
   //  private SetOperations<String, String> setOperations;
   private final RedisTemplate<String, String> redisTemplate;

```

### 테스트 결과
<img width="350" alt="image" src="https://github.com/Team-Capple/Capple-Server/assets/78026977/68251ff1-2b83-4977-af32-74abb596e6ae">
