### PR TITLE
[FEAT] 애플 푸시 알림 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
 
 //  https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'
+//	webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 dependencyManagement {

--- a/src/main/java/com/server/capple/CappleApplication.java
+++ b/src/main/java/com/server/capple/CappleApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -16,6 +17,7 @@ import java.util.TimeZone;
 @EnableFeignClients
 @EnableConfigurationProperties
 @EnableScheduling
+@EnableCaching
 public class CappleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/server/capple/config/RedisConfig.java
+++ b/src/main/java/com/server/capple/config/RedisConfig.java
@@ -1,13 +1,19 @@
 package com.server.capple.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {
@@ -34,5 +40,14 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager apnsJwtCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofMinutes(30));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
     }
 }

--- a/src/main/java/com/server/capple/config/RedisConfig.java
+++ b/src/main/java/com/server/capple/config/RedisConfig.java
@@ -1,12 +1,15 @@
 package com.server.capple.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -24,13 +27,25 @@ public class RedisConfig {
     private int port;
     @Value("${spring.data.redis.database}")
     private int database;
+    @Value("${redis-cloud.host}")
+    private String redisCloudHost;
+    @Value("${redis-cloud.port}")
+    private int redisCloudPort;
+    @Value("${redis-cloud.database}")
+    private int redisCloudDatabase;
+    @Value("${redis-cloud.username}")
+    private String redisCloudUsername;
+    @Value("${redis-cloud.password}")
+    private String redisCloudPassword;
 
     @Bean
+    @Primary
     public RedisConnectionFactory redisConnectionFactory() {
         LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(host, port);
         connectionFactory.setDatabase(database);
         return connectionFactory;
     }
+
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
@@ -43,11 +58,23 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager apnsJwtCacheManager(RedisConnectionFactory cf) {
+    public RedisConnectionFactory redisCloudConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration(redisCloudHost, redisCloudPort);
+        redisConfiguration.setUsername(redisCloudUsername);
+        redisConfiguration.setPassword(redisCloudPassword);
+        LettuceConnectionFactory apnsRedisConnectionFactory = new LettuceConnectionFactory(redisConfiguration);
+        apnsRedisConnectionFactory.setDatabase(redisCloudDatabase);
+        apnsRedisConnectionFactory.start();
+        return apnsRedisConnectionFactory;
+    }
+
+    @Bean
+    @Qualifier("redisCloudConnectionFactory")
+    public CacheManager apnsJwtCacheManager(RedisConnectionFactory redisCloudConnectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
             .entryTtl(Duration.ofMinutes(30));
-        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisCloudConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
     }
 }

--- a/src/main/java/com/server/capple/config/apns/config/ApnsClientConfig.java
+++ b/src/main/java/com/server/capple/config/apns/config/ApnsClientConfig.java
@@ -1,7 +1,5 @@
 package com.server.capple.config.apns.config;
 
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.timeout.WriteTimeoutHandler;
@@ -40,7 +38,6 @@ public class ApnsClientConfig {
             .keepAlive(true) // keep-alive 활성화
             .protocol(HttpProtocol.H2) // HTTP/2 활성화
             .doOnConnected(connection -> connection.addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS))) // 쓰기 타임 아웃
-            .doAfterRequest((req, conn) -> conn.addHandlerLast(new LoggingHandler(LogLevel.INFO)))
             .responseTimeout(Duration.ofSeconds(10)) // 응답 타임 아웃
             .secure(sslSpec -> sslSpec.sslContext(apnsSslContext)); // SSL 활성화
     }

--- a/src/main/java/com/server/capple/config/apns/config/ApnsClientConfig.java
+++ b/src/main/java/com/server/capple/config/apns/config/ApnsClientConfig.java
@@ -1,0 +1,47 @@
+package com.server.capple.config.apns.config;
+
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+import javax.net.ssl.SSLException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class ApnsClientConfig {
+    @Bean("apnsSslContext")
+    public SslContext getApnsSslContext() throws SSLException {
+        return SslContextBuilder.forClient().protocols("TLSv1.2").build(); // SSL 설정
+    }
+
+    @Bean("apnsConnectionProvider")
+    public ConnectionProvider getApnsConnectionProvider() {
+        return ConnectionProvider.builder("apns")
+            .maxConnections(10) // 최대 커낵션 수
+            .pendingAcquireMaxCount(-1) // 재시도 횟수 (-1 : 무한대)
+            .pendingAcquireTimeout(java.time.Duration.ofSeconds(10)) // 커넥션 풀에 사용 가능한 커넥션 없을 때의 대기 시간
+            .maxIdleTime(java.time.Duration.ofSeconds(5)) // 최대 유휴 시간
+            .maxLifeTime(java.time.Duration.ofSeconds(300)) // 최대 생명 시간
+            .lifo() // 후입선출
+            .build();
+    }
+
+    @Bean("apnsH2HttpClient")
+    public HttpClient getApnsH2HttpClient(ConnectionProvider apnsConnectionProvider, SslContext apnsSslContext) {
+        return HttpClient.create(apnsConnectionProvider) // reactor HttpClient 생성
+            .keepAlive(true) // keep-alive 활성화
+            .protocol(HttpProtocol.H2) // HTTP/2 활성화
+            .doOnConnected(connection -> connection.addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS))) // 쓰기 타임 아웃
+            .doAfterRequest((req, conn) -> conn.addHandlerLast(new LoggingHandler(LogLevel.INFO)))
+            .responseTimeout(Duration.ofSeconds(10)) // 응답 타임 아웃
+            .secure(sslSpec -> sslSpec.sslContext(apnsSslContext)); // SSL 활성화
+    }
+}

