### PR TITLE
[FEAT] 비즈니스 로직과 원격 알림 발송 로직 연결

### DIFF
--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -1,11 +1,13 @@
 package com.server.capple.config.apns.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.notifiaction.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 public class ApnsClientRequest {
-
     @Getter
     @NoArgsConstructor
     @ToString
@@ -33,7 +35,6 @@ public class ApnsClientRequest {
             private String threadId;
             @JsonProperty("target-content-id")
             private String targetContentId; // 프론트 측 작업 필요함
-
             @ToString
             @Getter
             @AllArgsConstructor
@@ -47,53 +48,90 @@ public class ApnsClientRequest {
     }
 
     @Getter
-    @AllArgsConstructor
     @NoArgsConstructor
-    @Builder
     @ToString
-    public static class FullAlertBody {
+    public static class BoardNotificationBody {
         private Aps aps;
+        private String boardId;
+        @Builder
+        public BoardNotificationBody(NotificationType type, Board board) {
+            this.aps = Aps.builder()
+                .threadId("board-" + board.getId())
+                .alert(Aps.Alert.builder()
+                    .title(type.getTitle())
+                    .body(board.getContent())
+                    .build())
+                .build();
+            this.boardId = board.getId().toString();
+        }
 
+        @ToString
         @Getter
+        @Builder
         @AllArgsConstructor
         @NoArgsConstructor
-        @Builder
-        @ToString
         public static class Aps {
-            private Alert alert; // alert 정보
-            private Integer badge; // 앱 아이콘에 표시할 뱃지 숫자
-            @Schema(defaultValue = "default")
-            private String sound; // Library/Sounds 폴더 내의 파일 이름
+            private Alert alert;
+            @Builder.Default
+            private String sound = "default"; // Library/Sounds 폴더 내의 파일 이름
             @JsonProperty("thread-id")
-            private String threadId; // 알림 그룹화를 위한 thread id (UNNotificationContent 객체의 threadIdentifier와 일치해야 함)
-            private String category; // 알림 그룹화를 위한 category, (UNNotificationCategory 식별자와 일치해야 함)
-            @Schema(defaultValue = "0")
-            @JsonProperty("content-available")
-            private Integer contentAvailable; // 백그라운드 알림 여부, 1이면 백그라운드 알림, 0이면 포그라운드 알림 (백그라운드일 경우 alert, badge, sound는 넣으면 안됨)
-            @Schema(defaultValue = "0")
-            @JsonProperty("mutable-content")
-            private Integer mutableContent; // 알림 서비스 확장 플래그
-            @Schema(defaultValue = "")
-            @JsonProperty("target-content-id")
-            private String targetContentId; // 알림이 클릭되었을 때 가져올 창의 식별자, UNNotificationContent 객체에 채워짐
+            private String threadId;
 
+            @ToString
             @Getter
+            @Builder
             @AllArgsConstructor
             @NoArgsConstructor
-            @Builder
-            @ToString
             public static class Alert {
-                @Schema(defaultValue = "title")
                 private String title;
-                @Schema(defaultValue = "subTitle")
-                private String subtitle;
-                @Schema(defaultValue = "body")
                 private String body;
-                @Schema(defaultValue = "")
-                @JsonProperty("launch-image")
-                private String launchImage; // 실행시 보여줄 이미지 파일, 기본 실행 이미지 대신 입력한 이미지 또는 스토리보드가 켜짐
             }
         }
     }
 
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class BoardCommentNotificationBody {
+        private Aps aps;
+        private String boardId;
+        private String boardCommentId;
+        @Builder
+        public BoardCommentNotificationBody(NotificationType type, Board board, BoardComment boardComment) {
+            this.aps = Aps.builder().threadId("board-" + board.getId())
+                .alert(Aps.Alert.builder()
+                    .title(type.getTitle())
+                    .subtitle(boardComment.getContent())
+                    .body(board.getContent())
+                    .build())
+                .build();
+            this.boardId = board.getId().toString();
+            this.boardCommentId = boardComment.getId().toString();
+        }
+
+        @ToString
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class Aps {
+            private Alert alert;
+            private Integer badge;
+            @Schema(defaultValue = "default")
+            private String sound; // Library/Sounds 폴더 내의 파일 이름
+            @JsonProperty("thread-id")
+            private String threadId;
+
+            @ToString
+            @Getter
+            @Builder
+            @AllArgsConstructor
+            @NoArgsConstructor
+            public static class Alert {
+                private String title;
+                private String subtitle;
+                private String body;
+            }
+        }
+    }
 }

--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -11,9 +11,13 @@ public class ApnsClientRequest {
     @ToString
     public static class SimplePushBody {
         private Aps aps;
+        private String boardId;
+        private String boardCommentId;
         @Builder
-        public SimplePushBody(String title, String subTitle, String body, Integer badge, String sound, String threadId, String targetContentId) {
+        public SimplePushBody(String title, String subTitle, String body, Integer badge, String sound, String threadId, String targetContentId, String boardId, String boardCommentId) {
             this.aps = new Aps(new Aps.Alert(title, subTitle, body), badge, sound, threadId, targetContentId);
+            this.boardId = boardId;
+            this.boardCommentId = boardCommentId;
         }
 
         @ToString

--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -11,9 +11,9 @@ public class ApnsClientRequest {
     @ToString
     public static class SimplePushBody {
         private Aps aps;
-
-        public SimplePushBody(String title, String subTitle, String body, Integer badge, String threadId, String targetContentId) {
-            this.aps = new Aps(new Aps.Alert(title, subTitle, body), badge, threadId, targetContentId);
+        @Builder
+        public SimplePushBody(String title, String subTitle, String body, Integer badge, String sound, String threadId, String targetContentId) {
+            this.aps = new Aps(new Aps.Alert(title, subTitle, body), badge, sound, threadId, targetContentId);
         }
 
         @ToString
@@ -23,6 +23,8 @@ public class ApnsClientRequest {
         public static class Aps {
             private Alert alert;
             private Integer badge;
+            @Schema(defaultValue = "default")
+            private String sound; // Library/Sounds 폴더 내의 파일 이름
             @JsonProperty("thread-id")
             private String threadId;
             @JsonProperty("target-content-id")
@@ -58,7 +60,7 @@ public class ApnsClientRequest {
             private Integer badge; // 앱 아이콘에 표시할 뱃지 숫자
             @Schema(defaultValue = "default")
             private String sound; // Library/Sounds 폴더 내의 파일 이름
-            @Schema(defaultValue = "thread-id")
+            @JsonProperty("thread-id")
             private String threadId; // 알림 그룹화를 위한 thread id (UNNotificationContent 객체의 threadIdentifier와 일치해야 함)
             private String category; // 알림 그룹화를 위한 category, (UNNotificationCategory 식별자와 일치해야 함)
             @Schema(defaultValue = "0")

--- a/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
@@ -58,6 +58,7 @@ public class ApnsServiceImpl implements ApnsService {
 
         deviceToken.parallelStream()
             .forEach(token -> {
+                if (token.isBlank()) return;
                 tmpWebClient
                     .method(HttpMethod.POST)
                     .uri(token)

--- a/src/main/java/com/server/capple/domain/boardSubscribeMember/entity/BoardSubscribeMember.java
+++ b/src/main/java/com/server/capple/domain/boardSubscribeMember/entity/BoardSubscribeMember.java
@@ -1,0 +1,24 @@
+package com.server.capple.domain.boardSubscribeMember.entity;
+
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardSubscribeMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+}

--- a/src/main/java/com/server/capple/domain/boardSubscribeMember/reposiotry/BoardSubscribeMemberRepository.java
+++ b/src/main/java/com/server/capple/domain/boardSubscribeMember/reposiotry/BoardSubscribeMemberRepository.java
@@ -1,0 +1,13 @@
+package com.server.capple.domain.boardSubscribeMember.reposiotry;
+
+import com.server.capple.domain.boardSubscribeMember.entity.BoardSubscribeMember;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BoardSubscribeMemberRepository extends JpaRepository<BoardSubscribeMember, Long> {
+    Boolean existsByMemberIdAndBoardId(Long memberId, Long boardId);
+    List<BoardSubscribeMember> findBoardSubscribeMembersByBoardId(Long boardId);
+    void deleteBoardSubscribeMemberByBoardId(Long boardId);
+}

--- a/src/main/java/com/server/capple/domain/boardSubscribeMember/service/BoardSubscribeMemberService.java
+++ b/src/main/java/com/server/capple/domain/boardSubscribeMember/service/BoardSubscribeMemberService.java
@@ -1,0 +1,12 @@
+package com.server.capple.domain.boardSubscribeMember.service;
+
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.member.entity.Member;
+
+import java.util.List;
+
+public interface BoardSubscribeMemberService {
+    void createBoardSubscribeMember(Member member, Board board);
+    List<Member> findBoardSubscribeMembers(Long boardId);
+    void deleteBoardSubscribeMemberByBoardId(Long boardId);
+}

--- a/src/main/java/com/server/capple/domain/boardSubscribeMember/service/BoardSubscribeMemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardSubscribeMember/service/BoardSubscribeMemberServiceImpl.java
@@ -1,0 +1,33 @@
+package com.server.capple.domain.boardSubscribeMember.service;
+
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.boardSubscribeMember.entity.BoardSubscribeMember;
+import com.server.capple.domain.boardSubscribeMember.reposiotry.BoardSubscribeMemberRepository;
+import com.server.capple.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardSubscribeMemberServiceImpl implements BoardSubscribeMemberService {
+    private final BoardSubscribeMemberRepository boardSubscribeMemberRepository;
+    @Override
+    public void createBoardSubscribeMember(Member member, Board board) {
+        if(boardSubscribeMemberRepository.existsByMemberIdAndBoardId(member.getId(), board.getId())) {
+            return;
+        }
+        boardSubscribeMemberRepository.save(BoardSubscribeMember.builder().member(member).board(board).build());
+    }
+
+    @Override
+    public List<Member> findBoardSubscribeMembers(Long boardId) {
+        return boardSubscribeMemberRepository.findBoardSubscribeMembersByBoardId(boardId).stream().map(BoardSubscribeMember::getMember).toList();
+    }
+
+    @Override
+    public void deleteBoardSubscribeMemberByBoardId(Long boardId) {
+        boardSubscribeMemberRepository.deleteBoardSubscribeMemberByBoardId(boardId);
+    }
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
@@ -1,0 +1,18 @@
+package com.server.capple.domain.notifiaction.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    BOARD_HEART("누군가 내 게시글을 좋아했어요", null),
+    BOARD_COMMENT("누군가 내 게시글에 댓글을 달았어요", null),
+    BAORD_COMMENT_DUPLCATE("누군가 나와 같은 게시글에 댓글을 달았아요", null),
+    BOARD_COMMENT_HEART("누군가 내 댓글을 좋아했어요", null),
+    TODAY_QUESTION_PUBLISHED("오늘의 질문", "오늘의 질문이 준비 되었어요.\n지금 바로 답변해보세요."),
+    TODAY_QUESTION_CLOSED("오늘의 질문", "오늘의 질문 답변 시간이 마감되었어요.\n다른 러너들은 어떻게 답 했는지 확인해보세요."),
+    ;
+    private final String title;
+    private final String content;
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
@@ -1,0 +1,10 @@
+package com.server.capple.domain.notifiaction.service;
+
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.boardComment.entity.BoardComment;
+
+public interface NotificationService {
+    void sendBoardHeartNotification(Long actorId, Board board);
+    void sendBoardCommentNotification(Long actorId, Board board, BoardComment boardComment);
+    void sendBoardCommentHeartNotification(Long actorId, Board board, BoardComment boardComment);
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -27,6 +27,7 @@ public class NotificationServiceImpl implements NotificationService {
             .body(board.getContent())
             .threadId("board-" + board.getId())
             .sound("default")
+            .boardId(board.getId().toString())
             .build(), board.getWriter().getId());
         // TODO 알림 데이터베이스 저장
     }
@@ -46,6 +47,8 @@ public class NotificationServiceImpl implements NotificationService {
                         .body(board.getContent())
                         .threadId("board-" + board.getId())
                         .sound("default")
+                        .boardId(board.getId().toString())
+                        .boardCommentId(boardComment.getId().toString())
                         .build(), subscriberId);
                 }
             })
@@ -57,6 +60,8 @@ public class NotificationServiceImpl implements NotificationService {
             .body(board.getContent())
             .threadId("board-" + board.getId())
             .sound("default")
+            .boardId(board.getId().toString())
+            .boardCommentId(boardComment.getId().toString())
             .build();
         apnsService.sendApnsToMembers(simplePushBody, subscriberIds);
         // TODO 알림 데이터베이스 저장
@@ -70,6 +75,8 @@ public class NotificationServiceImpl implements NotificationService {
             .body(board.getContent())
             .threadId("board-" + board.getId())
             .sound("default")
+            .boardId(board.getId().toString())
+            .boardCommentId(boardComment.getId().toString())
             .build(), boardComment.getMember().getId());
         // TODO 알림 데이터베이스 저장
     }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -22,12 +22,9 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public void sendBoardHeartNotification(Long actorId, Board board) {
         if (actorId.equals(board.getWriter().getId())) return;
-        apnsService.sendApnsToMembers(ApnsClientRequest.SimplePushBody.builder()
-            .title(BOARD_HEART.getTitle())
-            .body(board.getContent())
-            .threadId("board-" + board.getId())
-            .sound("default")
-            .boardId(board.getId().toString())
+        apnsService.sendApnsToMembers(ApnsClientRequest.BoardNotificationBody.builder()
+            .type(BOARD_HEART)
+            .board(board)
             .build(), board.getWriter().getId());
         // TODO 알림 데이터베이스 저장
     }
@@ -41,42 +38,29 @@ public class NotificationServiceImpl implements NotificationService {
 //        게시판 구독자에게 알림 전송
             .peek(subscriberId -> {
                 if (subscriberId.equals(board.getWriter().getId())) {
-                    apnsService.sendApnsToMembers(ApnsClientRequest.SimplePushBody.builder()
-                        .title(BOARD_COMMENT.getTitle())
-                        .subTitle(boardComment.getContent())
-                        .body(board.getContent())
-                        .threadId("board-" + board.getId())
-                        .sound("default")
-                        .boardId(board.getId().toString())
-                        .boardCommentId(boardComment.getId().toString())
+                    apnsService.sendApnsToMembers(ApnsClientRequest.BoardCommentNotificationBody.builder()
+                        .type(BOARD_COMMENT)
+                        .board(board)
+                        .boardComment(boardComment)
                         .build(), subscriberId);
                 }
             })
             .filter(id -> !id.equals(board.getWriter().getId()))
             .toList();
-        ApnsClientRequest.SimplePushBody simplePushBody = ApnsClientRequest.SimplePushBody.builder()
-            .title(BAORD_COMMENT_DUPLCATE.getTitle())
-            .subTitle(boardComment.getContent())
-            .body(board.getContent())
-            .threadId("board-" + board.getId())
-            .sound("default")
-            .boardId(board.getId().toString())
-            .boardCommentId(boardComment.getId().toString())
-            .build();
-        apnsService.sendApnsToMembers(simplePushBody, subscriberIds);
+        apnsService.sendApnsToMembers(ApnsClientRequest.BoardCommentNotificationBody.builder()
+            .type(BAORD_COMMENT_DUPLCATE)
+            .board(board)
+            .boardComment(boardComment)
+            .build(), subscriberIds);
         // TODO 알림 데이터베이스 저장
     }
 
     @Override
     public void sendBoardCommentHeartNotification(Long actorId, Board board, BoardComment boardComment) {
-        apnsService.sendApnsToMembers(ApnsClientRequest.SimplePushBody.builder()
-            .title(BOARD_COMMENT_HEART.getTitle())
-            .subTitle(boardComment.getContent())
-            .body(board.getContent())
-            .threadId("board-" + board.getId())
-            .sound("default")
-            .boardId(board.getId().toString())
-            .boardCommentId(boardComment.getId().toString())
+        apnsService.sendApnsToMembers(ApnsClientRequest.BoardCommentNotificationBody.builder()
+            .type(BOARD_COMMENT_HEART)
+            .board(board)
+            .boardComment(boardComment)
             .build(), boardComment.getMember().getId());
         // TODO 알림 데이터베이스 저장
     }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -1,0 +1,76 @@
+package com.server.capple.domain.notifiaction.service;
+
+import com.server.capple.config.apns.dto.ApnsClientRequest;
+import com.server.capple.config.apns.service.ApnsService;
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.boardSubscribeMember.service.BoardSubscribeMemberService;
+import com.server.capple.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.server.capple.domain.notifiaction.entity.NotificationType.*;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+    private final ApnsService apnsService;
+    private final BoardSubscribeMemberService boardSubscribeMemberService;
+
+    @Override
+    public void sendBoardHeartNotification(Long actorId, Board board) {
+        if (actorId.equals(board.getWriter().getId())) return;
+        apnsService.sendApnsToMembers(ApnsClientRequest.SimplePushBody.builder()
+            .title(BOARD_HEART.getTitle())
+            .body(board.getContent())
+            .threadId("board-" + board.getId())
+            .sound("default")
+            .build(), board.getWriter().getId());
+        // TODO 알림 데이터베이스 저장
+    }
+
+    @Override
+    public void sendBoardCommentNotification(Long actorId, Board board, BoardComment boardComment) {
+        List<Member> subscribers = boardSubscribeMemberService.findBoardSubscribeMembers(board.getId());
+        List<Long> subscriberIds = subscribers.stream()
+            .map(Member::getId)
+            .filter(id -> !id.equals(actorId))
+//        게시판 구독자에게 알림 전송
+            .peek(subscriberId -> {
+                if (subscriberId.equals(board.getWriter().getId())) {
+                    apnsService.sendApnsToMembers(ApnsClientRequest.SimplePushBody.builder()
+                        .title(BOARD_COMMENT.getTitle())
+                        .subTitle(boardComment.getContent())
+                        .body(board.getContent())
+                        .threadId("board-" + board.getId())
+                        .sound("default")
+                        .build(), subscriberId);
+                }
+            })
+            .filter(id -> !id.equals(board.getWriter().getId()))
+            .toList();
+        ApnsClientRequest.SimplePushBody simplePushBody = ApnsClientRequest.SimplePushBody.builder()
+            .title(BAORD_COMMENT_DUPLCATE.getTitle())
+            .subTitle(boardComment.getContent())
+            .body(board.getContent())
+            .threadId("board-" + board.getId())
+            .sound("default")
+            .build();
+        apnsService.sendApnsToMembers(simplePushBody, subscriberIds);
+        // TODO 알림 데이터베이스 저장
+    }
+
+    @Override
+    public void sendBoardCommentHeartNotification(Long actorId, Board board, BoardComment boardComment) {
+        apnsService.sendApnsToMembers(ApnsClientRequest.SimplePushBody.builder()
+            .title(BOARD_COMMENT_HEART.getTitle())
+            .subTitle(boardComment.getContent())
+            .body(board.getContent())
+            .threadId("board-" + board.getId())
+            .sound("default")
+            .build(), boardComment.getMember().getId());
+        // TODO 알림 데이터베이스 저장
+    }
+}

--- a/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
+++ b/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
@@ -34,7 +34,7 @@ class ApnsServiceImplTest {
         String targetContentId = "targetContentId";
 
         //when
-        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, "default", threadId, targetContentId), List.of(simulatorDeviceToken));
+        Boolean result = apnsService.sendApns(SimplePushBody.builder().title(title).subTitle(subTitle).body(body).sound("default").threadId(threadId).targetContentId(targetContentId).build(), List.of(simulatorDeviceToken));
 
         //then
         assertTrue(result);
@@ -55,7 +55,7 @@ class ApnsServiceImplTest {
         for (int i = 0; i < 100; i++) deviceTokens.add(simulatorDeviceToken);
 
         //when
-        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, "default", threadId, targetContentId), deviceTokens);
+        Boolean result = apnsService.sendApns(SimplePushBody.builder().title(title).subTitle(subTitle).body(body).sound("default").threadId(threadId).targetContentId(targetContentId).build(), deviceTokens);
 
         //then
         assertTrue(result);

--- a/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
+++ b/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.server.capple.config.apns.service;
 
-import com.server.capple.config.apns.dto.ApnsClientRequest.SimplePushBody;
+import com.server.capple.config.apns.dto.ApnsClientRequest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ class ApnsServiceImplTest {
         String targetContentId = "targetContentId";
 
         //when
-        Boolean result = apnsService.sendApns(SimplePushBody.builder().title(title).subTitle(subTitle).body(body).sound("default").threadId(threadId).targetContentId(targetContentId).build(), List.of(simulatorDeviceToken));
+        Boolean result = apnsService.sendApns(ApnsClientRequest.SimplePushBody.builder().title(title).subTitle(subTitle).body(body).sound("default").threadId(threadId).targetContentId(targetContentId).build(), List.of(simulatorDeviceToken));
 
         //then
         assertTrue(result);
@@ -55,7 +55,7 @@ class ApnsServiceImplTest {
         for (int i = 0; i < 100; i++) deviceTokens.add(simulatorDeviceToken);
 
         //when
-        Boolean result = apnsService.sendApns(SimplePushBody.builder().title(title).subTitle(subTitle).body(body).sound("default").threadId(threadId).targetContentId(targetContentId).build(), deviceTokens);
+        Boolean result = apnsService.sendApns(ApnsClientRequest.SimplePushBody.builder().title(title).subTitle(subTitle).body(body).sound("default").threadId(threadId).targetContentId(targetContentId).build(), deviceTokens);
 
         //then
         assertTrue(result);

--- a/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
+++ b/src/test/java/com/server/capple/config/apns/service/ApnsServiceImplTest.java
@@ -34,7 +34,7 @@ class ApnsServiceImplTest {
         String targetContentId = "targetContentId";
 
         //when
-        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, threadId, targetContentId), List.of(simulatorDeviceToken));
+        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, "default", threadId, targetContentId), List.of(simulatorDeviceToken));
 
         //then
         assertTrue(result);
@@ -55,7 +55,7 @@ class ApnsServiceImplTest {
         for (int i = 0; i < 100; i++) deviceTokens.add(simulatorDeviceToken);
 
         //when
-        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, threadId, targetContentId), deviceTokens);
+        Boolean result = apnsService.sendApns(new SimplePushBody(title, subTitle, body, null, "default", threadId, targetContentId), deviceTokens);
 
         //then
         assertTrue(result);


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#126/apnsSetting -> develop

### 변경 사항
- 게시글에 좋아요가 눌러질 경우
  - 기대하는 결과 : 게시글의 작성자에게 알림을 발송
  - 페이로드 데이터 예시
    ```json
    {
      "aps" : {
        "alert" : {
          "title" : "누군가 내 게시글을 좋아했어요",
          "body" : "{게시글 내용}"
        }
        "sound" : "default",
        "thread-id" : "board-{boardId}"
      },
      "boardId" : "{boardId}"
    }
    ```
- 게시글에 댓글이 달린 경우
  - 기대하는 결과 : 게시글의 작성자와 해당 게시글의 댓글의 작성자에게 알림을 발송
  - 관계형 데이터베이스에서 게시글의 댓글 알림 구독자를 저장하여 관리
    ```json
    게시글 작성자
    {
      "aps" : {
        "alert" : {
          "title" : "누군가 내 게시글에 댓글을 달았어요",
          "subtitle" : "{댓글 내용}",
          "body" : "{게시글 내용}"
        }
        "sound" : "default",
        "thread-id" : "board-{boardId}"
      },
      "boardId" : "{boardId}",
      "boardCommentId" : "{boardCommentId}"
    }
    ```
    ```json
    게시글의 댓글 작성자
    {
      "aps" : {
        "alert" : {
          "title" : "누군가 내 게시글에 댓글을 달았어요",
          "subtitle" : "{댓글 내용}",
          "body" : "{게시글 내용}"
        }
        "sound" : "default",
        "thread-id" : "board-{boardId}"
      },
      "boardId" : "{boardId}",
      "boardCommentId" : "{boardCommentId}"
    }
    ``` 
- 댓글에 좋아요가 눌러질 경우
  - 기대하는 결과 : 댓글의 작성자에게 알림을 발송
    ```json
    {
      "aps" : {
        "alert" : {
          "title" : "누군가 내 댓글을 좋아했어요",
          "subtitle" : "{댓글 내용}",
          "body" : "{게시글 내용}"
        }
        "sound" : "default",
        "thread-id" : "board-{boardId}"
      },
      "boardId" : "{boardId}",
      "boardCommentId" : "{boardCommentId}"
    }
    ```

### 추가 개발 요구 사항
- 사용자에게 전달된 알림을 저장 후 앱 내의 알림 리스트에서 조회
- 알림을 클릭 시 이벤트가 발생하게된 적합한 뷰로 이동하는 로직 구현
  - 프론트측과 상의 후 페이로드에 메타데이터 추가 완료 ✅

### 테스트 결과
<img width="408" alt="image" src="https://github.com/user-attachments/assets/e186708c-5b50-4d1c-8b22-f57d8c2e58f5">