### PR TITLE
[TEST] 게시판, 게시판 좋아요 더미데이터 API 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'
 //	webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 }
 
 dependencyManagement {

--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                 .requestMatchers("/reports", "/reports/**").authenticated()
                 .requestMatchers("/boards", "/boards/**").authenticated()
                 .requestMatchers("/boardComments", "/boardComments/**").authenticated()
-                .requestMatchers("/dummy","/dummy/**").permitAll()
+                .requestMatchers("/dummy","/dummy/**").hasRole(Role.ROLE_ADMIN.getName())
                 .anyRequest().denyAll());
         http
             .addFilterBefore(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                 .requestMatchers("/reports", "/reports/**").authenticated()
                 .requestMatchers("/boards", "/boards/**").authenticated()
                 .requestMatchers("/boardComments", "/boardComments/**").authenticated()
+                .requestMatchers("/dummy","/dummy/**").permitAll()
                 .anyRequest().denyAll());
         http
             .addFilterBefore(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/server/capple/domain/board/repository/BoardHeartRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardHeartRedisRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.Random;
 import java.util.Set;
 
 import static java.lang.Boolean.FALSE;
@@ -26,7 +27,7 @@ public class BoardHeartRedisRepository implements Serializable {
     public Boolean toggleBoardHeart(Long boardId, Long memberId) {
         String key = BOARD_HEART_KEY_PREFIX + boardId.toString();
         String member = MEMBER_KEY_PREFIX + memberId.toString();
-        String createAtKey = key + ":" + member + ":createAt"; // member ID를 포함한 createAtKeyㄱ
+        String createAtKey = key + ":" + member + ":createAt"; // member ID를 포함한 createAtKey
         SetOperations<String, String> setOperations = redisTemplate.opsForSet();
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
 
@@ -70,5 +71,23 @@ public class BoardHeartRedisRepository implements Serializable {
             }
         }
         return boardIds;
+    }
+
+
+    //더미 데이터 생성용
+    public void generateDummyBoardLikes(int boardCount) {
+        SetOperations<String, String> setOperations = redisTemplate.opsForSet();
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        Random random = new Random();
+        for (int boardId = 0; boardId < boardCount; boardId++) {
+            for (int memberId = 1; memberId <= 10; memberId++) {
+                if(random.nextBoolean()) {
+                    String key = BOARD_HEART_KEY_PREFIX + boardId;
+                    String member = MEMBER_KEY_PREFIX + memberId;
+                    setOperations.add(key, member);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -6,6 +6,7 @@ import com.server.capple.domain.board.entity.BoardType;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -17,4 +18,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT b FROM Board b WHERE b.content LIKE %:keyword%")
     List<Board> findBoardsByKeyword(String keyword);
+
+    @Query(value = "SELECT generate_dummy_boards(:num)", nativeQuery = true)
+    void generateDummyBoards(@Param("num") int num);
 }

--- a/src/main/java/com/server/capple/dummy/DummyController.java
+++ b/src/main/java/com/server/capple/dummy/DummyController.java
@@ -1,0 +1,40 @@
+package com.server.capple.dummy;
+
+import com.server.capple.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "더미데이터 생성 API", description = "더미데이터 생성을 위한 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/dummy")
+public class DummyController {
+
+    private final DummyService dummyService;
+
+    @Operation(summary = "게시글,게시글 좋아요 더미 생성 API", description = "게시글과 게시글 좋아요 더미를 생성합니다." +
+            "멤버 더미 먼저 생성 후 실행해주세요.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+    })
+    @PostMapping("/board")
+    private BaseResponse<Object> generateDummyBoards(@RequestParam("num") int num) {
+        return BaseResponse.onSuccess(dummyService.generateDummyBoards(num));
+    }
+
+    @Operation(summary = "멤버 더미 생성 API", description = "멤버 더미를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+    })
+    @PostMapping("/member")
+    private BaseResponse<Object> generateDummyMembers() {
+        return BaseResponse.onSuccess(dummyService.generateDummyMembers());
+    }
+}

--- a/src/main/java/com/server/capple/dummy/DummyService.java
+++ b/src/main/java/com/server/capple/dummy/DummyService.java
@@ -40,7 +40,6 @@ public class DummyService {
 
         for (long i = 1; i <= 10; i++) {
             Member member = Member.builder()
-                    .id(i)
                     .nickname("User" + i)
                     .email("user" + i + "@example.com")
                     .sub("sub" + i)

--- a/src/main/java/com/server/capple/dummy/DummyService.java
+++ b/src/main/java/com/server/capple/dummy/DummyService.java
@@ -1,0 +1,56 @@
+package com.server.capple.dummy;
+
+
+import com.server.capple.domain.board.repository.BoardHeartRedisRepository;
+import com.server.capple.domain.board.repository.BoardRepository;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
+
+@Service
+@RequiredArgsConstructor
+public class DummyService {
+    private final BoardRepository boardRepository;
+    private final BoardHeartRedisRepository boardHeartRedisRepository;
+    private final MemberRepository memberRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Transactional
+    public Object generateDummyBoards(int num) {
+        boardRepository.generateDummyBoards(num);
+        em.flush();
+        boardHeartRedisRepository.generateDummyBoardLikes(num);
+        return null;
+    }
+
+    @Transactional
+    public Object generateDummyMembers() {
+        List<Member> members = new ArrayList<>();
+
+        for (long i = 1; i <= 10; i++) {
+            Member member = Member.builder()
+                    .id(i)
+                    .nickname("User" + i)
+                    .email("user" + i + "@example.com")
+                    .sub("sub" + i)
+                    .role(ROLE_ACADEMIER)
+                    .build();
+
+            members.add(member);
+        }
+
+        memberRepository.saveAll(members);
+        return null;
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) test/#140/dummyDataApi -> develop

### 변경 사항
* `i.n.r.d.DnsServerAddressStreamProviders  : Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. ` 에러가 자꾸 떠서 build.gradle에 `'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'`의존성을 추가했습니다.

* 멤버 10명을 생성하고, param으로 넘겨준 수만큼 board 더미 데이터를 생성하는 API를 구현했습니다.
board 더미 데이터를 생성하는 프로시저를 사용하도록 하였습니다. (데이터베이스 내 프로시저를 만들어두었습니다.)

### 테스트 결과
<img width="489" alt="스크린샷 2024-09-07 오후 10 11 00" src="https://github.com/user-attachments/assets/c6b3449c-5313-46c8-b0d1-1732eda0c325">

스웨거와 localDB로 확인하였습니다.