### PR TITLE
[FEAT] 알림 리스트 저장, 조회, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                 .requestMatchers("/reports", "/reports/**").authenticated()
                 .requestMatchers("/boards", "/boards/**").authenticated()
                 .requestMatchers("/boardComments", "/boardComments/**").authenticated()
+                .requestMatchers("/notifications", "/notifications/**").authenticated()
                 .requestMatchers("/dummy","/dummy/**").hasRole(Role.ROLE_ADMIN.getName())
                 .anyRequest().denyAll());
         http

--- a/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
@@ -6,6 +6,7 @@ import com.server.capple.domain.notifiaction.dto.NotificationResponse.Notificati
 import com.server.capple.domain.notifiaction.service.NotificationService;
 import com.server.capple.global.common.BaseResponse;
 import com.server.capple.global.common.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
     private final NotificationService notificationService;
 
+    @Operation(summary = "알림 리스트 조회 API", description = "API를 호출한 사용자가 받은 알림 리스트를 조회합니다. 알림은 최신순으로 정렬되어 반환됩니다.")
     @GetMapping
     public BaseResponse<SliceResponse<NotificationInfo>> getNotifications(@AuthMember Member member, @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
         return BaseResponse.onSuccess(new SliceResponse<>(notificationService.getNotifications(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt")))));

--- a/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
@@ -1,0 +1,29 @@
+package com.server.capple.domain.notifiaction.controller;
+
+import com.server.capple.config.security.AuthMember;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.notifiaction.dto.NotificationResponse.NotificationInfo;
+import com.server.capple.domain.notifiaction.service.NotificationService;
+import com.server.capple.global.common.BaseResponse;
+import com.server.capple.global.common.SliceResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "알림 API", description = "알림 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public BaseResponse<SliceResponse<NotificationInfo>> getNotifications(@AuthMember Member member, @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(new SliceResponse<>(notificationService.getNotifications(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt")))));
+    }
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
@@ -1,0 +1,20 @@
+package com.server.capple.domain.notifiaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+public class NotificationResponse {
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor
+    public static class NotificationInfo {
+        private String title;
+        private String subtitle;
+        private String content;
+        private String boardId;
+        private String boardCommentId;
+    }
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
+
 public class NotificationResponse {
     @Getter
     @Builder
@@ -16,5 +18,6 @@ public class NotificationResponse {
         private String content;
         private String boardId;
         private String boardCommentId;
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
@@ -1,0 +1,26 @@
+package com.server.capple.domain.notifiaction.entity;
+
+import com.server.capple.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private Long memberId;
+    @Column(nullable = false)
+    private String title;
+    private String subtitle;
+    @Column(nullable = false)
+    private String content;
+    @Column(nullable = false)
+    private String boardId;
+    private String boardCommentId;
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -1,0 +1,29 @@
+package com.server.capple.domain.notifiaction.mapper;
+
+import com.server.capple.config.apns.dto.ApnsClientRequest;
+import com.server.capple.domain.notifiaction.dto.NotificationResponse.NotificationInfo;
+import com.server.capple.domain.notifiaction.entity.Notification;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationMapper {
+    public Notification toNotification(Long memberId, ApnsClientRequest.BoardNotificationBody boardNotificationBody) {
+        return Notification.builder()
+            .memberId(memberId)
+            .title(boardNotificationBody.getAps().getAlert().getTitle())
+            .content(boardNotificationBody.getAps().getAlert().getBody())
+            .boardId(boardNotificationBody.getBoardId())
+            .build();
+    }
+
+    public Notification toNotification(Long memberId, ApnsClientRequest.BoardCommentNotificationBody boardCommentNotificationBody) {
+        return Notification.builder()
+            .memberId(memberId)
+            .title(boardCommentNotificationBody.getAps().getAlert().getTitle())
+            .subtitle(boardCommentNotificationBody.getAps().getAlert().getSubtitle())
+            .content(boardCommentNotificationBody.getAps().getAlert().getBody())
+            .boardId(boardCommentNotificationBody.getBoardId())
+            .boardCommentId(boardCommentNotificationBody.getBoardCommentId())
+            .build();
+    }
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -1,7 +1,6 @@
 package com.server.capple.domain.notifiaction.mapper;
 
 import com.server.capple.config.apns.dto.ApnsClientRequest;
-import com.server.capple.domain.notifiaction.dto.NotificationResponse.NotificationInfo;
 import com.server.capple.domain.notifiaction.entity.Notification;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.server.capple.domain.notifiaction.repository;
+
+import com.server.capple.domain.notifiaction.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -1,7 +1,10 @@
 package com.server.capple.domain.notifiaction.repository;
 
 import com.server.capple.domain.notifiaction.entity.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    <T> Slice<T> findByMemberId(Long memberId, Pageable pageable, Class<T> type);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     <T> Slice<T> findByMemberId(Long memberId, Pageable pageable, Class<T> type);
+    void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/scheduler/NotificationScheduler.java
@@ -1,0 +1,24 @@
+package com.server.capple.domain.notifiaction.scheduler;
+
+import com.server.capple.domain.notifiaction.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+    private final NotificationService notificationService;
+    private final long NOTIFICATION_CACHE_WEEK = 1L;
+
+    @Scheduled(cron = "0 0 * * * *") //매 0분에
+    public void deleteNotifications() {
+        LocalDateTime targetTime = LocalDateTime.now().minusWeeks(NOTIFICATION_CACHE_WEEK);
+        notificationService.deleteNotificationsByCreatedAtBefore(targetTime);
+        log.info("오래된 알림을 제거했습니다. 제거 기한 : " + targetTime);
+    }
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
@@ -2,9 +2,14 @@ package com.server.capple.domain.notifiaction.service;
 
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.notifiaction.dto.NotificationResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface NotificationService {
     void sendBoardHeartNotification(Long actorId, Board board);
     void sendBoardCommentNotification(Long actorId, Board board, BoardComment boardComment);
     void sendBoardCommentHeartNotification(Long actorId, Board board, BoardComment boardComment);
+    Slice<NotificationResponse.NotificationInfo> getNotifications(Member member, Pageable pageable);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
@@ -7,9 +7,12 @@ import com.server.capple.domain.notifiaction.dto.NotificationResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.time.LocalDateTime;
+
 public interface NotificationService {
     void sendBoardHeartNotification(Long actorId, Board board);
     void sendBoardCommentNotification(Long actorId, Board board, BoardComment boardComment);
     void sendBoardCommentHeartNotification(Long actorId, Board board, BoardComment boardComment);
     Slice<NotificationResponse.NotificationInfo> getNotifications(Member member, Pageable pageable);
+    void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.server.capple.domain.notifiaction.entity.NotificationType.*;
@@ -92,5 +93,11 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public Slice<NotificationInfo> getNotifications(Member member, Pageable pageable) {
         return notificationRepository.findByMemberId(member.getId(), pageable, NotificationInfo.class);
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime) {
+        notificationRepository.deleteNotificationsByCreatedAtBefore(targetTime);
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -7,11 +7,14 @@ import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.boardSubscribeMember.service.BoardSubscribeMemberService;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.notifiaction.dto.NotificationResponse.NotificationInfo;
 import com.server.capple.domain.notifiaction.entity.Notification;
 import com.server.capple.domain.notifiaction.mapper.NotificationMapper;
 import com.server.capple.domain.notifiaction.repository.NotificationRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -84,5 +87,10 @@ public class NotificationServiceImpl implements NotificationService {
         // TODO 알림 데이터베이스 저장
         Notification notification = notificationMapper.toNotification(boardComment.getMember().getId(), boardCommentNotificationBody);
         notificationRepository.save(notification);
+    }
+
+    @Override
+    public Slice<NotificationInfo> getNotifications(Member member, Pageable pageable) {
+        return notificationRepository.findByMemberId(member.getId(), pageable, NotificationInfo.class);
     }
 }

--- a/src/main/java/com/server/capple/global/common/SliceResponse.java
+++ b/src/main/java/com/server/capple/global/common/SliceResponse.java
@@ -1,0 +1,26 @@
+package com.server.capple.global.common;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SliceResponse<T> {
+    int number;
+    int size;
+    List<T> content;
+    int numberOfElements;
+    boolean hasPrevious;
+    boolean hasNext;
+    public SliceResponse(Slice<T> sliceObject) {
+        number = sliceObject.getNumber();
+        size = sliceObject.getSize();
+        content = sliceObject.getContent();
+        numberOfElements = sliceObject.getNumberOfElements();
+        hasPrevious = sliceObject.hasPrevious();
+        hasNext = sliceObject.hasNext();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#150/saveNotifiaction -> develop

### 변경 사항
- 알림이 발생할 때 알림의 정보를 데이터베이스에도 저장
  - 알림은 로그와 같은 과거의 기록이라고 여겨져 수정이 되지 않도록 연관관계 맵핑없이 컨텐트를 직접 저장했습니다.
  - 댓글 작성 알림의 경우 해당 게시글에 댓글을 작성한 사용자 수 만큼 insert 쿼리가 발생하여 효율에 대해서 팔로업 하겠습니다.
- 사용자별로 알림 기록 조회 API
  - 페이지네이션을 적용하였지만, 기본값을 크게두어 프론트 측의 페이지네이션 도입 전에도 큰 차이 없이 이용가능하도록 하였습니다.
  - Slice를 반환하기 위한 컨벤션 객체를 작성하였습니다. 수정해야한다고 생각드신다면 얘기해주세요.
- 일주일이 지난 알림을 제거
  - 스케줄러를 이용해 일주일 이상 지난 알림은 제거합니다.
