### PR TITLE
[FEAT] 게시판 댓글 신고함 기능 구현

### DIFF
--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                 .requestMatchers("/reports", "/reports/**").authenticated()
                 .requestMatchers("/boards", "/boards/**").authenticated()
                 .requestMatchers("/boardComments", "/boardComments/**").authenticated()
+                .requestMatchers("/boardCommentReports", "/boardCommentReports/**").authenticated()
                 .requestMatchers("/dummy","/dummy/**").hasRole(Role.ROLE_ADMIN.getName())
                 .anyRequest().denyAll());
         http

--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -51,14 +51,14 @@ public class SecurityConfig {
                 .requestMatchers("/members/sign-in","/members/sign-up", "/members/local-sign-in", "/token/**", "/members/email/check", "/members/nickname/check", "/members/email/certification", "/members/email/certification/check").permitAll()
                 .requestMatchers("/admin/**", "/members/email/whitelist/register").hasRole(Role.ROLE_ADMIN.getName())
                 .requestMatchers("/answers","/answers/**").authenticated()
-                .requestMatchers("/answerComments","/answerComments/**").authenticated()
+                .requestMatchers("/answer-comments","/answer-comments/**").authenticated()
                 .requestMatchers("/members","/members/**").authenticated()
                 .requestMatchers("/tags","/tags/**").authenticated()
                 .requestMatchers("/questions","/questions/**").authenticated()
                 .requestMatchers("/reports", "/reports/**").authenticated()
                 .requestMatchers("/boards", "/boards/**").authenticated()
-                .requestMatchers("/boardComments", "/boardComments/**").authenticated()
-                .requestMatchers("/boardCommentReports", "/boardCommentReports/**").authenticated()
+                .requestMatchers("/board-comments", "/board-comments/**").authenticated()
+                .requestMatchers("/reports/board-comments", "/reports/board-comments/**").authenticated()
                 .requestMatchers("/dummy","/dummy/**").hasRole(Role.ROLE_ADMIN.getName())
                 .anyRequest().denyAll());
         http

