### PR TITLE
[REFACTOR] 좋아요 RDB로 구현

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.answer.service;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.AnswerLike;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
@@ -40,8 +41,13 @@ public class AnswerServiceImpl implements AnswerService {
         Member member = memberService.findMember(loginMember.getId());
         Question question = questionService.findQuestion(questionId);
 
+        if (answerRepository.existsByQuestionAndMember(question, loginMember)) {
+            throw new RestApiException(AnswerErrorCode.ANSWER_ALREADY_EXIST);
+        }
+
         //답변 저장
         Answer answer = answerRepository.save(answerMapper.toAnswerEntity(request, member, question));
+//        answer.getQuestion().increaseCommentCount();
 
         return new AnswerResponse.AnswerId(answer.getId());
     }
@@ -66,6 +72,8 @@ public class AnswerServiceImpl implements AnswerService {
         Answer answer = findAnswer(answerId);
 
         checkPermission(loginMember, answer);
+//        answer.getQuestion().decreaseCommentCount();
+
 
         answer.delete();
 
@@ -75,11 +83,11 @@ public class AnswerServiceImpl implements AnswerService {
 
     //답변 좋아요 / 취소
     @Override
-    public AnswerResponse.AnswerLike toggleAnswerHeart(Member loginMember, Long answerId) {
+    public AnswerLike toggleAnswerHeart(Member loginMember, Long answerId) {
         Member member = memberService.findMember(loginMember.getId());
 
         Boolean isLiked = answerHeartRedisRepository.toggleAnswerHeart(member.getId(), answerId);
-        return new AnswerResponse.AnswerLike(answerId, isLiked);
+        return new AnswerLike(answerId, isLiked);
     }
 
     @Override

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -90,14 +90,14 @@ public class AnswerServiceImpl implements AnswerService {
                     answerRepository.findByQuestion(questionId, pageable).orElseThrow(()
                                     -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND))
                             .stream()
-                            .map(answer -> answerMapper.toAnswerInfo(answer, memberId, reportRepository.existsReportByAnswer(answer)))
+                            .map(answer -> answerMapper.toAnswerInfo(answer, memberId, reportRepository.existsReportByAnswer(answer), answerHeartRedisRepository.isMemberLikedAnswer(memberId, answer.getId()), answer.getMember().getId().equals(memberId)))
                             .toList());
         } else {
             return answerMapper.toAnswerList(
                     answerRepository.findByQuestionAndKeyword(questionId, keyword, pageable).orElseThrow(()
                                     -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND))
                             .stream()
-                            .map(answer -> answerMapper.toAnswerInfo(answer, memberId, reportRepository.existsReportByAnswer(answer)))
+                            .map(answer -> answerMapper.toAnswerInfo(answer, memberId, reportRepository.existsReportByAnswer(answer), answerHeartRedisRepository.isMemberLikedAnswer(memberId, answer.getId()), answer.getMember().getId().equals(memberId)))
                             .toList());
         }
 
@@ -109,7 +109,7 @@ public class AnswerServiceImpl implements AnswerService {
         List<Answer> answers = answerRepository.findByMember(member).orElse(null);
         return answerMapper.toMemberAnswerList(
                 answers.stream()
-                        .map(answer -> answerMapper.toMemberAnswerInfo(answer, answerHeartRedisRepository.getAnswerHeartsCount(answer.getId())))
+                        .map(answer -> answerMapper.toMemberAnswerInfo(answer, answerHeartRedisRepository.getAnswerHeartsCount(answer.getId()), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answer.getId())))
                         .toList()
         );
     }
@@ -120,11 +120,10 @@ public class AnswerServiceImpl implements AnswerService {
         return answerMapper.toMemberAnswerList(
                 answerHeartRedisRepository.getMemberHeartsAnswer(member.getId())
                         .stream()
-                        .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer((answerId)), answerHeartRedisRepository.getAnswerHeartsCount(answerId)))
+                        .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer((answerId)), answerHeartRedisRepository.getAnswerHeartsCount(answerId), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answerId)))
                         .toList()
         );
     }
-
 
     //로그인된 유저와 작성자가 같은지 체크
     private void checkPermission(Member loginMember, Answer answer) {

--- a/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentMapper.java
@@ -20,7 +20,7 @@ public class AnswerCommentMapper {
     public AnswerCommentInfo toAnswerCommentInfo(AnswerComment comment, Long heartCount) {
         return AnswerCommentInfo.builder()
                 .answerCommentId(comment.getId())
-                .writer(comment.getMember().getNickname())
+                .writerId(comment.getMember().getId())
                 .content(comment.getContent())
                 .heartCount(heartCount)
                 .createdAt(comment.getCreatedAt())

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -39,7 +39,7 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/redis")
-    private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardType(
+    private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardTypeWithRedis(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType
             // TODO: 페이징 프론트 이슈로 추후 구현
@@ -53,13 +53,13 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping()
-    private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardTypeWithRDB(
+    private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardType(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType
             // TODO: 페이징 프론트 이슈로 추후 구현
 //            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) @Parameter(hidden = true) Pageable pageable
     ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRDB(member, boardType));
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType));
     }
 
     @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -1,23 +1,17 @@
 package com.server.capple.domain.board.controller;
 
 import com.server.capple.config.security.AuthMember;
-import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.board.dto.BoardRequest;
 import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.board.service.BoardService;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.question.dto.response.QuestionResponse;
 import com.server.capple.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "게시판 API", description = "게시판 관련 API")

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -82,5 +82,4 @@ public class BoardController {
     public BaseResponse<BoardResponse.BoardToggleHeart> toggleBoardHeart(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
         return BaseResponse.onSuccess(boardService.toggleBoardHeart(member, boardId));
     }
-
 }

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -79,7 +79,7 @@ public class BoardController {
     @Operation(summary = "게시글 좋아요/취소 API", description = " 게시글 좋아요/취소 API 입니다." +
             "pathvariable 으로 boardId를 주세요.")
     @PostMapping("/{boardId}/heart")
-    public BaseResponse<BoardResponse.BoardToggleHeart> toggleBoardHeart(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
+    public BaseResponse<BoardResponse.ToggleBoardHeart> toggleBoardHeart(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
         return BaseResponse.onSuccess(boardService.toggleBoardHeart(member, boardId));
     }
 }

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -45,7 +45,7 @@ public class BoardController {
             // TODO: 페이징 프론트 이슈로 추후 구현
 //            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) @Parameter(hidden = true) Pageable pageable
             ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType));
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRedis(member, boardType));
     }
 
     @Operation(summary = "카테고리별 게시글 조회", description = "카테고리별 게시글을 조회합니다.")

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -34,11 +34,11 @@ public class BoardController {
         return BaseResponse.onSuccess(boardService.createBoard(member, request.getBoardType(), request.getContent()));
     }
 
-    @Operation(summary = "카테고리별 게시글 조회 with REDIS API", description = "카테고리별 게시글을 조회합니다.")
+    @Operation(summary = "카테고리별 게시글 조회 with REDIS API(프론트 사용 X, 성능 테스트 용)", description = "카테고리별 게시글을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
-    @GetMapping()
+    @GetMapping("/redis")
     private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardType(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType
@@ -48,11 +48,11 @@ public class BoardController {
         return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType));
     }
 