--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -1,0 +1,93 @@
+package com.server.capple.config.apns.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class ApnsClientRequest {
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class SimplePushBody {
+        private Aps aps;
+
+        public SimplePushBody(String title, String subTitle, String body, Integer badge, String threaId, String targetContentId) {
+            this.aps = new Aps(new Aps.Alert(title, subTitle, body), badge, threaId, targetContentId);
+        }
+
+        @ToString
+        @Getter
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class Aps {
+            private Alert alert;
+            private Integer badge;
+            @JsonProperty("thread-id")
+            private String threadId;
+            @JsonProperty("target-content-id")
+            private String targetContentId; // 프론트 측 작업 필요함
+
+            @ToString
+            @Getter
+            @AllArgsConstructor
+            @NoArgsConstructor
+            public static class Alert {
+                private String title;
+                private String subtitle;
+                private String body;
+            }
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ToString
+    public static class FullAlertBody {
+        private Aps aps;
+
+        @Getter
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Builder
+        @ToString
+        public static class Aps {
+            private Alert alert; // alert 정보
+            private Integer badge; // 앱 아이콘에 표시할 뱃지 숫자
+            @Schema(defaultValue = "default")
+            private String sound; // Library/Sounds 폴더 내의 파일 이름
+            @Schema(defaultValue = "thread-id")
+            private String threadId; // 알림 그룹화를 위한 thread id (UNNotificationContent 객체의 threadIdentifier와 일치해야 함)
+            private String category; // 알림 그룹화를 위한 category, (UNNotificationCategory 식별자와 일치해야 함)
+            @Schema(defaultValue = "0")
+            @JsonProperty("content-available")
+            private Integer contentAvailable; // 백그라운드 알림 여부, 1이면 백그라운드 알림, 0이면 포그라운드 알림 (백그라운드일 경우 alert, badge, sound는 넣으면 안됨)
+            @Schema(defaultValue = "0")
+            @JsonProperty("mutable-content")
+            private Integer mutableContent; // 알림 서비스 확장 플래그
+            @Schema(defaultValue = "")
+            @JsonProperty("target-content-id")
+            private String targetContentId; // 알림이 클릭되었을 때 가져올 창의 식별자, UNNotificationContent 객체에 채워짐
+
+            @Getter
+            @AllArgsConstructor
+            @NoArgsConstructor
+            @Builder
+            @ToString
+            public static class Alert {
+                @Schema(defaultValue = "title")
+                private String title;
+                @Schema(defaultValue = "subTitle")
+                private String subtitle;
+                @Schema(defaultValue = "body")
+                private String body;
+                @Schema(defaultValue = "")
+                @JsonProperty("launch-image")
+                private String launchImage; // 실행시 보여줄 이미지 파일, 기본 실행 이미지 대신 입력한 이미지 또는 스토리보드가 켜짐
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -12,8 +12,8 @@ public class ApnsClientRequest {
     public static class SimplePushBody {
         private Aps aps;
 
-        public SimplePushBody(String title, String subTitle, String body, Integer badge, String threaId, String targetContentId) {
-            this.aps = new Aps(new Aps.Alert(title, subTitle, body), badge, threaId, targetContentId);
+        public SimplePushBody(String title, String subTitle, String body, Integer badge, String threadId, String targetContentId) {
+            this.aps = new Aps(new Aps.Alert(title, subTitle, body), badge, threadId, targetContentId);
         }
 
         @ToString

--- a/src/main/java/com/server/capple/config/apns/service/ApnsService.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsService.java
@@ -1,0 +1,7 @@
+package com.server.capple.config.apns.service;
+
+import java.util.List;
+
+public interface ApnsService {
+    <T> Boolean sendApns(T request, List<String> deviceToken);
+}

--- a/src/main/java/com/server/capple/config/apns/service/ApnsService.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsService.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 public interface ApnsService {
     <T> Boolean sendApns(T request, List<String> deviceToken);
+    <T> Boolean sendApnsToMembers(T request, List<Long> memberIdList);
 }

--- a/src/main/java/com/server/capple/config/apns/service/ApnsService.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsService.java
@@ -3,6 +3,8 @@ package com.server.capple.config.apns.service;
 import java.util.List;
 
 public interface ApnsService {
-    <T> Boolean sendApns(T request, List<String> deviceToken);
+    <T> Boolean sendApns(T request, String ... deviceTokens);
+    <T> Boolean sendApns(T request, List<String> deviceTokenList);
+    <T> Boolean sendApnsToMembers(T request, Long ... memberIds);
     <T> Boolean sendApnsToMembers(T request, List<Long> memberIdList);
 }

--- a/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.capple.config.apns.service;
 
 import com.server.capple.config.security.jwt.service.JwtService;
+import com.server.capple.domain.member.repository.DeviceTokenRedisRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import java.util.List;
 public class ApnsServiceImpl implements ApnsService {
     private final JwtService jwtService;
     private final HttpClient apnsH2HttpClient;
+    private final DeviceTokenRedisRepository deviceTokenRedisRepository;
     private WebClient defaultApnsWebClient;
 
     @Value("${apns.base-url}")
@@ -70,5 +72,10 @@ public class ApnsServiceImpl implements ApnsService {
                     .subscribe();
             });
         return true;
+    }
+
+    @Override
+    public <T> Boolean sendApnsToMembers(T request, List<Long> memberIdList) {
+        return sendApns(request, deviceTokenRedisRepository.getDeviceTokens(memberIdList));
     }
 }

--- a/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
@@ -1,0 +1,74 @@
+package com.server.capple.config.apns.service;
+
+import com.server.capple.config.security.jwt.service.JwtService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApnsServiceImpl implements ApnsService {
+    private final JwtService jwtService;
+    private final HttpClient apnsH2HttpClient;
+    private WebClient defaultApnsWebClient;
+
+    @Value("${apns.base-url}")
+    private String apnsBaseUrl;
+    @Value("${apns.base-sub-url}")
+    private String apnsBaseSubUrl;
+    @Value("${apple-auth.client_id}")
+    private String apnsTopic;
+    private final String apnsAlertPushType = "alert";
+
+    @PostConstruct
+    public void init() {
+        defaultApnsWebClient = WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(apnsH2HttpClient))
+            .baseUrl(apnsBaseUrl)
+            .defaultHeader("apns-topic", apnsTopic)
+            .defaultHeader("apns-push-type", apnsAlertPushType)
+            .build();
+    }
+
+    @Override
+    public <T> Boolean sendApns(T request, List<String> deviceToken) {
+        WebClient tmpWebClient = defaultApnsWebClient.mutate()
+            .defaultHeader("authorization", "bearer " + jwtService.createApnsJwt())
+            .build();
+
+        WebClient tmpSubWebClient = tmpWebClient.mutate()
+            .baseUrl(apnsBaseSubUrl)
+            .build();
+
+        deviceToken.parallelStream().forEach(token -> {
+            tmpWebClient
+                .method(HttpMethod.POST)
+                .uri(token)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(String.class)
+                .doOnError(e -> { // 에러 발생 시 보조 채널로 재시도
+                    tmpSubWebClient
+                        .method(HttpMethod.POST)
+                        .uri(token)
+                        .bodyValue(request)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block();
+                    log.error("APNs 전송 중 오류 발생", e);
+                })
+                .block();
+        });
+
+        return true;
+    }
+}

--- a/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
+++ b/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
@@ -16,4 +16,5 @@ public interface JwtService {
     Boolean isExpired(String token);
     Boolean checkJwt(String token);
     MemberResponse.Tokens refreshTokens(Long memberId, Role role);
+    String createApnsJwt();
 }

--- a/src/main/java/com/server/capple/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/capple/domain/member/controller/MemberController.java
@@ -84,8 +84,8 @@ public class MemberController {
                 """, description = "서버측의 애플 서버 접근 클라언트 관련 문제로 서버 관리자에게 문의해주세요."),
         })),
     })
-    public BaseResponse<MemberResponse.SignInResponse> login(@RequestParam String code) {
-        return BaseResponse.onSuccess(memberService.signIn(code));
+    public BaseResponse<MemberResponse.SignInResponse> login(@RequestParam String code, @RequestParam String deviceToken) {
+        return BaseResponse.onSuccess(memberService.signIn(code, deviceToken));
     }
 
     @Operation(summary = "회원가입 API", description = "회원가입 API 입니다." +
@@ -94,15 +94,15 @@ public class MemberController {
             "회원가입 성공시 accessToken과 refreshToken이 반환됩니다.")
     @PostMapping("/sign-up")
     public BaseResponse<MemberResponse.Tokens> signUp(@RequestBody MemberRequest.signUp request) {
-        return BaseResponse.onSuccess(memberService.signUp(request.getSignUpToken(), request.getEmail(), request.getNickname(), request.getProfileImage()));
+        return BaseResponse.onSuccess(memberService.signUp(request.getSignUpToken(), request.getEmail(), request.getNickname(), request.getProfileImage(), request.getDeviceToken()));
     }
 
     @Operation(summary = "테스트용 로컬 로그인 API", description = "테스트용 로컬 로그인 API 입니다." +
             "쿼리 파라미터를 이용해 테스트용 아이디를 입력해주세요." +
             "refreshToken의 위치에 signUpToken이 반환됩니다.")
     @GetMapping("/local-sign-in")
-    public BaseResponse<MemberResponse.SignInResponse> localLogin(@RequestParam String testId) {
-        return BaseResponse.onSuccess(memberService.localSignIn(testId));
+    public BaseResponse<MemberResponse.SignInResponse> localLogin(@RequestParam String testId, @RequestParam String deviceToken) {
+        return BaseResponse.onSuccess(memberService.localSignIn(testId, deviceToken));
     }
 
     @Operation(summary = "회원탈퇴 API", description = "회원탈퇴 API 입니다.")
@@ -186,5 +186,11 @@ public class MemberController {
         @Parameter(description = "화이트 리스트 등록 기간 (분)")
         @RequestParam Long whitelistDurationMinutes) {
         return BaseResponse.onSuccess(memberService.registerEmailWhitelist(mail, whitelistDurationMinutes));
+    }
+
+    @Operation(summary = "로그아웃 API", description = "로그아웃 API 입니다.<br>저장된 디바이스 토큰을 지웁니다.")
+    @GetMapping("/logout")
+    public BaseResponse<Boolean> logout(@AuthMember Member member) {
+        return BaseResponse.onSuccess(memberService.logout(member));
     }
 }

--- a/src/main/java/com/server/capple/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/server/capple/domain/member/dto/MemberRequest.java
@@ -30,6 +30,7 @@ public class MemberRequest {
         private String email;
         private String nickname;
         private String profileImage;
+        private String deviceToken;
     }
 
 }

--- a/src/main/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepository.java
@@ -1,0 +1,36 @@
+package com.server.capple.domain.member.repository;
+
+
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class DeviceTokenRedisRepository {
+    public static final String DEVICE_TOKEN_KEY = "device-token-";
+
+    @Resource(name = "redisTemplate")
+    private ValueOperations<String, String> valueOperations;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveDeviceToken(String key, String deviceToken) {
+        valueOperations.set(DEVICE_TOKEN_KEY + key, deviceToken);
+    }
+
+    public String getDeviceToken(String key) {
+        return valueOperations.get(DEVICE_TOKEN_KEY + key);
+    }
+
+    public List<String> getDeviceTokens(List<String> keys) {
+        return valueOperations.multiGet(keys.stream().map(key -> DEVICE_TOKEN_KEY + key).toList());
+    }
+
+    public void deleteDeviceToken(String key) {
+        redisTemplate.delete(DEVICE_TOKEN_KEY + key);
+    }
+}

--- a/src/main/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepository.java
@@ -18,19 +18,19 @@ public class DeviceTokenRedisRepository {
     private ValueOperations<String, String> valueOperations;
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void saveDeviceToken(String key, String deviceToken) {
-        valueOperations.set(DEVICE_TOKEN_KEY + key, deviceToken);
+    public void saveDeviceToken(Long memberId, String deviceToken) {
+        valueOperations.set(DEVICE_TOKEN_KEY + memberId.toString(), deviceToken);
     }
 
-    public String getDeviceToken(String key) {
-        return valueOperations.get(DEVICE_TOKEN_KEY + key);
+    public String getDeviceToken(Long memberId) {
+        return valueOperations.get(DEVICE_TOKEN_KEY + memberId.toString());
     }
 
-    public List<String> getDeviceTokens(List<String> keys) {
-        return valueOperations.multiGet(keys.stream().map(key -> DEVICE_TOKEN_KEY + key).toList());
+    public List<String> getDeviceTokens(List<Long> keys) {
+        return valueOperations.multiGet(keys.stream().map(key -> DEVICE_TOKEN_KEY + key.toString()).toList());
     }
 
-    public void deleteDeviceToken(String key) {
-        redisTemplate.delete(DEVICE_TOKEN_KEY + key);
+    public void deleteDeviceToken(Long memberId) {
+        redisTemplate.delete(DEVICE_TOKEN_KEY + memberId.toString());
     }
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberService.java
@@ -13,9 +13,9 @@ public interface MemberService {
     MemberResponse.EditMemberInfo editMemberInfo(Member member, MemberRequest.EditMemberInfo request);
     MemberResponse.ProfileImage uploadImage(MultipartFile image);
     MemberResponse.DeleteProfileImages deleteOrphanageImages();
-    MemberResponse.SignInResponse signIn(String authorizationCode);
-    MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage);
-    MemberResponse.SignInResponse localSignIn(String testId);
+    MemberResponse.SignInResponse signIn(String authorizationCode, String deviceToken);
+    MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage, String deviceToken);
+    MemberResponse.SignInResponse localSignIn(String testId, String deviceToken);
     MemberResponse.Tokens changeRole(Long memberId, Role role);
     MemberResponse.MemberId resignMember (Member member);
     Boolean checkNickname(String nickname);
@@ -23,4 +23,5 @@ public interface MemberService {
     Boolean registerEmailWhitelist(String email, Long whitelistDurationMinutes);
     Boolean sendCertMail(String signUpToken, String email);
     Boolean checkCertCode(String signUpToken, String email, String certCode);
+    Boolean logout(Member member);
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -107,7 +107,7 @@ public class MemberServiceImpl implements MemberService {
         String accessToken = jwtService.createJwt(memberId, role, "access");
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
         if(deviceToken != null)
-            deviceTokenRedisRepository.saveDeviceToken(memberId.toString(), deviceToken);
+            deviceTokenRedisRepository.saveDeviceToken(memberId, deviceToken);
         return memberMapper.toSignInResponse(accessToken, refreshToken, true);
     }
 
@@ -125,7 +125,7 @@ public class MemberServiceImpl implements MemberService {
         String accessToken = jwtService.createJwt(memberId, role, "access");
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
         if(deviceToken != null)
-            deviceTokenRedisRepository.saveDeviceToken(memberId.toString(), deviceToken);
+            deviceTokenRedisRepository.saveDeviceToken(memberId, deviceToken);
         return tokensMapper.toTokens(accessToken, refreshToken);
     }
 
@@ -141,7 +141,7 @@ public class MemberServiceImpl implements MemberService {
         String accessToken = jwtService.createJwt(memberId, role, "access");
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
         if(deviceToken != null)
-            deviceTokenRedisRepository.saveDeviceToken(memberId.toString(), deviceToken);
+            deviceTokenRedisRepository.saveDeviceToken(memberId, deviceToken);
         return memberMapper.toSignInResponse(accessToken, refreshToken, true);
     }
 
@@ -161,7 +161,7 @@ public class MemberServiceImpl implements MemberService {
         Member resignedMember = memberRepository.findById(member.getId()).orElseThrow(
                 () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
         resignedMember.resignMember();
-        deviceTokenRedisRepository.deleteDeviceToken(member.getId().toString());
+        deviceTokenRedisRepository.deleteDeviceToken(member.getId());
         return memberMapper.toMemberId(member);
     }
 
@@ -224,7 +224,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Boolean logout(Member member) {
-        deviceTokenRedisRepository.deleteDeviceToken(member.getId().toString());
+        deviceTokenRedisRepository.deleteDeviceToken(member.getId());
         return true;
     }
 }

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -11,6 +11,7 @@ import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.member.mapper.MemberMapper;
 import com.server.capple.domain.member.mapper.TokensMapper;
+import com.server.capple.domain.member.repository.DeviceTokenRedisRepository;
 import com.server.capple.domain.member.repository.MemberRepository;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.AuthErrorCode;
@@ -39,6 +40,7 @@ public class MemberServiceImpl implements MemberService {
     private final AppleAuthService appleAuthService;
     private final JwtService jwtService;
     private final MailService mailService;
+    private final DeviceTokenRedisRepository deviceTokenRedisRepository;
 
     @Override
     public MemberResponse.MyPageMemberInfo getMemberInfo(Member member) {
@@ -93,7 +95,7 @@ public class MemberServiceImpl implements MemberService {
         return new MemberResponse.DeleteProfileImages(deleteImages);
     }
 
-    public MemberResponse.SignInResponse signIn(String authorizationCode) {
+    public MemberResponse.SignInResponse signIn(String authorizationCode, String deviceToken) {
         AppleIdTokenPayload appleIdTokenPayload = appleAuthService.get(authorizationCode);
         Optional<Member> optionalMember = memberRepository.findBySub(appleIdTokenPayload.getSub());
         if (optionalMember.isEmpty()) {
@@ -104,12 +106,14 @@ public class MemberServiceImpl implements MemberService {
         String role = optionalMember.get().getRole().getName();
         String accessToken = jwtService.createJwt(memberId, role, "access");
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
+        if(deviceToken != null)
+            deviceTokenRedisRepository.saveDeviceToken(memberId.toString(), deviceToken);
         return memberMapper.toSignInResponse(accessToken, refreshToken, true);
     }
 
     @Override
     @Transactional
-    public MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage) {
+    public MemberResponse.Tokens signUp(String signUpToken, String email, String nickname, String profileImage, String deviceToken) {
         String sub = jwtService.getSub(signUpToken);
         String encryptedEmail = convertEmailToJwt(email);
 
@@ -120,11 +124,13 @@ public class MemberServiceImpl implements MemberService {
         String role = member.getRole().getName();
         String accessToken = jwtService.createJwt(memberId, role, "access");
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
+        if(deviceToken != null)
+            deviceTokenRedisRepository.saveDeviceToken(memberId.toString(), deviceToken);
         return tokensMapper.toTokens(accessToken, refreshToken);
     }
 
     @Override
-    public MemberResponse.SignInResponse localSignIn(String testId) {
+    public MemberResponse.SignInResponse localSignIn(String testId, String deviceToken) {
         Optional<Member> optionalMember = memberRepository.findBySub(testId);
         if (optionalMember.isEmpty()) {
             String signUpToken = jwtService.createSignUpAccessJwt(testId);
@@ -134,6 +140,8 @@ public class MemberServiceImpl implements MemberService {
         String role = optionalMember.get().getRole().getName();
         String accessToken = jwtService.createJwt(memberId, role, "access");
         String refreshToken = jwtService.createJwt(memberId, role, "refresh");
+        if(deviceToken != null)
+            deviceTokenRedisRepository.saveDeviceToken(memberId.toString(), deviceToken);
         return memberMapper.toSignInResponse(accessToken, refreshToken, true);
     }
 
@@ -153,6 +161,7 @@ public class MemberServiceImpl implements MemberService {
         Member resignedMember = memberRepository.findById(member.getId()).orElseThrow(
                 () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
         resignedMember.resignMember();
+        deviceTokenRedisRepository.deleteDeviceToken(member.getId().toString());
         return memberMapper.toMemberId(member);
     }
 
@@ -211,5 +220,11 @@ public class MemberServiceImpl implements MemberService {
         String emailJwt = convertEmailToJwt(email);
         // 이메일 인증코드 체크
         return mailService.checkEmailCertificationCode(emailJwt, certCode);
+    }
+
+    @Override
+    public Boolean logout(Member member) {
+        deviceTokenRedisRepository.deleteDeviceToken(member.getId().toString());
+        return true;
     }
 }

--- a/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
+++ b/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.server.capple.config.apns.service;
+
+import com.server.capple.config.apns.dto.ApnsClientRequest.SimplePushBody;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@DisplayName("APNs 서비스로 ")
+@SpringBootTest
+@ActiveProfiles("test")
+class ApnsServiceImplTest {
+    @Autowired
+    private ApnsService apnsService;
+
+    @Test
+    @Disabled
+    @DisplayName("메시지를 전송한다.")
+    void sendApns() {
+        //given
+        String simulatorDeviceToken = "{deviceToken}"; // 기기의 deviceToken을 넣어야 작동
+        String title = "title";
+        String subTitle = "subTitle";
+        String body = "body";
+        String threadId = "testApnsMessage";
+        String targetContentId = "targetContentId";
+
+        //when
+        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, threadId, targetContentId), List.of(simulatorDeviceToken));
+
+        //then
+        assertTrue(result);
+    }
+
+    @Test
+    @Disabled
+    @DisplayName("다수의 메시지를 전송한다.")
+    void sendApnsMessages() {
+        //given
+        String simulatorDeviceToken = "{deviceToken}"; // 기기의 deviceToken을 넣어야 작동
+        String title = "title";
+        String subTitle = "subTitle";
+        String body = "body";
+        String threadId = "multipleTestApnsMessages";
+        String targetContentId = "targetContentId";
+        ArrayList<String> deviceTokens = new ArrayList<>();
+        for (int i = 0; i < 100; i++) deviceTokens.add(simulatorDeviceToken);
+
+        //when
+        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, threadId, targetContentId), deviceTokens);
+
+        //then
+        assertTrue(result);
+    }
+}

--- a/src/test/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepositoryTest.java
+++ b/src/test/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepositoryTest.java
@@ -20,8 +20,8 @@ class DeviceTokenRedisRepositoryTest {
     @Autowired
     private DeviceTokenRedisRepository deviceTokenRedisRepository;
 
-    private String testKeyPrefix = "testKey-";
-    private List<String> testKeys = new ArrayList<>();
+    private Long testKeyPrefix = 1_000_000_000L;
+    private List<Long> testKeys = new ArrayList<>();
 
     @AfterEach
     void afterEach() {
@@ -32,7 +32,7 @@ class DeviceTokenRedisRepositoryTest {
     @DisplayName("디바이스 토큰 저장, 조회 테스트")
     void saveDeviceTokenTest() {
         //given
-        String key = testKeyPrefix + UUID.randomUUID().toString();
+        Long key = testKeyPrefix + 1;
         testKeys.add(key);
         String deviceToken = UUID.randomUUID().toString();
 
@@ -47,7 +47,7 @@ class DeviceTokenRedisRepositoryTest {
     @DisplayName("디바이스 토큰 삭제 테스트")
     void deleteDeviceTokenTest() {
         //given
-        String key = testKeyPrefix + UUID.randomUUID().toString();
+        Long key = testKeyPrefix + 1;
         String deviceToken = UUID.randomUUID().toString();
 
         //when
@@ -62,9 +62,9 @@ class DeviceTokenRedisRepositoryTest {
     @DisplayName("디바이스 토큰 여러개 조회 테스트")
     void getDeviceTokensTest() {
         //given
-        String key1 = testKeyPrefix + UUID.randomUUID().toString();
-        String key2 = testKeyPrefix + UUID.randomUUID().toString();
-        String key3 = testKeyPrefix + UUID.randomUUID().toString();
+        Long key1 = testKeyPrefix + 1;
+        Long key2 = testKeyPrefix + 2;
+        Long key3 = testKeyPrefix + 3;
         testKeys.add(key1);
         testKeys.add(key2);
         testKeys.add(key3);
@@ -89,9 +89,9 @@ class DeviceTokenRedisRepositoryTest {
     @DisplayName("디바이스 토큰 삭제 후 여러개 조회 테스트")
     void getDeviceTokensAfterDeleteTest() {
         //given
-        String key1 = testKeyPrefix + UUID.randomUUID().toString();
-        String key2 = testKeyPrefix + UUID.randomUUID().toString();
-        String key3 = testKeyPrefix + UUID.randomUUID().toString();
+        Long key1 = testKeyPrefix + 1;
+        Long key2 = testKeyPrefix + 2;
+        Long key3 = testKeyPrefix + 3;
         testKeys.add(key1);
         testKeys.add(key2);
         testKeys.add(key3);
@@ -118,7 +118,7 @@ class DeviceTokenRedisRepositoryTest {
     @DisplayName("디바이스 토큰 중복 저장, 조회 테스트")
     void saveDuplicateDeviceTokenTest() {
         //given
-        String key = testKeyPrefix + UUID.randomUUID().toString();
+        Long key = testKeyPrefix + 1;
         testKeys.add(key);
         String deviceToken1 = UUID.randomUUID().toString();
         String deviceToken2 = UUID.randomUUID().toString();

--- a/src/test/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepositoryTest.java
+++ b/src/test/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepositoryTest.java
@@ -1,0 +1,134 @@
+package com.server.capple.domain.member.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("디바이스 토큰 레포지토리의 ")
+@SpringBootTest
+@ActiveProfiles("test")
+class DeviceTokenRedisRepositoryTest {
+    @Autowired
+    private DeviceTokenRedisRepository deviceTokenRedisRepository;
+
+    private String testKeyPrefix = "testKey-";
+    private List<String> testKeys = new ArrayList<>();
+
+    @AfterEach
+    void afterEach() {
+        testKeys.forEach(deviceTokenRedisRepository::deleteDeviceToken);
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰 저장, 조회 테스트")
+    void saveDeviceTokenTest() {
+        //given
+        String key = testKeyPrefix + UUID.randomUUID().toString();
+        testKeys.add(key);
+        String deviceToken = UUID.randomUUID().toString();
+
+        //when
+        deviceTokenRedisRepository.saveDeviceToken(key, deviceToken);
+
+        //then
+        assertEquals(deviceToken, deviceTokenRedisRepository.getDeviceToken(key));
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰 삭제 테스트")
+    void deleteDeviceTokenTest() {
+        //given
+        String key = testKeyPrefix + UUID.randomUUID().toString();
+        String deviceToken = UUID.randomUUID().toString();
+
+        //when
+        deviceTokenRedisRepository.saveDeviceToken(key, deviceToken);
+        deviceTokenRedisRepository.deleteDeviceToken(key);
+
+        //then
+        assertNull(deviceTokenRedisRepository.getDeviceToken(key));
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰 여러개 조회 테스트")
+    void getDeviceTokensTest() {
+        //given
+        String key1 = testKeyPrefix + UUID.randomUUID().toString();
+        String key2 = testKeyPrefix + UUID.randomUUID().toString();
+        String key3 = testKeyPrefix + UUID.randomUUID().toString();
+        testKeys.add(key1);
+        testKeys.add(key2);
+        testKeys.add(key3);
+        String deviceToken1 = UUID.randomUUID().toString();
+        String deviceToken2 = UUID.randomUUID().toString();
+        String deviceToken3 = UUID.randomUUID().toString();
+
+        //when
+        deviceTokenRedisRepository.saveDeviceToken(key1, deviceToken1);
+        deviceTokenRedisRepository.saveDeviceToken(key2, deviceToken2);
+        deviceTokenRedisRepository.saveDeviceToken(key3, deviceToken3);
+
+        //then
+        List<String> deviceTokens = deviceTokenRedisRepository.getDeviceTokens(List.of(key1, key2, key3));
+        assertEquals(3, deviceTokens.size());
+        assertTrue(deviceTokens.contains(deviceToken1));
+        assertTrue(deviceTokens.contains(deviceToken2));
+        assertTrue(deviceTokens.contains(deviceToken3));
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰 삭제 후 여러개 조회 테스트")
+    void getDeviceTokensAfterDeleteTest() {
+        //given
+        String key1 = testKeyPrefix + UUID.randomUUID().toString();
+        String key2 = testKeyPrefix + UUID.randomUUID().toString();
+        String key3 = testKeyPrefix + UUID.randomUUID().toString();
+        testKeys.add(key1);
+        testKeys.add(key2);
+        testKeys.add(key3);
+        String deviceToken1 = UUID.randomUUID().toString();
+        String deviceToken2 = UUID.randomUUID().toString();
+        String deviceToken3 = UUID.randomUUID().toString();
+
+        //when
+        deviceTokenRedisRepository.saveDeviceToken(key1, deviceToken1);
+        deviceTokenRedisRepository.saveDeviceToken(key2, deviceToken2);
+        deviceTokenRedisRepository.saveDeviceToken(key3, deviceToken3);
+        deviceTokenRedisRepository.deleteDeviceToken(key2);
+
+        //then
+        List<String> deviceTokens = deviceTokenRedisRepository.getDeviceTokens(List.of(key1, key2, key3));
+        assertEquals(3, deviceTokens.size());
+        assertTrue(deviceTokens.contains(deviceToken1));
+        assertFalse(deviceTokens.contains(deviceToken2));
+        assertNull(deviceTokens.get(1));
+        assertTrue(deviceTokens.contains(deviceToken3));
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰 중복 저장, 조회 테스트")
+    void saveDuplicateDeviceTokenTest() {
+        //given
+        String key = testKeyPrefix + UUID.randomUUID().toString();
+        testKeys.add(key);
+        String deviceToken1 = UUID.randomUUID().toString();
+        String deviceToken2 = UUID.randomUUID().toString();
+
+        //when
+        deviceTokenRedisRepository.saveDeviceToken(key, deviceToken1);
+        deviceTokenRedisRepository.saveDeviceToken(key, deviceToken2);
+
+        //then
+        assertNotEquals(deviceToken1, deviceTokenRedisRepository.getDeviceToken(key));
+        assertEquals(deviceToken2, deviceTokenRedisRepository.getDeviceToken(key));
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feat/#126/apns -> develop

### 변경 사항
- APNs 페이로드 발송 메서드 구현
  - APNs 통신용 JWT 토큰 저장
    - APNs의 토큰 베이스 인증의 JWT 토큰이 단위시간 중 계정당 한개의 값만을 사용 가능하여 퍼블릭으로 사용할 수 있는 레디스 데이터베이스를 연결
    - redis cloud의 무료 데이터베이스를 이용
    - `@Cacheable` 어노테이션의 사용으로 메서드 단위의 캐싱 전략을 사용
      - Look Aside + Write Around 방식의 캐싱 전략을 적용 ([Look Aside, Write Around 란?](https://yoongrammer.tistory.com/101))
  - APNs 의 HTTP/2 & TLS1.2 통신 정책에 따라 기존의 Http Client를 사용하지 못해 WebClient를 도입
    - HTTP/2 방식의 이점을 살리기 위해 병렬처리, 논블로킹 IO, Connection Pool 을 이용하여 APNs와의 통신속도를 극대화
- 로그아웃 메서드 구현
  - 기존에 로그아웃 메서드가 없었고 로그아웃 시에는 푸시알림을 받으면 안되기 때문에 디바이스 토큰 제거 로직을 추가했습니다.

### 테스트 결과
병렬처리, 논블로킹 IO, Connection Pool 의 테스트 결과
- Blocking
  <img width="1188" alt="image" src="https://github.com/user-attachments/assets/a648557a-8883-4010-b371-d6f4f8c81d2f">
- Non-Blocking
  <img width="1185" alt="image" src="https://github.com/user-attachments/assets/efe27538-7bd0-41a2-9095-a4fa9cead8ba">
  -> Non-Blocking으로 하나의 Connection pool을 사용할 경우 하나의 소켓주소에서 같은 주소로 너무 많은 요청이 보내져 `429 Too Many Request` Error 가 반환되어 `최소 2개 이상`의 Connection pool을 사용해야함
- 결과
  - Block/NonBlock
    - 눈에 띌 정도로 확실하게 존재 100개의 요청 시 4초 vs 0.2초
  - 병렬 처리와 순차 처리
    - 테스트 기기 M1 (8 Core, 16GB mem)과 서버 EC2 (t2.micro, 1vCPU 1GiB mem)의 스펙 차이가 존재하여 성능 팔로업 필요
  - Connection pool
    - deviceToken 별 uri가 다르지만, 여러 소켓으로 나눠 요청을 보내는것이 `Too Many Request` 를 에방할 수 있는 방법으로 여겨짐

디바이스 토큰 저장
![image](https://github.com/user-attachments/assets/c1b5df7b-6c03-4122-b725-d20e89701abe)