--- a/src/main/java/com/server/capple/domain/answerComment/controller/AnswerCommentController.java
+++ b/src/main/java/com/server/capple/domain/answerComment/controller/AnswerCommentController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "답변 댓글 API", description = "답변 댓글 API입니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/answerComments")
+@RequestMapping("/answer-comments")
 public class AnswerCommentController {
 
     private final AnswerCommentService answerCommentService;

--- a/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
+++ b/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "게시글 댓글 API", description = "게시글 댓글 API입니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boardComments")
+@RequestMapping("/board-comments")
 public class BoardCommentController {
 
     private final BoardCommentService boardCommentService;

--- a/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
+++ b/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
@@ -30,6 +30,8 @@ public class BoardCommentResponse {
         private String content;
         private Long heartCount;
         private Boolean isLiked;
+        private Boolean isMine;
+        private Boolean isReport;
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
+++ b/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
@@ -29,7 +29,14 @@ public class BoardComment extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
+    private Boolean isReport;
+
     public void update(String content) {
         this.content = content;
     }
+
+    public void submitReport() { this.isReport = true; }
+
+    public void cancelReport() { this.isReport = false; }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
+++ b/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
@@ -29,14 +29,13 @@ public class BoardComment extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
     private Boolean isReport;
 
     public void update(String content) {
         this.content = content;
     }
 
-    public void submitReport() { this.isReport = true; }
+    public void submitReport() { this.isReport = Boolean.TRUE; }
 
-    public void cancelReport() { this.isReport = false; }
+    public void cancelReport() { this.isReport = Boolean.FALSE; }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
+++ b/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
@@ -29,6 +29,7 @@ public class BoardComment extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
     private Boolean isReport;
 
     public void update(String content) {

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -13,7 +13,7 @@ public class BoardCommentMapper {
                 .member(member)
                 .board(board)
                 .content(comment)
-                .isReport(false)
+                .isReport(Boolean.FALSE)
                 .build();
     }
 

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -13,16 +13,19 @@ public class BoardCommentMapper {
                 .member(member)
                 .board(board)
                 .content(comment)
+                .isReport(false)
                 .build();
     }
 
-    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Long heartCount, Boolean isLiked) {
+    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Long heartCount, Boolean isLiked, Boolean isMine) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())
                 .writerId(comment.getMember().getId())
                 .content(comment.getContent())
                 .heartCount(heartCount)
                 .isLiked(isLiked)
+                .isMine(isMine)
+                .isReport(comment.getIsReport())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -82,7 +82,8 @@ public class BoardCommentServiceImpl implements BoardCommentService {
                         comment -> {
                             Long heartCount = boardCommentHeartRedisRepository.getBoardCommentsCount(comment.getId());
                             Boolean isLiked = boardCommentHeartRedisRepository.isMemberLiked(comment.getId(), member.getId());
-                            return boardCommentMapper.toBoardCommentInfo(comment, heartCount, isLiked);
+                            Boolean isMine = member.getId().equals(comment.getMember().getId());
+                            return boardCommentMapper.toBoardCommentInfo(comment, heartCount, isLiked, isMine);
                         }).toList();
 
         return new BoardCommentInfos(commentInfos);

--- a/src/main/java/com/server/capple/domain/boardCommentReport/controller/BoardCommentReportController.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/controller/BoardCommentReportController.java
@@ -19,11 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "게시판 댓글 신고 API", description = "게시판 댓글 신고 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boardCommentReports")
+@RequestMapping("/reports/board-comment")
 public class BoardCommentReportController {
     private final BoardCommentReportService boardCommentReportService;
 
-    @Operation(summary = "게시판 신고함 작성 API", description = "게시판 신고를 작성합니다.")
+    @Operation(summary = "게시판 댓글 신고 API", description = "게시판 댓글 신고를 작성합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })

--- a/src/main/java/com/server/capple/domain/boardCommentReport/controller/BoardCommentReportController.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/controller/BoardCommentReportController.java
@@ -1,0 +1,36 @@
+package com.server.capple.domain.boardCommentReport.controller;
+
+import com.server.capple.config.security.AuthMember;
+import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportRequest;
+import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportResponse;
+import com.server.capple.domain.boardCommentReport.service.BoardCommentReportService;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "게시판 댓글 신고 API", description = "게시판 댓글 신고 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/boardCommentReports")
+public class BoardCommentReportController {
+    private final BoardCommentReportService boardCommentReportService;
+
+    @Operation(summary = "게시판 신고함 작성 API", description = "게시판 신고를 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+    })
+    @PostMapping
+    private BaseResponse<BoardCommentReportResponse.BoardCommentReportCreate> createBoardCommentReport(
+            @AuthMember Member member,
+            @RequestBody BoardCommentReportRequest.BoardCommentReportCreate request) {
+        return BaseResponse.onSuccess(boardCommentReportService.createBoardCommentReport(member, request.getBoardCommentId(), request.getBoardCommentReportType()));
+    }
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportRequest.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportRequest.java
@@ -1,0 +1,14 @@
+package com.server.capple.domain.boardCommentReport.dto;
+
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BoardCommentReportRequest {
+    @Getter
+    @NoArgsConstructor
+    public static class BoardCommentReportCreate {
+        Long boardCommentId;
+        BoardCommentReportType boardCommentReportType;
+    }
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportRequest.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportRequest.java
@@ -1,12 +1,14 @@
 package com.server.capple.domain.boardCommentReport.dto;
 
 import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class BoardCommentReportRequest {
     @Getter
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class BoardCommentReportCreate {
         Long boardCommentId;
         BoardCommentReportType boardCommentReportType;

--- a/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportResponse.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportResponse.java
@@ -1,12 +1,13 @@
 package com.server.capple.domain.boardCommentReport.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 public class BoardCommentReportResponse {
 
+    @Getter
     @AllArgsConstructor
     public static class BoardCommentReportCreate {
         Long boardCommentReportId;
-
     }
 }

--- a/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportResponse.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/dto/BoardCommentReportResponse.java
@@ -1,0 +1,12 @@
+package com.server.capple.domain.boardCommentReport.dto;
+
+import lombok.AllArgsConstructor;
+
+public class BoardCommentReportResponse {
+
+    @AllArgsConstructor
+    public static class BoardCommentReportCreate {
+        Long boardCommentReportId;
+
+    }
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/entity/BoardCommentReport.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/entity/BoardCommentReport.java
@@ -1,0 +1,34 @@
+package com.server.capple.domain.boardCommentReport.entity;
+
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SQLRestriction("deleted_at is null")
+@DynamicInsert
+public class BoardCommentReport extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private BoardComment boardComment;
+
+    @Column(nullable = false)
+    private BoardCommentReportType boardCommentReportType;
+
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/entity/BoardCommentReportType.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/entity/BoardCommentReportType.java
@@ -1,0 +1,17 @@
+package com.server.capple.domain.boardCommentReport.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BoardCommentReportType {
+
+    COMMENT_DISTRIBUTION_OF_ILLEGAL_PHOTOGRAPHS("불법촬영물 등의 유통"),
+    COMMENT_COMMERCIAL_ADVERTISING_AND_SALES("상업적 광고 및 판매"),
+    COMMENT_INADEQUATE_BOARD_CHARACTER("게시판 성격에 부적절함"),
+    COMMENT_ABUSIVE_LANGUAGE_AND_DISPARAGEMENT("욕설/비하"),
+    COMMENT_POLITICAL_PARTY_OR_POLITICIAN_DEMEANING_AND_CAMPAIGNING("정당/정치인 비하 및 선거운동"),
+    COMMENT_LEAK_IMPERSONATION_FRAUD("욕설/사칭/사기"),
+    COMMENT_TRICK_TEASING_PLASTERED("낚시, 놀림, 도배");
+
+    private final String toKorean;
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/mapper/BoardCommentReportMapper.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/mapper/BoardCommentReportMapper.java
@@ -1,0 +1,20 @@
+package com.server.capple.domain.boardCommentReport.mapper;
+
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReport;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BoardCommentReportMapper {
+
+    public BoardCommentReport toBoardCommentReportEntity(Member member, BoardComment boardComment, BoardCommentReportType boardCommentReportType) {
+        return BoardCommentReport.builder()
+                .member(member)
+                .boardComment(boardComment)
+                .boardCommentReportType(boardCommentReportType)
+                .build();
+    }
+
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/repository/BoardCommentReportRepository.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/repository/BoardCommentReportRepository.java
@@ -1,0 +1,10 @@
+package com.server.capple.domain.boardCommentReport.repository;
+
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReport;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardCommentReportRepository extends JpaRepository<BoardCommentReport, Long> {
+    Boolean existsByBoardCommentAndMember(BoardComment boardComment, Member member);
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportService.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportService.java
@@ -1,9 +1,11 @@
 package com.server.capple.domain.boardCommentReport.service;
 
 import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportResponse;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReport;
 import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
 import com.server.capple.domain.member.entity.Member;
 
 public interface BoardCommentReportService {
     BoardCommentReportResponse.BoardCommentReportCreate createBoardCommentReport(Member member, Long boardCommentId, BoardCommentReportType boardCommentReportType);
+    BoardCommentReport findBoardCommentReport(Long id);
 }

--- a/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportService.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportService.java
@@ -1,0 +1,9 @@
+package com.server.capple.domain.boardCommentReport.service;
+
+import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportResponse;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
+import com.server.capple.domain.member.entity.Member;
+
+public interface BoardCommentReportService {
+    BoardCommentReportResponse.BoardCommentReportCreate createBoardCommentReport(Member member, Long boardCommentId, BoardCommentReportType boardCommentReportType);
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceImpl.java
@@ -1,7 +1,6 @@
 package com.server.capple.domain.boardCommentReport.service;
 
 import com.server.capple.domain.boardComment.entity.BoardComment;
-import com.server.capple.domain.boardComment.mapper.BoardCommentMapper;
 import com.server.capple.domain.boardComment.service.BoardCommentService;
 import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportResponse;
 import com.server.capple.domain.boardCommentReport.entity.BoardCommentReport;
@@ -36,6 +35,7 @@ public class BoardCommentReportServiceImpl implements BoardCommentReportService 
 
         // 신고
         BoardCommentReport newReport = boardCommentReportMapper.toBoardCommentReportEntity(member, boardComment, boardCommentReportType);
+        boardComment.submitReport();
         boardCommentReportRepository.save(newReport);
 
         return new BoardCommentReportResponse.BoardCommentReportCreate(newReport.getId());

--- a/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceImpl.java
@@ -1,0 +1,43 @@
+package com.server.capple.domain.boardCommentReport.service;
+
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.boardComment.mapper.BoardCommentMapper;
+import com.server.capple.domain.boardComment.service.BoardCommentService;
+import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportResponse;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReport;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
+import com.server.capple.domain.boardCommentReport.mapper.BoardCommentReportMapper;
+import com.server.capple.domain.boardCommentReport.repository.BoardCommentReportRepository;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.exception.RestApiException;
+import com.server.capple.global.exception.errorCode.BoardCommentReportErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommentReportServiceImpl implements BoardCommentReportService {
+    private final BoardCommentReportRepository boardCommentReportRepository;
+    private final BoardCommentReportMapper boardCommentReportMapper;
+    private final BoardCommentService boardCommentService;
+
+    @Override
+    @Transactional
+    public BoardCommentReportResponse.BoardCommentReportCreate createBoardCommentReport(Member member, Long boardCommentId, BoardCommentReportType boardCommentReportType) {
+        // 신고 대상
+        BoardComment boardComment = boardCommentService.findBoardComment(boardCommentId);
+
+        // 신고 여부 확인
+        if(boardCommentReportRepository.existsByBoardCommentAndMember(boardComment, member)) {
+            throw new RestApiException(BoardCommentReportErrorCode.COMMENT_REPORT_ALREADY_EXIST);
+        }
+
+        // 신고
+        BoardCommentReport newReport = boardCommentReportMapper.toBoardCommentReportEntity(member, boardComment, boardCommentReportType);
+        boardCommentReportRepository.save(newReport);
+
+        return new BoardCommentReportResponse.BoardCommentReportCreate(newReport.getId());
+    }
+}

--- a/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceImpl.java
@@ -40,4 +40,11 @@ public class BoardCommentReportServiceImpl implements BoardCommentReportService 
 
         return new BoardCommentReportResponse.BoardCommentReportCreate(newReport.getId());
     }
+
+    @Override
+    public BoardCommentReport findBoardCommentReport(Long id) {
+        return boardCommentReportRepository.findById(id).orElseThrow(
+                () -> new RestApiException(BoardCommentReportErrorCode.COMMENT_REPORT_NOT_FOUND)
+        );
+    }
 }

--- a/src/main/java/com/server/capple/global/exception/errorCode/BoardCommentReportErrorCode.java
+++ b/src/main/java/com/server/capple/global/exception/errorCode/BoardCommentReportErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum BoardCommentReportErrorCode implements ErrorCodeInterface {
-    COMMENT_REPORT_ALREADY_EXIST("COMMENTREPORT001", "이미 신고한 댓글입니다.", HttpStatus.ALREADY_REPORTED)
+    COMMENT_REPORT_ALREADY_EXIST("COMMENT_REPORT_001", "이미 신고한 댓글입니다.", HttpStatus.ALREADY_REPORTED),
+    COMMENT_REPORT_NOT_FOUND("COMMENT_REPORT_002", "댓글에 대한 신고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     ;
 
     private final String code;

--- a/src/main/java/com/server/capple/global/exception/errorCode/BoardCommentReportErrorCode.java
+++ b/src/main/java/com/server/capple/global/exception/errorCode/BoardCommentReportErrorCode.java
@@ -1,0 +1,27 @@
+package com.server.capple.global.exception.errorCode;
+
+import com.server.capple.global.exception.ErrorCode;
+import com.server.capple.global.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BoardCommentReportErrorCode implements ErrorCodeInterface {
+    COMMENT_REPORT_ALREADY_EXIST("COMMENTREPORT001", "이미 신고한 댓글입니다.", HttpStatus.ALREADY_REPORTED)
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.builder()
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/test/java/com/server/capple/domain/answerComment/controller/AnswerCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/answerComment/controller/AnswerCommentControllerTest.java
@@ -33,7 +33,7 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
     @DisplayName("답변 댓글 생성 API 테스트")
     public void createAnswerCommentTest() throws Exception {
         //given
-        final String url = "/answerComments/answer/{answerId}";
+        final String url = "/answer-comments/answer/{answerId}";
 
         AnswerCommentRequest request = getAnswerCommentRequest();
         AnswerCommentResponse.AnswerCommentId response = new AnswerCommentResponse.AnswerCommentId(1L);
@@ -59,7 +59,7 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
     @DisplayName("답변 댓글 수정 API 테스트")
     public void updateAnswerCommentTest() throws Exception {
         //given
-        final String url = "/answerComments/{commentId}";
+        final String url = "/answer-comments/{commentId}";
 
         AnswerCommentRequest request = getAnswerCommentRequest();
         AnswerCommentResponse.AnswerCommentId response = new AnswerCommentResponse.AnswerCommentId(1L);
@@ -85,7 +85,7 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
     @DisplayName("답변 댓글 삭제 API 테스트")
     public void deleteAnswerCommentTest() throws Exception {
         //given
-        final String url = "/answerComments/{commentId}";
+        final String url = "/answer-comments/{commentId}";
         AnswerCommentResponse.AnswerCommentId response = new AnswerCommentResponse.AnswerCommentId(1L);
 
         doReturn(response).when(answerCommentService).deleteAnswerComment(any(Member.class), any(Long.class));
@@ -108,7 +108,7 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
     @DisplayName("답변 좋아요/취소 API 테스트")
     public void heartAnswerCommentTest() throws Exception {
         //given
-        final String url = "/answerComments/heart/{commentId}";
+        final String url = "/answer-comments/heart/{commentId}";
         AnswerCommentResponse.AnswerCommentHeart response = new AnswerCommentResponse.AnswerCommentHeart(1L, Boolean.TRUE);
 
         doReturn(response).when(answerCommentService).heartAnswerComment(any(Member.class), any(Long.class));
@@ -132,7 +132,7 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
     @DisplayName("답변에 대한 댓글 조회 API 테스트")
     public void getAnswerCommentInfosTest() throws Exception {
         //given
-        final String url = "/answerComments/{answerId}";
+        final String url = "/answer-comments/{answerId}";
         AnswerCommentResponse.AnswerCommentInfos response = getAnswerCommentInfos();
 
         doReturn(response).when(answerCommentService).getAnswerCommentInfos(any(Long.class));

--- a/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentReportControllerTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentReportControllerTest.java
@@ -1,0 +1,57 @@
+package com.server.capple.domain.boardComment.controller;
+
+import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportRequest;
+import com.server.capple.domain.boardCommentReport.dto.BoardCommentReportResponse;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
+import com.server.capple.domain.boardCommentReport.service.BoardCommentReportService;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.support.ControllerTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("BoardCommentReport 컨트롤러의")
+@SpringBootTest
+@AutoConfigureMockMvc
+public class BoardCommentReportControllerTest extends ControllerTestConfig {
+
+    @MockBean
+    private BoardCommentReportService boardCommentReportService;
+
+    @Test
+    @DisplayName("게시글 댓글 신고 API 테스트")
+    public void updateBoardCommentTest() throws Exception {
+        //given
+        final String url = "/reports/board-comment";
+
+        BoardCommentReportRequest.BoardCommentReportCreate request = new BoardCommentReportRequest.BoardCommentReportCreate(1L, BoardCommentReportType.COMMENT_INADEQUATE_BOARD_CHARACTER);
+        BoardCommentReportResponse.BoardCommentReportCreate response = new BoardCommentReportResponse.BoardCommentReportCreate(1L);
+        doReturn(response).when(boardCommentReportService).createBoardCommentReport(any(Member.class), any(Long.class), any(BoardCommentReportType.class));
+
+        //when
+        ResultActions resultActions = this.mockMvc.perform(
+                post(url)
+                .contentType(APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(request))
+                .header("Authorization", "Bearer " + jwt));
+
+        //then
+        resultActions.
+                andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."));
+    }
+
+}

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentReportServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentReportServiceTest.java
@@ -1,0 +1,40 @@
+package com.server.capple.domain.boardComment.service;
+
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReport;
+import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;
+import com.server.capple.domain.boardCommentReport.service.BoardCommentReportService;
+import com.server.capple.support.ServiceTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("BoardCommentReport 서비스의 ")
+@SpringBootTest
+public class BoardCommentReportServiceTest extends ServiceTestConfig {
+
+    @Autowired
+    private BoardCommentReportService boardCommentReportService;
+
+    @Test
+    @DisplayName("게시글 댓글 신고 테스트")
+    @Transactional
+    public void createBoardCommentReportTest() {
+        //given
+        Long boardCommentReportId = 1L;
+
+        //when
+        boardCommentReportService.createBoardCommentReport(member, boardComment.getId(), BoardCommentReportType.COMMENT_INADEQUATE_BOARD_CHARACTER);
+        BoardCommentReport boardCommentReport = boardCommentReportService.findBoardCommentReport(boardCommentReportId);
+
+        //then
+        assertEquals(boardCommentReportId, boardCommentReport.getId());
+        assertEquals(boardComment, boardCommentReport.getBoardComment());
+        assertEquals(boardComment.getIsReport(), Boolean.TRUE);
+        assertEquals(BoardCommentReportType.COMMENT_INADEQUATE_BOARD_CHARACTER, boardCommentReport.getBoardCommentReportType());
+    }
+
+}

--- a/src/test/java/com/server/capple/domain/boardCommentReport/boardComment/controller/BoardCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/boardCommentReport/boardComment/controller/BoardCommentControllerTest.java
@@ -1,4 +1,4 @@
-package com.server.capple.domain.boardComment.controller;
+package com.server.capple.domain.boardCommentReport.boardComment.controller;
 
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.service.BoardCommentService;
@@ -33,7 +33,7 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     @DisplayName("게시글 댓글 생성 API 테스트")
     public void createBoardCommentTest() throws Exception {
         //given
-        final String url = "/boardComments/board/{boardId}";
+        final String url = "/board-comments/board/{boardId}";
 
         BoardCommentRequest request = getBoardCommentRequest();
         BoardCommentId response = new BoardCommentId(1L);
@@ -59,7 +59,7 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     @DisplayName("게시글 댓글 수정 API 테스트")
     public void updateBoardCommentTest() throws Exception {
         //given
-        final String url = "/boardComments/{commentId}";
+        final String url = "/board-comments/{commentId}";
 
         BoardCommentRequest request = getBoardCommentRequest();
         BoardCommentId response = new BoardCommentId(1L);
@@ -85,7 +85,7 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     @DisplayName("게시글 댓글 삭제 API 테스트")
     public void deleteBoardCommentTest() throws Exception {
         //given
-        final String url = "/boardComments/{commentId}";
+        final String url = "/board-comments/{commentId}";
         BoardCommentId response = new BoardCommentId(1L);
 
         doReturn(response).when(boardCommentService).deleteBoardComment(any(Member.class), any(Long.class));
@@ -108,7 +108,7 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     @DisplayName("게시글 댓글 좋아요/취소 API 테스트")
     public void heartBoardCommentTest() throws Exception {
         //given
-        final String url = "/boardComments/heart/{commentId}";
+        final String url = "/board-comments/heart/{commentId}";
         BoardCommentHeart response = new BoardCommentHeart(1L, Boolean.TRUE);
 
         doReturn(response).when(boardCommentService).heartBoardComment(any(Member.class), any(Long.class));
@@ -132,7 +132,7 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     @DisplayName("게시글 댓글 리스트 조회 API 테스트")
     public void getBoardCommentInfosTest() throws Exception {
         //given
-        final String url = "/boardComments/{boardId}";
+        final String url = "/board-comments/{boardId}";
         BoardCommentInfos response = getBoardCommentInfos();
 
         doReturn(response).when(boardCommentService).getBoardCommentInfos(any(Member.class), any(Long.class));

--- a/src/test/java/com/server/capple/domain/boardCommentReport/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardCommentReport/boardComment/service/BoardCommentServiceTest.java
@@ -1,9 +1,10 @@
-package com.server.capple.domain.boardComment.service;
+package com.server.capple.domain.boardCommentReport.boardComment.service;
 
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentHeart;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
 import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.boardComment.service.BoardCommentService;
 import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.mockito.Mockito.when;
 
@@ -122,6 +123,7 @@ public abstract class ControllerTestConfig {
                         .createdAt(LocalDateTime.now())
                         .heartCount(2L)
                         .isLiked(TRUE)
+                        .isReport(FALSE)
                         .build());
 
         return new BoardCommentInfos(commentInfos);

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -26,6 +26,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 
+import static java.lang.Boolean.FALSE;
+
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class ServiceTestConfig {
@@ -138,6 +140,7 @@ public abstract class ServiceTestConfig {
                         .member(member)
                         .board(board)
                         .content("게시글 댓글")
+                        .isReport(FALSE)
                         .build());
     }
 


### PR DESCRIPTION
- closed #145


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/#145/boardComment -> develop

### 변경 사항
1. 게시글 댓글 신고 기능 추가했습니다. 
2. BoardComment Entity에 isReport 추가했습니다. (신고 여부 확인용)
3. 게시글 댓글 엔드포인트 `/board-comments`로 수정했습니다. 

### 테스트 결과
<img width="360" alt="image" src="https://github.com/user-attachments/assets/385fb7f2-14fd-4a46-aefa-00b4ca85734c">