-    @Operation(summary = "카테고리별 게시글 조회 WITH RDB API (프론트 사용 X, 성능 테스트 용)", description = "카테고리별 게시글을 조회합니다.")
+    @Operation(summary = "카테고리별 게시글 조회", description = "카테고리별 게시글을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
-    @GetMapping("/rdb")
+    @GetMapping()
     private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardTypeWithRDB(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -40,7 +40,7 @@ public class BoardController {
         return BaseResponse.onSuccess(boardService.createBoard(member, request.getBoardType(), request.getContent()));
     }
 
-    @Operation(summary = "카테고리별 게시글 조회 API", description = "카테고리별 게시글을 조회합니다.")
+    @Operation(summary = "카테고리별 게시글 조회 with REDIS API", description = "카테고리별 게시글을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
@@ -51,6 +51,19 @@ public class BoardController {
 //            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) @Parameter(hidden = true) Pageable pageable
             ) {
         return BaseResponse.onSuccess(boardService.getBoardsByBoardType(boardType));
+    }
+
+    @Operation(summary = "카테고리별 게시글 조회 WITH RDB API (프론트 사용 X, 성능 테스트 용)", description = "카테고리별 게시글을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+    })
+    @GetMapping("/rdb")
+    private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardTypeWithRDB(
+            @RequestParam(name = "boardType", required = false) BoardType boardType
+            // TODO: 페이징 프론트 이슈로 추후 구현
+//            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) @Parameter(hidden = true) Pageable pageable
+    ) {
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRDB(boardType));
     }
 
     @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")

--- a/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
@@ -74,7 +74,7 @@ public class BoardResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class BoardToggleHeart {
+    public static class ToggleBoardHeart {
         private Long boardId;
         private Boolean isLiked;
     }

--- a/src/main/java/com/server/capple/domain/board/entity/Board.java
+++ b/src/main/java/com/server/capple/domain/board/entity/Board.java
@@ -4,6 +4,7 @@ import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -29,10 +30,10 @@ public class Board extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
+    @ColumnDefault("0")
     private Integer commentCount;
 
-    @Column(nullable = false)
+    @ColumnDefault("0")
     private Integer heartCount;
 
     public void setHeartCount(boolean isLiked) {
@@ -41,5 +42,13 @@ public class Board extends BaseEntity {
         } else {
             this.heartCount--;
         }
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        this.commentCount--;
     }
 }

--- a/src/main/java/com/server/capple/domain/board/entity/Board.java
+++ b/src/main/java/com/server/capple/domain/board/entity/Board.java
@@ -31,4 +31,15 @@ public class Board extends BaseEntity {
 
     @Column(nullable = false)
     private Integer commentCount;
+
+    @Column(nullable = false)
+    private Integer heartCount;
+
+    public void setHeartCount(boolean isLiked) {
+        if (isLiked) {
+            this.heartCount++;
+        } else {
+            this.heartCount--;
+        }
+    }
 }

--- a/src/main/java/com/server/capple/domain/board/entity/BoardHeart.java
+++ b/src/main/java/com/server/capple/domain/board/entity/BoardHeart.java
@@ -1,0 +1,33 @@
+package com.server.capple.domain.board.entity;
+
+import com.server.capple.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SQLRestriction("deleted_at is null")
+public class BoardHeart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private boolean isLiked;
+
+    public boolean toggleHeart() {
+        this.isLiked = !this.isLiked;
+        return isLiked;
+    }
+}

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardHeartMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardHeartMapper.java
@@ -1,0 +1,18 @@
+package com.server.capple.domain.board.mapper;
+
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.board.entity.BoardHeart;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class BoardHeartMapper {
+    public BoardHeart toBoardHeart(Board board, Member member) {
+        return BoardHeart.builder()
+                .board(board)
+                .member(member)
+                .isLiked(false)
+                .build();
+    }
+}

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -43,9 +43,8 @@ public class BoardMapper {
                 .build();
     }
 
-/*    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
-            Board board,
-            Integer boardHeartsCount) {
+    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
+            Board board, Integer boardHeartsCount) {
         return BoardResponse.BoardsGetByBoardTypeBoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
@@ -54,7 +53,7 @@ public class BoardMapper {
                 .commentCount(board.getCommentCount())
                 .createAt(board.getCreatedAt())
                 .build();
-    }*/
+    }
 
     public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
             Board board) {

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -23,6 +23,7 @@ public class BoardMapper {
                 .boardType(boardType)
                 .content(content)
                 .commentCount(commentCount)
+                .heartCount(heartCount)
                 .build();
     }
 
@@ -42,7 +43,7 @@ public class BoardMapper {
                 .build();
     }
 
-    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
+/*    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
             Board board,
             Integer boardHeartsCount) {
         return BoardResponse.BoardsGetByBoardTypeBoardInfo.builder()
@@ -50,8 +51,19 @@ public class BoardMapper {
                 .writerId(board.getWriter().getId())
                 .content(board.getContent())
                 .heartCount(boardHeartsCount)
-                // TODO : 댓글 작성 API 나오면 추후 구현
-                .commentCount(0)
+                .commentCount(board.getCommentCount())
+                .createAt(board.getCreatedAt())
+                .build();
+    }*/
+
+    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
+            Board board) {
+        return BoardResponse.BoardsGetByBoardTypeBoardInfo.builder()
+                .boardId(board.getId())
+                .writerId(board.getWriter().getId())
+                .content(board.getContent())
+                .heartCount(board.getHeartCount())
+                .commentCount(board.getCommentCount())
                 .createAt(board.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -14,16 +14,14 @@ public class BoardMapper {
     public Board toBoard(
             Member member,
             BoardType boardType,
-            String content,
-            Integer heartCount,
-            Integer commentCount
+            String content
     ) {
         return Board.builder()
                 .writer(member)
                 .boardType(boardType)
                 .content(content)
-                .commentCount(commentCount)
-                .heartCount(heartCount)
+                .commentCount(0)
+                .heartCount(0)
                 .build();
     }
 
@@ -43,6 +41,7 @@ public class BoardMapper {
                 .build();
     }
 
+    //redis
     public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
             Board board, Integer boardHeartsCount) {
         return BoardResponse.BoardsGetByBoardTypeBoardInfo.builder()
@@ -55,8 +54,8 @@ public class BoardMapper {
                 .build();
     }
 
-    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
-            Board board) {
+    //rdb
+    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(Board board) {
         return BoardResponse.BoardsGetByBoardTypeBoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())

--- a/src/main/java/com/server/capple/domain/board/repository/BoardHeartRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardHeartRedisRepository.java
@@ -79,12 +79,12 @@ public class BoardHeartRedisRepository implements Serializable {
     }
 
     //더미 데이터 생성용
-    public void generateDummyBoardLikes(int boardCount) {
+    public void generateDummyBoardLikes(int memberCount, int boardCount) {
         SetOperations<String, String> setOperations = redisTemplate.opsForSet();
 
         Random random = new Random();
-        for (int boardId = 0; boardId < boardCount; boardId++) {
-            for (int memberId = 1; memberId <= 10; memberId++) {
+        for (int boardId = 1; boardId <= boardCount; boardId++) {
+            for (int memberId = 1; memberId <= memberCount; memberId++) {
                 if(random.nextBoolean()) {
                     String key = BOARD_HEART_KEY_PREFIX + boardId;
                     String member = MEMBER_KEY_PREFIX + memberId;

--- a/src/main/java/com/server/capple/domain/board/repository/BoardHeartRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardHeartRedisRepository.java
@@ -81,7 +81,6 @@ public class BoardHeartRedisRepository implements Serializable {
     //더미 데이터 생성용
     public void generateDummyBoardLikes(int boardCount) {
         SetOperations<String, String> setOperations = redisTemplate.opsForSet();
-        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
 
         Random random = new Random();
         for (int boardId = 0; boardId < boardCount; boardId++) {

--- a/src/main/java/com/server/capple/domain/board/repository/BoardHeartRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardHeartRepository.java
@@ -1,0 +1,13 @@
+package com.server.capple.domain.board.repository;
+
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.board.entity.BoardHeart;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoardHeartRepository extends JpaRepository<BoardHeart, Long> {
+    Optional<BoardHeart> findByMemberAndBoard(Member member, Board board);
+
+}

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.board.repository;
 
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.board.entity.BoardHeart;
 import com.server.capple.domain.board.entity.BoardType;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
@@ -17,4 +18,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT b FROM Board b WHERE b.content LIKE %:keyword%")
     List<Board> findBoardsByKeyword(String keyword);
+
 }

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -14,7 +14,4 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT b FROM Board b WHERE b.content LIKE %:keyword%")
     List<Board> findBoardsByKeyword(String keyword);
-
-    @Query(value = "SELECT generate_dummy_boards(:num)", nativeQuery = true)
-    void generateDummyBoards(@Param("num") int num);
 }

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -2,7 +2,6 @@ package com.server.capple.domain.board.repository;
 
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/com/server/capple/domain/board/service/BoardService.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardService.java
@@ -11,6 +11,7 @@ public interface BoardService {
     BoardCreate createBoard(Member member, BoardType boardType, String content);
 
     BoardsGetByBoardType getBoardsByBoardType(BoardType boardType);
+    BoardsGetByBoardType getBoardsByBoardTypeWithRDB(BoardType boardType);
 
     BoardDelete deleteBoard(Member member, Long boardId);
 

--- a/src/main/java/com/server/capple/domain/board/service/BoardService.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardService.java
@@ -8,7 +8,7 @@ import com.server.capple.domain.member.entity.Member;
 public interface BoardService {
     BoardCreate createBoard(Member member, BoardType boardType, String content);
 
-    BoardsGetByBoardType getBoardsByBoardTypeWithRDB(Member member, BoardType boardType);
+    BoardsGetByBoardType getBoardsByBoardTypeWithRedis(Member member, BoardType boardType);
 
     BoardsGetByBoardType getBoardsByBoardType(Member member, BoardType boardType);
 

--- a/src/main/java/com/server/capple/domain/board/service/BoardService.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardService.java
@@ -16,6 +16,6 @@ public interface BoardService {
 
     BoardsSearchByKeyword searchBoardsByKeyword(String keyword);
 
-    BoardToggleHeart toggleBoardHeart(Member member, Long boardId);
+    ToggleBoardHeart toggleBoardHeart(Member member, Long boardId);
     Board findBoard(Long boardId);
 }

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -42,9 +42,8 @@ public class BoardServiceImpl implements BoardService {
     }
 
     //redis
-
     @Override
-    public BoardResponse.BoardsGetByBoardType getBoardsByBoardType(Member member, BoardType boardType) {
+    public BoardResponse.BoardsGetByBoardType getBoardsByBoardTypeWithRedis(Member member, BoardType boardType) {
         List<Board> boards;
         if (boardType == null) {
             boards = boardRepository.findAll();
@@ -69,7 +68,7 @@ public class BoardServiceImpl implements BoardService {
 
     //rdb
     @Override
-    public BoardResponse.BoardsGetByBoardType getBoardsByBoardTypeWithRDB(Member member, BoardType boardType) {
+    public BoardResponse.BoardsGetByBoardType getBoardsByBoardType(Member member, BoardType boardType) {
         List<Board> boards;
         if (boardType == null) {
             boards = boardRepository.findAll();

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -27,7 +27,7 @@ public class BoardServiceImpl implements BoardService {
     private final BoardRepository boardRepository;
     private final BoardHeartRedisRepository boardHeartRedisRepository;
     private final BoardHeartRepository boardHeartRepository;
-    private final BoardMapper boardMapper;
+    private final BoardMapper  boardMapper;
     private final BoardHeartMapper boardHeartMapper;
 
     @Override
@@ -54,7 +54,24 @@ public class BoardServiceImpl implements BoardService {
             throw new RestApiException(BoardErrorCode.BOARD_BAD_REQUEST);
         }
         return boardMapper.toBoardsGetByBoardType(boards.stream()
-                //.map(board -> boardMapper.toBoardsGetByBoardTypeBoardInfo(board, boardHeartRedisRepository.getBoardHeartsCount(board.getId())))
+                .map(board -> boardMapper.toBoardsGetByBoardTypeBoardInfo(board, boardHeartRedisRepository.getBoardHeartsCount(board.getId())))
+                .toList()
+        );
+    }
+
+    @Override
+    public BoardResponse.BoardsGetByBoardType getBoardsByBoardTypeWithRDB(BoardType boardType) {
+        List<Board> boards;
+        if (boardType == null) {
+            boards = boardRepository.findAll();
+        } else if (boardType == BoardType.FREEBOARD) {
+            boards = boardRepository.findBoardsByBoardType(BoardType.FREEBOARD);
+        } else if (boardType == BoardType.HOTBOARD) {
+            boards = boardRepository.findBoardsByBoardType(BoardType.HOTBOARD);
+        } else {
+            throw new RestApiException(BoardErrorCode.BOARD_BAD_REQUEST);
+        }
+        return boardMapper.toBoardsGetByBoardType(boards.stream()
                 .map(board -> boardMapper.toBoardsGetByBoardTypeBoardInfo(board))
                 .toList()
         );
@@ -80,18 +97,17 @@ public class BoardServiceImpl implements BoardService {
     }
 
     //redis 용
- /*
     @Override
-    public BoardResponse.BoardToggleHeart toggleBoardHeart(Member member, Long boardId) {
+    public BoardResponse.ToggleBoardHeart toggleBoardHeart(Member member, Long boardId) {
         Board board = findBoard(boardId);
         System.out.println(boardHeartRedisRepository.getBoardHeartCreateAt(board.getId(), member.getId()));
 
         Boolean isLiked = boardHeartRedisRepository.toggleBoardHeart(member.getId(), board.getId());
-        return new BoardResponse.BoardToggleHeart(boardId, isLiked);
+        return new BoardResponse.ToggleBoardHeart(boardId, isLiked);
     }
-*/
 
     //rdb용
+    /*
     @Override
     public BoardResponse.ToggleBoardHeart toggleBoardHeart(Member member, Long boardId) {
         Board board = findBoard(boardId);
@@ -109,12 +125,11 @@ public class BoardServiceImpl implements BoardService {
 
         return new BoardResponse.ToggleBoardHeart(boardId, isLiked);
     }
+*/
 
     @Override
     public Board findBoard(Long boardId) {
         return boardRepository.findById(boardId)
                 .orElseThrow(() -> new RestApiException(BoardErrorCode.BOARD_NOT_FOUND));
     }
-
-
 }

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -2,12 +2,9 @@ package com.server.capple.domain.board.service;
 
 import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.board.entity.Board;
-import com.server.capple.domain.board.entity.BoardHeart;
 import com.server.capple.domain.board.entity.BoardType;
-import com.server.capple.domain.board.mapper.BoardHeartMapper;
 import com.server.capple.domain.board.mapper.BoardMapper;
 import com.server.capple.domain.board.repository.BoardHeartRedisRepository;
-import com.server.capple.domain.board.repository.BoardHeartRepository;
 import com.server.capple.domain.board.repository.BoardRepository;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.exception.RestApiException;
@@ -16,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -26,21 +22,19 @@ public class BoardServiceImpl implements BoardService {
 
     private final BoardRepository boardRepository;
     private final BoardHeartRedisRepository boardHeartRedisRepository;
-    private final BoardHeartRepository boardHeartRepository;
     private final BoardMapper  boardMapper;
-    private final BoardHeartMapper boardHeartMapper;
-
     @Override
     public BoardResponse.BoardCreate createBoard(Member member, BoardType boardType, String content) {
         Board board;
         if (content != null) {
-            board = boardRepository.save(boardMapper.toBoard(member, boardType, content, 0, 0));
+            board = boardRepository.save(boardMapper.toBoard(member, boardType, content));
         } else {
             throw new RestApiException(BoardErrorCode.BOARD_BAD_REQUEST);
         }
         return boardMapper.toBoardCreate(board);
     }
 
+    //redis
     @Override
     public BoardResponse.BoardsGetByBoardType getBoardsByBoardType(BoardType boardType) {
         List<Board> boards;
@@ -59,6 +53,7 @@ public class BoardServiceImpl implements BoardService {
         );
     }
 
+    //rdb
     @Override
     public BoardResponse.BoardsGetByBoardType getBoardsByBoardTypeWithRDB(BoardType boardType) {
         List<Board> boards;
@@ -105,27 +100,6 @@ public class BoardServiceImpl implements BoardService {
         Boolean isLiked = boardHeartRedisRepository.toggleBoardHeart(member.getId(), board.getId());
         return new BoardResponse.ToggleBoardHeart(boardId, isLiked);
     }
-
-    //rdb용
-    /*
-    @Override
-    public BoardResponse.ToggleBoardHeart toggleBoardHeart(Member member, Long boardId) {
-        Board board = findBoard(boardId);
-        // 좋아요 눌렀는지 확인
-
-        //boardHeart에 없다면 새로 저장
-        BoardHeart boardHeart = boardHeartRepository.findByMemberAndBoard(member, board)
-                .orElseGet(() -> {
-                    BoardHeart newHeart = boardHeartMapper.toBoardHeart(board, member);
-                    return boardHeartRepository.save(newHeart);
-                });
-
-        boolean isLiked = boardHeart.toggleHeart();
-        board.setHeartCount(boardHeart.isLiked());
-
-        return new BoardResponse.ToggleBoardHeart(boardId, isLiked);
-    }
-*/
 
     @Override
     public Board findBoard(Long boardId) {

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -79,7 +79,9 @@ public class BoardServiceImpl implements BoardService {
                 .toList());
     }
 
- /*   @Override
+    //redis 용
+ /*
+    @Override
     public BoardResponse.BoardToggleHeart toggleBoardHeart(Member member, Long boardId) {
         Board board = findBoard(boardId);
         System.out.println(boardHeartRedisRepository.getBoardHeartCreateAt(board.getId(), member.getId()));
@@ -89,8 +91,9 @@ public class BoardServiceImpl implements BoardService {
     }
 */
 
+    //rdb용
     @Override
-    public BoardResponse.BoardToggleHeart toggleBoardHeart(Member member, Long boardId) {
+    public BoardResponse.ToggleBoardHeart toggleBoardHeart(Member member, Long boardId) {
         Board board = findBoard(boardId);
         // 좋아요 눌렀는지 확인
 
@@ -104,7 +107,7 @@ public class BoardServiceImpl implements BoardService {
         boolean isLiked = boardHeart.toggleHeart();
         board.setHeartCount(boardHeart.isLiked());
 
-        return new BoardResponse.BoardToggleHeart(boardId, isLiked);
+        return new BoardResponse.ToggleBoardHeart(boardId, isLiked);
     }
 
     @Override

--- a/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
+++ b/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
@@ -3,7 +3,7 @@ package com.server.capple.domain.boardComment.controller;
 
 import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentHeart;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentId;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
 import com.server.capple.domain.boardComment.service.BoardCommentService;
@@ -46,8 +46,8 @@ public class BoardCommentController {
 
     @Operation(summary = "게시글 댓글 좋아요/취소 토글 API", description = " 게시글 댓글 좋아요/취소 토글 API 입니다. pathVariable 으로 commentId를 주세요.")
     @PatchMapping("/heart/{commentId}")
-    public BaseResponse<BoardCommentHeart> heartBoardComment(@AuthMember Member member, @PathVariable(value = "commentId") Long commentId) {
-        return BaseResponse.onSuccess(boardCommentService.heartBoardComment(member, commentId));
+    public BaseResponse<ToggleBoardCommentHeart> heartBoardComment(@AuthMember Member member, @PathVariable(value = "commentId") Long commentId) {
+        return BaseResponse.onSuccess(boardCommentService.toggleBoardCommentHeart(member, commentId));
     }
 
     @Operation(summary = "게시글 댓글 리스트 조회 API", description = " 게시글 댓글 리스트 조회 API 입니다. pathVariable 으로 boardId를 주세요.")

--- a/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
+++ b/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
@@ -56,4 +56,10 @@ public class BoardCommentController {
         return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId));
     }
 
+    @Operation(summary = "게시글 댓글 리스트 조회 API(프론트 사용 X, 성능 테스트 용)", description = " 게시글 댓글 리스트 조회 API 입니다. pathVariable 으로 boardId를 주세요.")
+    @GetMapping("/{boardId}/rdb")
+    public BaseResponse<BoardCommentInfos> getBoardCommentInfosWithRDB(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
+        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfosWithRDB(member,boardId));
+    }
+
 }

--- a/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
+++ b/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
@@ -56,10 +56,4 @@ public class BoardCommentController {
         return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId));
     }
 
-    @Operation(summary = "게시글 댓글 리스트 조회 API(프론트 사용 X, 성능 테스트 용)", description = " 게시글 댓글 리스트 조회 API 입니다. pathVariable 으로 boardId를 주세요.")
-    @GetMapping("/{boardId}/rdb")
-    public BaseResponse<BoardCommentInfos> getBoardCommentInfosWithRDB(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
-        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfosWithRDB(member,boardId));
-    }
-
 }

--- a/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
+++ b/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
@@ -17,7 +17,7 @@ public class BoardCommentResponse {
 
     @Getter
     @AllArgsConstructor
-    public static class BoardCommentHeart {
+    public static class ToggleBoardCommentHeart {
         private Long boardCommentId;
         private Boolean isLiked;
     }
@@ -28,7 +28,7 @@ public class BoardCommentResponse {
         private Long boardCommentId;
         private String writer;
         private String content;
-        private Long heartCount;
+        private Integer heartCount;
         private Boolean isLiked;
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
+++ b/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
@@ -30,6 +30,7 @@ public class BoardCommentResponse {
         private String content;
         private Integer heartCount;
         private Boolean isLiked;
+        private Boolean isMine;
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
+++ b/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
@@ -5,6 +5,8 @@ import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLRestriction;
 
 @Getter
@@ -13,6 +15,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @SQLRestriction("deleted_at is null")
+@DynamicInsert
 public class BoardComment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,7 +32,18 @@ public class BoardComment extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @ColumnDefault("0")
+    private Integer heartCount;
+
     public void update(String content) {
         this.content = content;
+    }
+
+    public void setHeartCount(boolean isLiked) {
+        if (isLiked) {
+            this.heartCount++;
+        } else {
+            this.heartCount--;
+        }
     }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/entity/BoardCommentHeart.java
+++ b/src/main/java/com/server/capple/domain/boardComment/entity/BoardCommentHeart.java
@@ -1,28 +1,25 @@
-package com.server.capple.domain.board.entity;
+package com.server.capple.domain.boardComment.entity;
 
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Builder
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLRestriction("deleted_at is null")
-public class BoardHeart extends BaseEntity {
+public class BoardCommentHeart extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "board_id", nullable = false)
-    private Board board;
+    private BoardComment boardComment;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     private boolean isLiked;

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentHeartMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentHeartMapper.java
@@ -1,0 +1,18 @@
+package com.server.capple.domain.boardComment.mapper;
+
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.boardComment.entity.BoardCommentHeart;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BoardCommentHeartMapper {
+
+    public BoardCommentHeart toBoardCommentHeart(BoardComment boardComment, Member member) {
+        return BoardCommentHeart.builder()
+                .boardComment(boardComment)
+                .member(member)
+                .isLiked(false)
+                .build();
+    }
+}

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -17,6 +17,19 @@ public class BoardCommentMapper {
                 .build();
     }
 
+    //redis
+    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Integer boardHeart, Boolean isLiked) {
+        return BoardCommentInfo.builder()
+                .boardCommentId(comment.getId())
+                .writer(comment.getMember().getNickname())
+                .content(comment.getContent())
+                .heartCount(boardHeart)
+                .isLiked(isLiked)
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+    //rdb
     public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -18,25 +18,27 @@ public class BoardCommentMapper {
     }
 
     //redis
-    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Integer boardHeart, Boolean isLiked) {
+    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Integer boardHeart, Boolean isLiked, Boolean isMine) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())
                 .writerId(comment.getMember().getId())
                 .content(comment.getContent())
                 .heartCount(boardHeart)
                 .isLiked(isLiked)
+                .isMine(isMine)
                 .createdAt(comment.getCreatedAt())
                 .build();
     }
 
     //rdb
-    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked) {
+    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked, Boolean isMine) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())
                 .writerId(comment.getMember().getId())
                 .content(comment.getContent())
                 .heartCount(comment.getHeartCount())
                 .isLiked(isLiked)
+                .isMine(isMine)
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -8,20 +8,21 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class BoardCommentMapper {
-    public BoardComment toBoardCommentEntity(Member member, Board board, String comment) {
+    public BoardComment toBoardComment(Member member, Board board, String comment) {
         return BoardComment.builder()
                 .member(member)
                 .board(board)
                 .content(comment)
+                .heartCount(0)
                 .build();
     }
 
-    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Long heartCount, Boolean isLiked) {
+    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())
                 .writer(comment.getMember().getNickname())
                 .content(comment.getContent())
-                .heartCount(heartCount)
+                .heartCount(comment.getHeartCount())
                 .isLiked(isLiked)
                 .createdAt(comment.getCreatedAt())
                 .build();

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentHeartRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentHeartRedisRepository.java
@@ -45,9 +45,10 @@ public class BoardCommentHeartRedisRepository implements Serializable {
         return setOperations.isMember(key, member);
     }
 
-    public Long getBoardCommentsCount(Long commentId) {
+    public Integer getBoardCommentsCount(Long commentId) {
         String key = BOARD_COMMENT_HEART_KEY_PREFIX + commentId.toString();
-        return redisTemplate.opsForSet().size(key);
+        Long size = redisTemplate.opsForSet().size(key);
+        return (size != null) ? size.intValue() : 0;
     }
 
 }

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentHeartRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentHeartRedisRepository.java
@@ -45,7 +45,7 @@ public class BoardCommentHeartRedisRepository implements Serializable {
         return setOperations.isMember(key, member);
     }
 
-    public Integer getBoardCommentsCount(Long commentId) {
+    public Integer getBoardCommentsHeartCount(Long commentId) {
         String key = BOARD_COMMENT_HEART_KEY_PREFIX + commentId.toString();
         Long size = redisTemplate.opsForSet().size(key);
         return (size != null) ? size.intValue() : 0;

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentHeartRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentHeartRepository.java
@@ -1,0 +1,13 @@
+package com.server.capple.domain.boardComment.repository;
+
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.boardComment.entity.BoardCommentHeart;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoardCommentHeartRepository extends JpaRepository<BoardCommentHeart,Long> {
+    Optional<BoardCommentHeart> findByMemberAndBoardComment(Member member, BoardComment boardComment);
+
+}

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
@@ -1,7 +1,7 @@
 package com.server.capple.domain.boardComment.service;
 
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentHeart;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentId;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
 import com.server.capple.domain.boardComment.entity.BoardComment;
@@ -11,7 +11,7 @@ public interface BoardCommentService {
     BoardCommentId createBoardComment(Member member, Long boardId, BoardCommentRequest request);
     BoardCommentId updateBoardComment(Member member, Long commentId,BoardCommentRequest request);
     BoardCommentId deleteBoardComment(Member member, Long commentId);
-    BoardCommentHeart heartBoardComment(Member member, Long commentId);
+    ToggleBoardCommentHeart toggleBoardCommentHeart(Member member, Long commentId);
     BoardCommentInfos getBoardCommentInfos(Member member, Long boardId);
     BoardComment findBoardComment(Long commentId);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
@@ -13,7 +13,5 @@ public interface BoardCommentService {
     BoardCommentId deleteBoardComment(Member member, Long commentId);
     ToggleBoardCommentHeart toggleBoardCommentHeart(Member member, Long commentId);
     BoardCommentInfos getBoardCommentInfos(Member member, Long boardId);
-   BoardCommentInfos getBoardCommentInfosWithRDB(Member member, Long boardId);
-
     BoardComment findBoardComment(Long commentId);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
@@ -13,5 +13,7 @@ public interface BoardCommentService {
     BoardCommentId deleteBoardComment(Member member, Long commentId);
     ToggleBoardCommentHeart toggleBoardCommentHeart(Member member, Long commentId);
     BoardCommentInfos getBoardCommentInfos(Member member, Long boardId);
+   BoardCommentInfos getBoardCommentInfosWithRDB(Member member, Long boardId);
+
     BoardComment findBoardComment(Long commentId);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -40,6 +40,7 @@ public class BoardCommentServiceImpl implements BoardCommentService {
         BoardComment boardComment = boardCommentRepository.save(
                 boardCommentMapper.toBoardCommentEntity(loginMember, board, request.getComment()));
 
+        board.increaseCommentCount();
         return new BoardCommentId(boardComment.getId());
     }
 
@@ -59,7 +60,10 @@ public class BoardCommentServiceImpl implements BoardCommentService {
         BoardComment boardComment = findBoardComment(commentId);
         checkPermission(member, boardComment);
 
+        Board board = boardComment.getBoard();
+
         boardComment.delete();
+        board.decreaseCommentCount();
 
         return new BoardCommentId(boardComment.getId());
     }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -9,7 +9,6 @@ import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardComme
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.boardComment.entity.BoardCommentHeart;
-import com.server.capple.domain.boardComment.mapper.BoardCommentHeartMapper;
 import com.server.capple.domain.boardComment.mapper.BoardCommentMapper;
 import com.server.capple.domain.boardComment.repository.BoardCommentHeartRedisRepository;
 import com.server.capple.domain.boardComment.repository.BoardCommentHeartRepository;
@@ -34,7 +33,6 @@ public class BoardCommentServiceImpl implements BoardCommentService {
     private final BoardCommentHeartRedisRepository boardCommentHeartRedisRepository;
     private final BoardCommentHeartRepository boardCommentHeartRepository;
     private final BoardCommentMapper boardCommentMapper;
-    private final BoardCommentHeartMapper boardCommentHeartMapper;
 
     @Override
     @Transactional
@@ -83,35 +81,14 @@ public class BoardCommentServiceImpl implements BoardCommentService {
         return new ToggleBoardCommentHeart(commentId, isLiked);
     }
 
-    //rdb용
-    /*
-    @Override
-    @Transactional
-    public ToggleBoardCommentHeart toggleBoardCommentHeart(Member member, Long boardCommentId) {
-        BoardComment boardComment = findBoardComment(boardCommentId);
-
-        //boardCommentHeart에 없다면 새로 저장
-        BoardCommentHeart boardCommentHeart = boardCommentHeartRepository.findByMemberAndBoardComment(member, boardComment)
-                .orElseGet(() -> {
-                    BoardCommentHeart newHeart = boardCommentHeartMapper.toBoardCommentHeart(boardComment, member);
-                    return boardCommentHeartRepository.save(newHeart);
-                });
-
-        boolean isLiked = boardCommentHeart.toggleHeart();
-        boardComment.setHeartCount(boardCommentHeart.isLiked());
-
-        return new ToggleBoardCommentHeart(boardCommentId, isLiked);
-    }
-     */
-
     @Override
     public BoardCommentInfos getBoardCommentInfos(Member member, Long boardId) {
         List<BoardCommentInfo> commentInfos = boardCommentRepository
                 .findBoardCommentByBoardIdOrderByCreatedAt(boardId).stream().map(
                         comment -> {
-                            Long heartCount = boardCommentHeartRedisRepository.getBoardCommentsCount(comment.getId());
+                            Integer heartCount = boardCommentHeartRedisRepository.getBoardCommentsCount(comment.getId());
                             Boolean isLiked = boardCommentHeartRedisRepository.isMemberLiked(comment.getId(), member.getId());
-                            return boardCommentMapper.toBoardCommentInfo(comment, isLiked);
+                            return boardCommentMapper.toBoardCommentInfo(comment, heartCount, isLiked);
                         }).toList();
 
         return new BoardCommentInfos(commentInfos);

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -85,6 +85,7 @@ public class BoardCommentServiceImpl implements BoardCommentService {
 
     //rdb용
     @Override
+    @Transactional
     public ToggleBoardCommentHeart toggleBoardCommentHeart(Member member, Long boardCommentId) {
         BoardComment boardComment = findBoardComment(boardCommentId);
 

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -88,7 +88,8 @@ public class BoardCommentServiceImpl implements BoardCommentService {
                         comment -> {
                             Integer heartCount = boardCommentHeartRedisRepository.getBoardCommentsCount(comment.getId());
                             Boolean isLiked = boardCommentHeartRedisRepository.isMemberLiked(comment.getId(), member.getId());
-                            return boardCommentMapper.toBoardCommentInfo(comment, heartCount, isLiked);
+                            Boolean isMine = comment.getMember().getId().equals(member.getId());
+                            return boardCommentMapper.toBoardCommentInfo(comment, heartCount, isLiked, isMine);
                         }).toList();
 
         return new BoardCommentInfos(commentInfos);
@@ -100,9 +101,9 @@ public class BoardCommentServiceImpl implements BoardCommentService {
                 .findBoardCommentByBoardIdOrderByCreatedAt(boardId).stream().map(
                         comment -> {
                             Boolean isLiked = boardCommentHeartRepository.findByMemberAndBoardComment(member, comment)
-                                    .map(BoardCommentHeart::isLiked)
-                                    .orElse(false);
-                            return boardCommentMapper.toBoardCommentInfo(comment, isLiked);
+                                    .isPresent();
+                            Boolean isMine = comment.getMember().getId().equals(member.getId());
+                            return boardCommentMapper.toBoardCommentInfo(comment, isLiked, isMine);
                         }).toList();
 
         return new BoardCommentInfos(commentInfos);

--- a/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
@@ -1,11 +1,10 @@
 package com.server.capple.domain.question.controller;
 
 import com.server.capple.config.security.AuthMember;
-import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
-import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfos;
+import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.service.QuestionService;
 import com.server.capple.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/server/capple/dummy/DummyController.java
+++ b/src/main/java/com/server/capple/dummy/DummyController.java
@@ -19,22 +19,13 @@ public class DummyController {
 
     private final DummyService dummyService;
 
-    @Operation(summary = "게시글,게시글 좋아요 더미 생성 API", description = "게시글과 게시글 좋아요 더미를 생성합니다." +
-            "멤버 더미 먼저 생성 후 실행해주세요.")
+    @Operation(summary = "멤버, 게시글,게시글 좋아요 더미 생성 API", description = "멤버, 게시글과 게시글 좋아요 더미를 생성합니다." +
+            "생성하고싶은 멤버 수와, 게시글 수를 파라미터로 입력해주세요. 좋아요는 redis와 rdb에 동시에 저장됩니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
-    @PostMapping("/board")
-    private BaseResponse<Object> generateDummyBoards(@RequestParam("num") int num) {
-        return BaseResponse.onSuccess(dummyService.generateDummyBoards(num));
-    }
-
-    @Operation(summary = "멤버 더미 생성 API", description = "멤버 더미를 생성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공"),
-    })
-    @PostMapping("/member")
-    private BaseResponse<Object> generateDummyMembers() {
-        return BaseResponse.onSuccess(dummyService.generateDummyMembers());
+    @PostMapping()
+    private BaseResponse<Object> generateDummyBoards(@RequestParam("memberCount") int memberCount, @RequestParam("boardCount") int boardCount) {
+        return BaseResponse.onSuccess(dummyService.generateDummy(memberCount, boardCount));
     }
 }

--- a/src/main/java/com/server/capple/dummy/DummyService.java
+++ b/src/main/java/com/server/capple/dummy/DummyService.java
@@ -2,24 +2,15 @@ package com.server.capple.dummy;
 
 
 import com.server.capple.domain.board.repository.BoardHeartRedisRepository;
-import com.server.capple.domain.board.repository.BoardRepository;
-import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.member.repository.MemberRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
-
 @Service
 @RequiredArgsConstructor
 public class DummyService {
-   // private final DummyRepository dummyRepository;
     private final BoardHeartRedisRepository boardHeartRedisRepository;
 
     @PersistenceContext

--- a/src/main/java/com/server/capple/dummy/DummyService.java
+++ b/src/main/java/com/server/capple/dummy/DummyService.java
@@ -19,37 +19,30 @@ import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
 @Service
 @RequiredArgsConstructor
 public class DummyService {
-    private final BoardRepository boardRepository;
+   // private final DummyRepository dummyRepository;
     private final BoardHeartRedisRepository boardHeartRedisRepository;
-    private final MemberRepository memberRepository;
 
     @PersistenceContext
     private EntityManager em;
 
+    //멤버, 게시글, 게시글 좋아요 생성
     @Transactional
-    public Object generateDummyBoards(int num) {
-        boardRepository.generateDummyBoards(num);
+    public Object generateDummy(int memberCount, int boardCount) {
+        generateDummyData(memberCount,boardCount);
         em.flush();
-        boardHeartRedisRepository.generateDummyBoardLikes(num);
+        boardHeartRedisRepository.generateDummyBoardLikes(memberCount, boardCount);
         return null;
     }
 
     @Transactional
-    public Object generateDummyMembers() {
-        List<Member> members = new ArrayList<>();
-
-        for (long i = 1; i <= 10; i++) {
-            Member member = Member.builder()
-                    .nickname("User" + i)
-                    .email("user" + i + "@example.com")
-                    .sub("sub" + i)
-                    .role(ROLE_ACADEMIER)
-                    .build();
-
-            members.add(member);
-        }
-
-        memberRepository.saveAll(members);
-        return null;
+    public void generateDummyData(int memberCount, int boardCount) {
+        em.createNativeQuery("select generate_dummy_data(:memberCount, :boardCount)")
+                .setParameter("memberCount", memberCount)
+                .setParameter("boardCount", boardCount)
+                .getSingleResult(); //프로시저 수행 후 아무것도 반환하지 않음
+        //excuteUpdate() 수행시 int 값을 반환해야하는데, 반환하지 않아서 Error -> getSingleResult() 사용해서 null값 받음
     }
+
+
+
 }

--- a/src/main/java/com/server/capple/dummy/DummyService.java
+++ b/src/main/java/com/server/capple/dummy/DummyService.java
@@ -31,7 +31,7 @@ public class DummyService {
                 .setParameter("memberCount", memberCount)
                 .setParameter("boardCount", boardCount)
                 .getSingleResult(); //프로시저 수행 후 아무것도 반환하지 않음
-        //excuteUpdate() 수행시 int 값을 반환해야하는데, 반환하지 않아서 Error -> getSingleResult() 사용해서 null값 받음
+        //executeUpdate() 수행시 int 값을 반환해야하는데, 반환하지 않아서 Error -> getSingleResult() 사용해서 null값 받음
     }
 
 

--- a/src/main/java/com/server/capple/dummy/generate_dummy_data.sql
+++ b/src/main/java/com/server/capple/dummy/generate_dummy_data.sql
@@ -1,0 +1,68 @@
+create function generate_dummy_data(member_count integer, board_count integer) returns void
+    language plpgsql
+as
+$$
+DECLARE
+    member_id INT;
+    board_id INT;
+    random_content TEXT;
+    random_comment_count INT;
+    random_board_type SMALLINT;
+    random_value FLOAT;
+BEGIN
+    -- 1. 멤버 더미 데이터 생성
+FOR member_id IN 1..member_count LOOP
+            INSERT INTO member (nickname, email, sub, role, created_at, updated_at)
+            VALUES (
+                       'User' || member_id,
+                       'user' || member_id || '@example.com',
+                       'sub' || member_id,
+                       'ROLE_ACADEMIER',
+                       NOW(),
+                       NULL
+                   );
+END LOOP;
+
+    -- 2. 보드 더미 데이터 생성
+FOR board_id IN 1..board_count LOOP
+            random_content := 'This is a dummy content for board ' || board_id;
+            random_comment_count := FLOOR(RANDOM() * 100);
+
+            -- FREEBOARD와 HOTBOARD를 번갈아가며 설정 (0은 FREEBOARD, 1은 HOTBOARD)
+            IF board_id % 2 = 0 THEN
+                random_board_type := 0;
+            ELSE
+                random_board_type := 1;
+            END IF;
+
+            -- 보드 데이터 삽입
+INSERT INTO board (member_id, board_type, content, comment_count, created_at, updated_at)
+VALUES (
+           FLOOR(RANDOM() * member_count) + 1,
+           random_board_type,
+           random_content,
+           random_comment_count,
+           NOW(),
+           NULL
+       );
+END LOOP;
+
+    -- 3. 보드하트 더미 데이터 생성
+FOR board_id IN 1..board_count LOOP
+            FOR member_id IN 1..member_count LOOP
+                    random_value := RANDOM();
+                    IF random_value < 0.5 THEN
+                        INSERT INTO board_heart (board_id, member_id, is_liked, created_at, updated_at)
+                        VALUES (
+                                   board_id,
+                                   member_id,
+                                   TRUE,
+                                   NOW(),
+                                   NULL
+                               );
+                    END IF;
+            END LOOP;
+END LOOP;
+
+END;
+$$;

--- a/src/test/java/com/server/capple/domain/answerComment/controller/AnswerCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/answerComment/controller/AnswerCommentControllerTest.java
@@ -149,9 +149,9 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.code").value("COMMON200"))
                 .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
                 .andExpect(jsonPath("$.result.answerCommentInfos[0].answerCommentId").value(1L))
-                .andExpect(jsonPath("$.result.answerCommentInfos[0].writer").value("루시"))
+                .andExpect(jsonPath("$.result.answerCommentInfos[0].writerId").value(1L))
                 .andExpect(jsonPath("$.result.answerCommentInfos[0].content").value("댓글 1"))
-                .andExpect(jsonPath("$.result.answerCommentInfos[0].heartCount").value(3L))
+                .andExpect(jsonPath("$.result.answerCommentInfos[0].heartCount").value(3))
                 .andExpect(jsonPath("$.result.answerCommentInfos[0].createdAt").value("2022-11-01T12:02:00"));
 
     }

--- a/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
@@ -109,9 +109,9 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     public void heartBoardCommentTest() throws Exception {
         //given
         final String url = "/boardComments/heart/{commentId}";
-        BoardCommentHeart response = new BoardCommentHeart(1L, Boolean.TRUE);
+        ToggleBoardCommentHeart response = new ToggleBoardCommentHeart(1L, Boolean.TRUE);
 
-        doReturn(response).when(boardCommentService).heartBoardComment(any(Member.class), any(Long.class));
+        doReturn(response).when(boardCommentService).toggleBoardCommentHeart(any(Member.class), any(Long.class));
 
         //when
         ResultActions resultActions = this.mockMvc.perform(patch(url, 1L)

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -79,22 +79,22 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
     public void heartBoardCommentTest() {
         //1. 좋아요
         //given & when
-        int heartCount = boardComment.getHeartCount();
         ToggleBoardCommentHeart liked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
-
+        BoardCommentInfos likedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
         //then
         assertEquals(boardComment.getId(), liked.getBoardCommentId());
         assertEquals(true, liked.getIsLiked());
-        assertEquals(heartCount + 1, boardComment.getHeartCount());
+        assertEquals(true, likedResponse.getBoardCommentInfos().get(0).getIsLiked());
+
         //2. 좋아요 취소
         //given & when
-        heartCount = boardComment.getHeartCount();
         ToggleBoardCommentHeart unLiked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
+        BoardCommentInfos unLikedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
 
         //then
         assertEquals(boardComment.getId(), unLiked.getBoardCommentId());
         assertEquals(false, unLiked.getIsLiked());
-        assertEquals(heartCount - 1, boardComment.getHeartCount());
+        assertEquals(false, unLikedResponse.getBoardCommentInfos().get(0).getIsLiked());
 
     }
 

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -79,22 +79,27 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
     public void heartBoardCommentTest() {
         //1. 좋아요
         //given & when
+        int heartCount = boardComment.getHeartCount();
         ToggleBoardCommentHeart liked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
-        BoardCommentInfos likedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
+
+        //BoardCommentInfos likedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
         //then
         assertEquals(boardComment.getId(), liked.getBoardCommentId());
         assertEquals(true, liked.getIsLiked());
-        assertEquals(true, likedResponse.getBoardCommentInfos().get(0).getIsLiked());
+        assertEquals(heartCount + 1, boardComment.getHeartCount());
+        //assertEquals(true, likedResponse.getBoardCommentInfos().get(0).getIsLiked());
 
         //2. 좋아요 취소
         //given & when
+        heartCount = boardComment.getHeartCount();
         ToggleBoardCommentHeart unLiked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
-        BoardCommentInfos unLikedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
+        //BoardCommentInfos unLikedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
 
         //then
         assertEquals(boardComment.getId(), unLiked.getBoardCommentId());
         assertEquals(false, unLiked.getIsLiked());
-        assertEquals(false, unLikedResponse.getBoardCommentInfos().get(0).getIsLiked());
+        assertEquals(heartCount - 1, boardComment.getHeartCount());
+        //assertEquals(false, unLikedResponse.getBoardCommentInfos().get(0).getIsLiked());
 
     }
 

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -27,13 +27,14 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
     public void createBoardCommentTest() {
         //given
         BoardCommentRequest request = getBoardCommentRequest();
-
+        int commentCount = board.getCommentCount();
         //when
         Long boardCommentId = boardCommentService.createBoardComment(member, board.getId(), request).getBoardCommentId();
         BoardComment comment = boardCommentService.findBoardComment(boardCommentId);
 
         //then
         assertEquals("게시글 댓글", comment.getContent());
+        assertEquals(commentCount+1, board.getCommentCount());
     }
 
     @Test
@@ -61,6 +62,7 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
         //given
         BoardCommentRequest request = getBoardCommentRequest();
         Long boardCommentId = boardCommentService.createBoardComment(member, board.getId(), request).getBoardCommentId();
+        int commentCount = board.getCommentCount();
 
         //when
         boardCommentService.deleteBoardComment(member, boardCommentId);
@@ -68,6 +70,7 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
 
         //then
         assertNotNull(comment.getDeletedAt());
+        assertEquals(commentCount-1,board.getCommentCount());
     }
 
     @Test

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -1,8 +1,8 @@
 package com.server.capple.domain.boardComment.service;
 
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentHeart;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +34,7 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
 
         //then
         assertEquals("게시글 댓글", comment.getContent());
-        assertEquals(commentCount+1, board.getCommentCount());
+        assertEquals(commentCount + 1, board.getCommentCount());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
 
         //then
         assertNotNull(comment.getDeletedAt());
-        assertEquals(commentCount-1,board.getCommentCount());
+        assertEquals(commentCount - 1, board.getCommentCount());
     }
 
     @Test
@@ -79,22 +79,22 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
     public void heartBoardCommentTest() {
         //1. 좋아요
         //given & when
-        BoardCommentHeart liked = boardCommentService.heartBoardComment(member, boardComment.getId());
-        BoardCommentInfos likedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
+        int heartCount = boardComment.getHeartCount();
+        ToggleBoardCommentHeart liked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
+
         //then
         assertEquals(boardComment.getId(), liked.getBoardCommentId());
         assertEquals(true, liked.getIsLiked());
-        assertEquals(true, likedResponse.getBoardCommentInfos().get(0).getIsLiked());
-
+        assertEquals(heartCount + 1, boardComment.getHeartCount());
         //2. 좋아요 취소
         //given & when
-        BoardCommentHeart unLiked = boardCommentService.heartBoardComment(member, boardComment.getId());
-        BoardCommentInfos unLikedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
+        heartCount = boardComment.getHeartCount();
+        ToggleBoardCommentHeart unLiked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
 
         //then
         assertEquals(boardComment.getId(), unLiked.getBoardCommentId());
         assertEquals(false, unLiked.getIsLiked());
-        assertEquals(false, unLikedResponse.getBoardCommentInfos().get(0).getIsLiked());
+        assertEquals(heartCount - 1, boardComment.getHeartCount());
 
     }
 
@@ -108,7 +108,7 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
         //then
         assertEquals("루시", response.getBoardCommentInfos().get(0).getWriter());
         assertEquals("게시글 댓글", response.getBoardCommentInfos().get(0).getContent());
-        assertEquals(0L, response.getBoardCommentInfos().get(0).getHeartCount());
+        assertEquals(0, response.getBoardCommentInfos().get(0).getHeartCount());
         assertEquals(false, response.getBoardCommentInfos().get(0).getIsLiked());
     }
 }

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -79,33 +79,6 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
     public void heartBoardCommentTest() {
         //1. 좋아요
         //given & when
-        ToggleBoardCommentHeart liked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
-        BoardCommentInfos likedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
-        //then
-        assertEquals(boardComment.getId(), liked.getBoardCommentId());
-        assertEquals(true, liked.getIsLiked());
-        assertEquals(true, likedResponse.getBoardCommentInfos().get(0).getIsLiked());
-
-        //2. 좋아요 취소
-        //given & when
-        ToggleBoardCommentHeart unLiked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
-        BoardCommentInfos unLikedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
-
-        //then
-        assertEquals(boardComment.getId(), unLiked.getBoardCommentId());
-        assertEquals(false, unLiked.getIsLiked());
-        assertEquals(false, unLikedResponse.getBoardCommentInfos().get(0).getIsLiked());
-    }
-
-
-    //rdb용
-    /*
-    @Test
-    @DisplayName("게시글 댓글 좋아요/취소 토글 테스트 - rdb용")
-    @Transactional
-    public void heartBoardCommentTest() {
-        //1. 좋아요
-        //given & when
         int heartCount = boardComment.getHeartCount();
         ToggleBoardCommentHeart liked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
 
@@ -122,8 +95,8 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
         assertEquals(boardComment.getId(), unLiked.getBoardCommentId());
         assertEquals(false, unLiked.getIsLiked());
         assertEquals(heartCount - 1, boardComment.getHeartCount());
+
     }
-     */
 
     @Test
     @DisplayName("게시판 댓글 리스트 조회 테스트")

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -110,5 +110,6 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
         assertEquals("게시글 댓글", response.getBoardCommentInfos().get(0).getContent());
         assertEquals(0, response.getBoardCommentInfos().get(0).getHeartCount());
         assertEquals(false, response.getBoardCommentInfos().get(0).getIsLiked());
+        assertEquals(true, response.getBoardCommentInfos().get(0).getIsMine());
     }
 }

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -79,6 +79,33 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
     public void heartBoardCommentTest() {
         //1. 좋아요
         //given & when
+        ToggleBoardCommentHeart liked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
+        BoardCommentInfos likedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
+        //then
+        assertEquals(boardComment.getId(), liked.getBoardCommentId());
+        assertEquals(true, liked.getIsLiked());
+        assertEquals(true, likedResponse.getBoardCommentInfos().get(0).getIsLiked());
+
+        //2. 좋아요 취소
+        //given & when
+        ToggleBoardCommentHeart unLiked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
+        BoardCommentInfos unLikedResponse = boardCommentService.getBoardCommentInfos(member, board.getId());
+
+        //then
+        assertEquals(boardComment.getId(), unLiked.getBoardCommentId());
+        assertEquals(false, unLiked.getIsLiked());
+        assertEquals(false, unLikedResponse.getBoardCommentInfos().get(0).getIsLiked());
+    }
+
+
+    //rdb용
+    /*
+    @Test
+    @DisplayName("게시글 댓글 좋아요/취소 토글 테스트 - rdb용")
+    @Transactional
+    public void heartBoardCommentTest() {
+        //1. 좋아요
+        //given & when
         int heartCount = boardComment.getHeartCount();
         ToggleBoardCommentHeart liked = boardCommentService.toggleBoardCommentHeart(member, boardComment.getId());
 
@@ -95,8 +122,8 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
         assertEquals(boardComment.getId(), unLiked.getBoardCommentId());
         assertEquals(false, unLiked.getIsLiked());
         assertEquals(heartCount - 1, boardComment.getHeartCount());
-
     }
+     */
 
     @Test
     @DisplayName("게시판 댓글 리스트 조회 테스트")

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -120,7 +120,7 @@ public abstract class ControllerTestConfig {
                         .writer(member.getNickname())
                         .content("댓글")
                         .createdAt(LocalDateTime.now())
-                        .heartCount(2L)
+                        .heartCount(2)
                         .isLiked(TRUE)
                         .build());
 

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -138,6 +138,7 @@ public abstract class ServiceTestConfig {
                         .member(member)
                         .board(board)
                         .content("게시글 댓글")
+                        .heartCount(0)
                         .build());
     }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) refactor/#139/LikeWithRDB

### 변경 사항
* 게시판, 게시판 댓글 좋아요 엔티티를 RDB로 구현하였습니다.
* 좋아요/취소 API도 RDB로 동작합니다.
* 게시판 조회 시 redis를 이용한 좋아요수 조회, rdb를 이용한 좋아요 수 조회 2개의 API가 있습니다. redis 이용한 API는 성능테스트에서만 사용할 예정입니다.
* 게시판 댓글 isMine 여부 추가하였습니다.
* 더미 데이터 생성방식을 변경했습니다. RDB의 멤버, 게시판, 게시판 좋아요를 프로시저로 한번에 수행합니다. Redis게시판 좋아요도 함께 생성됩니다. 프로시저 SQL도 추가해두었습니다!
<img width="643" alt="스크린샷 2024-09-10 오후 8 53 36" src="https://github.com/user-attachments/assets/d99e2774-7fe2-468b-b4ef-bb85ac6d4f39">

해당 문법이 맞고, 실행도 잘되는데 postgreSQL 방언을 인식하지 못하는 건지 자꾸 빨간 밑줄이 그어집니다..; yml에 dialect 설정 해놔도 그러네요..

### 테스트
<img width="416" alt="스크린샷 2024-09-10 오후 9 41 28" src="https://github.com/user-attachments/assets/fd47ef42-51b5-4312-8e5a-544f3613fc1b">
