### PR TITLE
[REFACTOR] RDB 좋아요 조회 방식 수정 

### DIFF
--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -58,8 +58,8 @@ public class SecurityConfig {
                 .requestMatchers("/reports", "/reports/**").authenticated()
                 .requestMatchers("/boards", "/boards/**").authenticated()
                 .requestMatchers("/board-comments", "/board-comments/**").authenticated()
-                .requestMatchers("/reports/board-comments", "/reports/board-comments/**").authenticated()
-                .requestMatchers("/reports/boards", "/reports/boards/**").authenticated()
+                .requestMatchers("/reports/board-comment", "/reports/board-comment/**").authenticated()
+                .requestMatchers("/reports/board", "/reports/board/**").authenticated()
                 .requestMatchers("/notifications", "/notifications/**").authenticated()
                 .requestMatchers("/dummy","/dummy/**").hasRole(Role.ROLE_ADMIN.getName())
                 .anyRequest().denyAll());

--- a/src/main/java/com/server/capple/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/capple/config/security/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                 .requestMatchers("/boards", "/boards/**").authenticated()
                 .requestMatchers("/board-comments", "/board-comments/**").authenticated()
                 .requestMatchers("/reports/board-comments", "/reports/board-comments/**").authenticated()
-                .requestMatchers("/boardReports", "boardReports/**").authenticated()
+                .requestMatchers("/reports/boards", "/reports/boards/**").authenticated()
                 .requestMatchers("/notifications", "/notifications/**").authenticated()
                 .requestMatchers("/dummy","/dummy/**").hasRole(Role.ROLE_ADMIN.getName())
                 .anyRequest().denyAll());

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,10 +28,8 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @PostMapping()
-    private BaseResponse<BoardResponse.BoardCreate> createBoard(
-            @AuthMember Member member,
-            @RequestBody BoardRequest.BoardCreate request
-    ) {
+    private BaseResponse<BoardResponse.BoardCreate> createBoard(@AuthMember Member member,
+                                                                @RequestBody @Valid BoardRequest.BoardCreate request) {
         return BaseResponse.onSuccess(boardService.createBoard(member, request.getBoardType(), request.getContent()));
     }
 
@@ -67,7 +66,8 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/search")
-    private BaseResponse<BoardResponse.BoardsGetBoardInfos> searchBoardsByKeyword(@AuthMember Member member, @RequestParam(name = "keyword") String keyword) {
+    private BaseResponse<BoardResponse.BoardsGetBoardInfos> searchBoardsByKeyword(@AuthMember Member member,
+                                                                                  @RequestParam(name = "keyword") String keyword) {
         return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword));
     }
 
@@ -77,10 +77,7 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @DeleteMapping("/{boardId}")
-    private BaseResponse<BoardResponse.BoardDelete> deleteBoard(
-            @AuthMember Member member,
-            @PathVariable(name = "boardId") Long boardId
-    ) {
+    private BaseResponse<BoardResponse.BoardDelete> deleteBoard(@AuthMember Member member, @PathVariable(name = "boardId") Long boardId) {
         return BaseResponse.onSuccess(boardService.deleteBoard(member, boardId));
     }
 

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -39,7 +39,7 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/redis")
-    private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardTypeWithRedis(
+    private BaseResponse<BoardResponse.BoardsGetBoardInfos> getBoardsByBoardTypeWithRedis(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType
             // TODO: 페이징 프론트 이슈로 추후 구현
@@ -53,7 +53,7 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping()
-    private BaseResponse<BoardResponse.BoardsGetByBoardType> getBoardsByBoardType(
+    private BaseResponse<BoardResponse.BoardsGetBoardInfos> getBoardsByBoardType(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType
             // TODO: 페이징 프론트 이슈로 추후 구현
@@ -61,6 +61,16 @@ public class BoardController {
     ) {
         return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType));
     }
+
+    @Operation(summary = "게시글 검색 API", description = "게시글을 검색합니다. 자유게시판에서만 검색이 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+    })
+    @GetMapping("/search")
+    private BaseResponse<BoardResponse.BoardsGetBoardInfos> searchBoardsByKeyword(@AuthMember Member member, @RequestParam(name = "keyword") String keyword) {
+        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword));
+    }
+
 
     @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")
     @ApiResponses(value = {
@@ -72,17 +82,6 @@ public class BoardController {
             @PathVariable(name = "boardId") Long boardId
     ) {
         return BaseResponse.onSuccess(boardService.deleteBoard(member, boardId));
-    }
-
-    @Operation(summary = "게시글 검색 API", description = "게시글을 검색합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공"),
-    })
-    @GetMapping("/search")
-    private BaseResponse<BoardResponse.BoardsSearchByKeyword> searchBoardsByKeyword(
-            @RequestParam(name = "keyword") String keyword
-    ) {
-        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(keyword));
     }
 
     @Operation(summary = "게시글 좋아요/취소 API", description = " 게시글 좋아요/취소 API 입니다." +

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -2,7 +2,9 @@ package com.server.capple.domain.board.controller;
 
 import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.board.dto.BoardRequest;
-import com.server.capple.domain.board.dto.BoardResponse;
+import com.server.capple.domain.board.dto.BoardResponse.BoardId;
+import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfos;
+import com.server.capple.domain.board.dto.BoardResponse.ToggleBoardHeart;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.board.service.BoardService;
 import com.server.capple.domain.member.entity.Member;
@@ -28,8 +30,8 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @PostMapping()
-    private BaseResponse<BoardResponse.BoardCreate> createBoard(@AuthMember Member member,
-                                                                @RequestBody @Valid BoardRequest.BoardCreate request) {
+    private BaseResponse<BoardId> createBoard(@AuthMember Member member,
+                                              @RequestBody @Valid BoardRequest.BoardCreate request) {
         return BaseResponse.onSuccess(boardService.createBoard(member, request.getBoardType(), request.getContent()));
     }
 
@@ -38,7 +40,7 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/redis")
-    private BaseResponse<BoardResponse.BoardsGetBoardInfos> getBoardsByBoardTypeWithRedis(
+    private BaseResponse<BoardsGetBoardInfos> getBoardsByBoardTypeWithRedis(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType
             // TODO: 페이징 프론트 이슈로 추후 구현
@@ -52,7 +54,7 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping()
-    private BaseResponse<BoardResponse.BoardsGetBoardInfos> getBoardsByBoardType(
+    private BaseResponse<BoardsGetBoardInfos> getBoardsByBoardType(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType
             // TODO: 페이징 프론트 이슈로 추후 구현
@@ -66,8 +68,8 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/search")
-    private BaseResponse<BoardResponse.BoardsGetBoardInfos> searchBoardsByKeyword(@AuthMember Member member,
-                                                                                  @RequestParam(name = "keyword") String keyword) {
+    private BaseResponse<BoardsGetBoardInfos> searchBoardsByKeyword(@AuthMember Member member,
+                                                                    @RequestParam(name = "keyword") String keyword) {
         return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword));
     }
 
@@ -77,14 +79,14 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @DeleteMapping("/{boardId}")
-    private BaseResponse<BoardResponse.BoardDelete> deleteBoard(@AuthMember Member member, @PathVariable(name = "boardId") Long boardId) {
+    private BaseResponse<BoardId> deleteBoard(@AuthMember Member member, @PathVariable(name = "boardId") Long boardId) {
         return BaseResponse.onSuccess(boardService.deleteBoard(member, boardId));
     }
 
     @Operation(summary = "게시글 좋아요/취소 API", description = " 게시글 좋아요/취소 API 입니다." +
-            "pathvariable 으로 boardId를 주세요.")
+            "pathVariable 으로 boardId를 주세요.")
     @PostMapping("/{boardId}/heart")
-    public BaseResponse<BoardResponse.ToggleBoardHeart> toggleBoardHeart(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
+    public BaseResponse<ToggleBoardHeart> toggleBoardHeart(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
         return BaseResponse.onSuccess(boardService.toggleBoardHeart(member, boardId));
     }
 }

--- a/src/main/java/com/server/capple/domain/board/dao/BoardInfoInterface.java
+++ b/src/main/java/com/server/capple/domain/board/dao/BoardInfoInterface.java
@@ -1,0 +1,9 @@
+package com.server.capple.domain.board.dao;
+
+import com.server.capple.domain.board.entity.Board;
+
+public interface BoardInfoInterface {
+    Board getBoard();
+    Boolean getIsLike();
+    Boolean getIsMine();
+}

--- a/src/main/java/com/server/capple/domain/board/dto/BoardRequest.java
+++ b/src/main/java/com/server/capple/domain/board/dto/BoardRequest.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.board.dto;
 
 import com.server.capple.domain.board.entity.BoardType;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class BoardRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class BoardCreate {
+        @NotEmpty
         private String content;
         private BoardType boardType;
     }

--- a/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
@@ -22,15 +22,15 @@ public class BoardResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class BoardsGetByBoardType {
-        private List<BoardsGetByBoardTypeBoardInfo> boards;
+    public static class BoardsGetBoardInfos {
+        private List<BoardsGetBoardInfo> boards;
     }
 
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class BoardsGetByBoardTypeBoardInfo {
+    public static class BoardsGetBoardInfo {
         private Long boardId;
         private Long writerId;
         private String content;
@@ -48,27 +48,6 @@ public class BoardResponse {
     @NoArgsConstructor
     public static class BoardDelete {
         private Long boardId;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class BoardsSearchByKeyword {
-        private List<BoardsSearchByKeywordBoardInfo> boards;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class BoardsSearchByKeywordBoardInfo {
-        private Long boardId;
-        private Long writerId;
-        private String content;
-        private Integer heartCount;
-        private Integer commentCount;
-        private LocalDateTime createAt;
     }
 
     @Getter

--- a/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
@@ -11,10 +11,8 @@ import java.util.List;
 public class BoardResponse {
 
     @Getter
-    @Builder
     @AllArgsConstructor
-    @NoArgsConstructor
-    public static class BoardCreate {
+    public static class BoardId {
         private Long boardId;
     }
 
@@ -40,14 +38,6 @@ public class BoardResponse {
         private Boolean isMine;
         private Boolean isReported;
         private Boolean isLiked;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class BoardDelete {
-        private Long boardId;
     }
 
     @Getter

--- a/src/main/java/com/server/capple/domain/board/entity/Board.java
+++ b/src/main/java/com/server/capple/domain/board/entity/Board.java
@@ -36,6 +36,9 @@ public class Board extends BaseEntity {
     @ColumnDefault("0")
     private Integer heartCount;
 
+    @Column(nullable = false)
+    private Boolean isReport;
+
     public void setHeartCount(boolean isLiked) {
         if (isLiked) {
             this.heartCount++;
@@ -43,6 +46,10 @@ public class Board extends BaseEntity {
             this.heartCount--;
         }
     }
+
+    public void submitReport() { this.isReport = Boolean.TRUE; }
+
+    public void cancelReport() { this.isReport = Boolean.FALSE; }
 
     public void increaseCommentCount() {
         this.commentCount++;

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -1,6 +1,8 @@
 package com.server.capple.domain.board.mapper;
 
 import com.server.capple.domain.board.dto.BoardResponse;
+import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfo;
+import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfos;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.member.entity.Member;
@@ -27,22 +29,16 @@ public class BoardMapper {
                 .build();
     }
 
-    public BoardResponse.BoardsGetByBoardType toBoardsGetByBoardType(
-            List<BoardResponse.BoardsGetByBoardTypeBoardInfo> boards
-    ) {
-        return BoardResponse.BoardsGetByBoardType.builder()
+    public BoardsGetBoardInfos toBoardsGetBoardInfos(List<BoardsGetBoardInfo> boards) {
+        return BoardsGetBoardInfos.builder()
                 .boards(boards)
                 .build();
     }
 
     //redis
-    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(
-            Board board,
-            Integer boardHeartsCount,
-            Boolean isLiked,
-            Boolean isMine,
-            Boolean isReported) {
-        return BoardResponse.BoardsGetByBoardTypeBoardInfo.builder()
+    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Integer boardHeartsCount, Boolean isLiked,
+            Boolean isMine, Boolean isReported) {
+        return BoardsGetBoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
                 .content(board.getContent())
@@ -57,11 +53,8 @@ public class BoardMapper {
     }
 
     //rdb
-    public BoardResponse.BoardsGetByBoardTypeBoardInfo toBoardsGetByBoardTypeBoardInfo(Board board,
-                                                                                       Boolean isLiked,
-                                                                                       Boolean isMine,
-                                                                                       Boolean isReported) {
-        return BoardResponse.BoardsGetByBoardTypeBoardInfo.builder()
+    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Boolean isLiked, Boolean isMine, Boolean isReported) {
+        return BoardsGetBoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
                 .content(board.getContent())
@@ -78,28 +71,6 @@ public class BoardMapper {
     public BoardResponse.BoardDelete toBoardDelete(Board board) {
         return BoardResponse.BoardDelete.builder()
                 .boardId(board.getId())
-                .build();
-    }
-
-    public BoardResponse.BoardsSearchByKeywordBoardInfo toBoardsSearchByKeywordBoardInfo(
-            Board board,
-            Integer heartCount
-    ) {
-        return BoardResponse.BoardsSearchByKeywordBoardInfo.builder()
-                .boardId(board.getId())
-                .writerId(board.getWriter().getId())
-                .content(board.getContent())
-                .heartCount(heartCount)
-                .commentCount(board.getCommentCount())
-                .createAt(board.getCreatedAt())
-                .build();
-    }
-
-    public BoardResponse.BoardsSearchByKeyword toBoardsSearchByKeyword(
-            List<BoardResponse.BoardsSearchByKeywordBoardInfo> boards
-    ) {
-        return BoardResponse.BoardsSearchByKeyword.builder()
-                .boards(boards)
                 .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -29,12 +29,6 @@ public class BoardMapper {
                 .build();
     }
 
-    public BoardsGetBoardInfos toBoardsGetBoardInfos(List<BoardsGetBoardInfo> boards) {
-        return BoardsGetBoardInfos.builder()
-                .boards(boards)
-                .build();
-    }
-
     //redis
     public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Integer boardHeartsCount, Boolean isLiked,
             Boolean isMine, Boolean isReported) {

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -1,14 +1,10 @@
 package com.server.capple.domain.board.mapper;
 
-import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfo;
-import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfos;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 public class BoardMapper {
@@ -20,18 +16,12 @@ public class BoardMapper {
                 .content(content)
                 .commentCount(0)
                 .heartCount(0)
-                .build();
-    }
-
-    public BoardResponse.BoardCreate toBoardCreate(Board board) {
-        return BoardResponse.BoardCreate.builder()
-                .boardId(board.getId())
+                .isReport(Boolean.FALSE)
                 .build();
     }
 
     //redis
-    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Integer boardHeartsCount, Boolean isLiked,
-            Boolean isMine, Boolean isReported) {
+    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Integer boardHeartsCount, Boolean isLiked, Boolean isMine) {
         return BoardsGetBoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
@@ -41,13 +31,12 @@ public class BoardMapper {
                 .createAt(board.getCreatedAt())
                 .isLiked(isLiked)
                 .isMine(isMine)
-                // TODO: BoardReport 관련 테이블 구현 후 수정 요망
-                .isReported(isReported)
+                .isReported(board.getIsReport())
                 .build();
     }
 
     //rdb
-    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Boolean isLiked, Boolean isMine, Boolean isReported) {
+    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Boolean isLiked, Boolean isMine) {
         return BoardsGetBoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
@@ -57,14 +46,7 @@ public class BoardMapper {
                 .createAt(board.getCreatedAt())
                 .isLiked(isLiked)
                 .isMine(isMine)
-                // TODO: BoardReport 관련 테이블 구현 후 수정 요망
-                .isReported(isReported)
-                .build();
-    }
-
-    public BoardResponse.BoardDelete toBoardDelete(Board board) {
-        return BoardResponse.BoardDelete.builder()
-                .boardId(board.getId())
+                .isReported(board.getIsReport())
                 .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -1,13 +1,21 @@
 package com.server.capple.domain.board.repository;
 
+import com.server.capple.domain.board.dao.BoardInfoInterface;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
+import com.server.capple.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    @Query("SELECT b AS board, (CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "FROM Board b LEFT JOIN BoardHeart bh ON b = bh.board " +
+            "AND :boardType IS NULL OR b.boardType = :boardType ORDER BY b.createdAt DESC")
+    List<BoardInfoInterface> findBoardInfosByMemberAndBoardType(Member member, BoardType boardType);
 
     List<Board> findBoardsByBoardType(BoardType boardType);
 

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -17,8 +17,11 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "WHERE :boardType IS NULL OR b.boardType = :boardType ORDER BY b.createdAt DESC")
     List<BoardInfoInterface> findBoardInfosByMemberAndBoardType(Member member, BoardType boardType);
 
-    List<Board> findBoardsByBoardType(BoardType boardType);
+    @Query("SELECT b AS board, (CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "FROM Board b LEFT JOIN BoardHeart bh ON b = bh.board " +
+            "WHERE b.content LIKE %:keyword% AND b.boardType = 0 ORDER BY b.createdAt DESC") //FREETYPE = 0
+    List<BoardInfoInterface> findBoardInfosByMemberAndKeyword(Member member, String keyword);
 
-    @Query("SELECT b FROM Board b WHERE b.content LIKE %:keyword%")
-    List<Board> findBoardsByKeyword(String keyword);
+    List<Board> findBoardsByBoardType(BoardType boardType);
 }

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -14,7 +14,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT b AS board, (CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM Board b LEFT JOIN BoardHeart bh ON b = bh.board " +
-            "AND :boardType IS NULL OR b.boardType = :boardType ORDER BY b.createdAt DESC")
+            "WHERE :boardType IS NULL OR b.boardType = :boardType ORDER BY b.createdAt DESC")
     List<BoardInfoInterface> findBoardInfosByMemberAndBoardType(Member member, BoardType boardType);
 
     List<Board> findBoardsByBoardType(BoardType boardType);

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -11,15 +11,19 @@ import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    @Query("SELECT b AS board, (CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+    @Query("SELECT b AS board, " +
+            "(CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
-            "FROM Board b LEFT JOIN BoardHeart bh ON b = bh.board " +
+            "FROM Board b " +
+            "LEFT JOIN BoardHeart bh ON b = bh.board " +
             "WHERE :boardType IS NULL OR b.boardType = :boardType ORDER BY b.createdAt DESC")
     List<BoardInfoInterface> findBoardInfosByMemberAndBoardType(Member member, BoardType boardType);
 
-    @Query("SELECT b AS board, (CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+    @Query("SELECT b AS board, " +
+            "(CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
-            "FROM Board b LEFT JOIN BoardHeart bh ON b = bh.board " +
+            "FROM Board b " +
+            "LEFT JOIN BoardHeart bh ON b = bh.board " +
             "WHERE b.content LIKE %:keyword% AND b.boardType = 0 ORDER BY b.createdAt DESC") //FREETYPE = 0
     List<BoardInfoInterface> findBoardInfosByMemberAndKeyword(Member member, String keyword);
 

--- a/src/main/java/com/server/capple/domain/board/service/BoardService.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardService.java
@@ -8,13 +8,13 @@ import com.server.capple.domain.member.entity.Member;
 public interface BoardService {
     BoardCreate createBoard(Member member, BoardType boardType, String content);
 
-    BoardsGetByBoardType getBoardsByBoardTypeWithRedis(Member member, BoardType boardType);
+    BoardsGetBoardInfos getBoardsByBoardTypeWithRedis(Member member, BoardType boardType);
 
-    BoardsGetByBoardType getBoardsByBoardType(Member member, BoardType boardType);
+    BoardsGetBoardInfos getBoardsByBoardType(Member member, BoardType boardType);
 
     BoardDelete deleteBoard(Member member, Long boardId);
 
-    BoardsSearchByKeyword searchBoardsByKeyword(String keyword);
+    BoardsGetBoardInfos searchBoardsByKeyword(Member member, String keyword);
 
     ToggleBoardHeart toggleBoardHeart(Member member, Long boardId);
 

--- a/src/main/java/com/server/capple/domain/board/service/BoardService.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardService.java
@@ -1,18 +1,20 @@
 package com.server.capple.domain.board.service;
 
-import com.server.capple.domain.board.dto.BoardResponse.*;
+import com.server.capple.domain.board.dto.BoardResponse.BoardId;
+import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfos;
+import com.server.capple.domain.board.dto.BoardResponse.ToggleBoardHeart;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.member.entity.Member;
 
 public interface BoardService {
-    BoardCreate createBoard(Member member, BoardType boardType, String content);
+    BoardId createBoard(Member member, BoardType boardType, String content);
 
     BoardsGetBoardInfos getBoardsByBoardTypeWithRedis(Member member, BoardType boardType);
 
     BoardsGetBoardInfos getBoardsByBoardType(Member member, BoardType boardType);
 
-    BoardDelete deleteBoard(Member member, Long boardId);
+    BoardId deleteBoard(Member member, Long boardId);
 
     BoardsGetBoardInfos searchBoardsByKeyword(Member member, String keyword);
 

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -56,7 +56,7 @@ public class BoardServiceImpl implements BoardService {
             boards = boardRepository.findBoardsByBoardType(boardType);
         }
 
-        return boardMapper.toBoardsGetBoardInfos(boards.stream()
+        return new BoardsGetBoardInfos(boards.stream()
                 // TODO: BoardReport 관련 테이블 구현 후 수정 요망
                 .map(board -> {
                     int heartCount = boardHeartRedisRepository.getBoardHeartsCount(board.getId());
@@ -73,7 +73,7 @@ public class BoardServiceImpl implements BoardService {
     public BoardsGetBoardInfos getBoardsByBoardType(Member member, BoardType boardType) {
         List<BoardInfoInterface> boardInfos = boardRepository.findBoardInfosByMemberAndBoardType(member, boardType);
 
-        return boardMapper.toBoardsGetBoardInfos(boardInfos.stream()
+        return new BoardsGetBoardInfos(boardInfos.stream()
                 // TODO: BoardReport 관련 테이블 구현 후 수정 요망
                 .map(boardInfo -> boardMapper.toBoardsGetBoardInfo(boardInfo.getBoard(), boardInfo.getIsLike(),
                         boardInfo.getIsMine(), false))
@@ -85,7 +85,7 @@ public class BoardServiceImpl implements BoardService {
     public BoardsGetBoardInfos searchBoardsByKeyword(Member member, String keyword) {
         List<BoardInfoInterface> boardInfos = boardRepository.findBoardInfosByMemberAndKeyword(member, keyword);
 
-        return boardMapper.toBoardsGetBoardInfos(boardInfos.stream()
+        return new BoardsGetBoardInfos(boardInfos.stream()
                 // TODO: BoardReport 관련 테이블 구현 후 수정 요망
                 .map(boardInfo -> boardMapper.toBoardsGetBoardInfo(boardInfo.getBoard(), boardInfo.getIsLike(), boardInfo.getIsMine(), false))
                 .toList()

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.board.service;
 
+import com.server.capple.domain.board.dao.BoardInfoInterface;
 import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.board.dto.BoardResponse.ToggleBoardHeart;
 import com.server.capple.domain.board.entity.Board;
@@ -74,23 +75,19 @@ public class BoardServiceImpl implements BoardService {
     //rdb
     @Override
     public BoardResponse.BoardsGetByBoardType getBoardsByBoardType(Member member, BoardType boardType) {
-        List<Board> boards;
+        List<BoardInfoInterface> boardInfos;
         if (boardType == null) {
-            boards = boardRepository.findAll();
+            boardInfos = boardRepository.findBoardInfosByMemberAndBoardType(member, null);
         } else if (boardType == BoardType.FREEBOARD) {
-            boards = boardRepository.findBoardsByBoardType(BoardType.FREEBOARD);
+            boardInfos = boardRepository.findBoardInfosByMemberAndBoardType(member, BoardType.FREEBOARD);
         } else if (boardType == BoardType.HOTBOARD) {
-            boards = boardRepository.findBoardsByBoardType(BoardType.HOTBOARD);
+            boardInfos = boardRepository.findBoardInfosByMemberAndBoardType(member, BoardType.HOTBOARD);
         } else {
             throw new RestApiException(BoardErrorCode.BOARD_BAD_REQUEST);
         }
-        return boardMapper.toBoardsGetByBoardType(boards.stream()
+        return boardMapper.toBoardsGetByBoardType(boardInfos.stream()
                 // TODO: BoardReport 관련 테이블 구현 후 수정 요망
-                .map(board -> {
-                    boolean isLiked = boardHeartRepository.findByMemberAndBoard(member,board).isPresent();
-                    boolean isMine =  board.getWriter().getId().equals(member.getId());
-                    return boardMapper.toBoardsGetByBoardTypeBoardInfo(board, isLiked, isMine,false);
-                })
+                .map(boardInfo -> boardMapper.toBoardsGetByBoardTypeBoardInfo(boardInfo.getBoard(),boardInfo.getIsLike() , boardInfo.getIsMine(),false))
                 .toList()
         );
     }

--- a/src/main/java/com/server/capple/domain/boardComment/dao/BoardCommentInfoInterface.java
+++ b/src/main/java/com/server/capple/domain/boardComment/dao/BoardCommentInfoInterface.java
@@ -1,0 +1,9 @@
+package com.server.capple.domain.boardComment.dao;
+
+import com.server.capple.domain.boardComment.entity.BoardComment;
+
+public interface BoardCommentInfoInterface {
+    BoardComment getBoardComment();
+    Boolean getIsLike();
+    Boolean getIsMine();
+}

--- a/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
+++ b/src/main/java/com/server/capple/domain/boardComment/entity/BoardComment.java
@@ -23,7 +23,7 @@ public class BoardComment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    private Member writer;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -10,23 +10,10 @@ import org.springframework.stereotype.Component;
 public class BoardCommentMapper {
     public BoardComment toBoardComment(Member member, Board board, String comment) {
         return BoardComment.builder()
-                .member(member)
+                .writer(member)
                 .board(board)
                 .content(comment)
                 .heartCount(0)
-                .build();
-    }
-
-    //redis
-    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Integer boardHeart, Boolean isLiked, Boolean isMine) {
-        return BoardCommentInfo.builder()
-                .boardCommentId(comment.getId())
-                .writerId(comment.getMember().getId())
-                .content(comment.getContent())
-                .heartCount(boardHeart)
-                .isLiked(isLiked)
-                .isMine(isMine)
-                .createdAt(comment.getCreatedAt())
                 .build();
     }
 
@@ -34,7 +21,7 @@ public class BoardCommentMapper {
     public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked, Boolean isMine) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())
-                .writerId(comment.getMember().getId())
+                .writerId(comment.getWriter().getId())
                 .content(comment.getContent())
                 .heartCount(comment.getHeartCount())
                 .isLiked(isLiked)

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
@@ -9,9 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
-    @Query("SELECT bc AS boardComment, (CASE WHEN bch.member = :member AND bch.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+    @Query("SELECT bc AS boardComment, " +
+            "(CASE WHEN bch.member = :member AND bch.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN bc.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
-            "FROM BoardComment bc LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment " +
+            "FROM BoardComment bc " +
+            "LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment " +
             "WHERE bc.board.id = :boardId ORDER BY bc.createdAt DESC")
     List<BoardCommentInfoInterface> findBoardCommentInfosByMemberAndBoardId(Member member, Long boardId);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
@@ -1,10 +1,17 @@
 package com.server.capple.domain.boardComment.repository;
 
+import com.server.capple.domain.boardComment.dao.BoardCommentInfoInterface;
 import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
-    List<BoardComment> findBoardCommentByBoardIdOrderByCreatedAt(Long boardId);
+    @Query("SELECT bc AS boardComment, (CASE WHEN bch.member = :member AND bch.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+            "(CASE WHEN bc.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "FROM BoardComment bc LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment " +
+            "WHERE bc.board.id = :boardId ORDER BY bc.createdAt DESC")
+    List<BoardCommentInfoInterface> findBoardCommentInfosByMemberAndBoardId(Member member, Long boardId);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -43,13 +43,12 @@ public class BoardCommentServiceImpl implements BoardCommentService {
     @Override
     @Transactional
     public BoardCommentId createBoardComment(Member member, Long boardId, BoardCommentRequest request) {
-        Member loginMember = memberService.findMember(member.getId());
         Board board = boardService.findBoard(boardId);
 
         BoardComment boardComment = boardCommentRepository.save(
-                boardCommentMapper.toBoardComment(loginMember, board, request.getComment()));
-        notificationService.sendBoardCommentNotification(loginMember.getId(), board, boardComment); // 게시글 댓글 알림
-        boardSubscribeMemberService.createBoardSubscribeMember(loginMember, board); // 알림 리스트 추가
+                boardCommentMapper.toBoardComment(member, board, request.getComment()));
+        notificationService.sendBoardCommentNotification(member.getId(), board, boardComment); // 게시글 댓글 알림
+        boardSubscribeMemberService.createBoardSubscribeMember(member, board); // 알림 리스트 추가
 
         board.increaseCommentCount();
         return new BoardCommentId(boardComment.getId());

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -30,7 +30,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BoardCommentServiceImpl implements BoardCommentService {
-    private final MemberService memberService;
     private final BoardService boardService;
     private final BoardCommentRepository boardCommentRepository;
     private final BoardCommentHeartRedisRepository boardCommentHeartRedisRepository;

--- a/src/main/java/com/server/capple/domain/boardReport/controller/BoardReportController.java
+++ b/src/main/java/com/server/capple/domain/boardReport/controller/BoardReportController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "게시판 신고 API", description = "게시판 신고 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boardReports")
+@RequestMapping("/reports/boards")
 public class BoardReportController {
 
     private final BoardReportService boardReportService;

--- a/src/main/java/com/server/capple/domain/boardReport/controller/BoardReportController.java
+++ b/src/main/java/com/server/capple/domain/boardReport/controller/BoardReportController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "게시판 신고 API", description = "게시판 신고 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reports/boards")
+@RequestMapping("/reports/board")
 public class BoardReportController {
 
     private final BoardReportService boardReportService;

--- a/src/main/java/com/server/capple/domain/boardReport/controller/BoardReportController.java
+++ b/src/main/java/com/server/capple/domain/boardReport/controller/BoardReportController.java
@@ -5,7 +5,6 @@ import com.server.capple.domain.boardReport.dto.BoardReportRequest;
 import com.server.capple.domain.boardReport.dto.BoardReportResponse;
 import com.server.capple.domain.boardReport.service.BoardReportService;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.report.dto.reponse.ReportResponse;
 import com.server.capple.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/server/capple/domain/boardReport/dto/BoardReportResponse.java
+++ b/src/main/java/com/server/capple/domain/boardReport/dto/BoardReportResponse.java
@@ -1,8 +1,6 @@
 package com.server.capple.domain.boardReport.dto;
 
-import com.server.capple.domain.boardReport.entity.BoardReport;
 import com.server.capple.domain.boardReport.entity.BoardReportType;
-import com.server.capple.global.exception.errorCode.BoardReportErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/server/capple/domain/boardReport/repository/BoardReportRepository.java
+++ b/src/main/java/com/server/capple/domain/boardReport/repository/BoardReportRepository.java
@@ -12,7 +12,5 @@ public interface BoardReportRepository extends JpaRepository<BoardReport, Long> 
 
     Boolean existsByMemberAndBoard(Member member, Board board);
 
-    Optional<BoardReport> findByMemberAndBoard(Member member, Board board);
-
     List<BoardReport> findByMember(Member member);
 }

--- a/src/main/java/com/server/capple/domain/boardReport/service/BoardReportService.java
+++ b/src/main/java/com/server/capple/domain/boardReport/service/BoardReportService.java
@@ -1,18 +1,13 @@
 package com.server.capple.domain.boardReport.service;
 
-import com.server.capple.domain.board.entity.BoardType;
-import com.server.capple.domain.boardReport.dto.BoardReportRequest;
 import com.server.capple.domain.boardReport.dto.BoardReportResponse;
 import com.server.capple.domain.boardReport.entity.BoardReport;
 import com.server.capple.domain.boardReport.entity.BoardReportType;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.report.entity.Report;
 
 public interface BoardReportService {
 
     BoardReport findBoardReport(Long boardReportId);
-
-    Boolean isReporter(Long reporterId, Long memberId);
 
     BoardReportResponse.BoardReportsGet getMyBoardReports(Member member);
 

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -61,7 +61,7 @@ public class NotificationServiceImpl implements NotificationService {
             .type(BOARD_COMMENT_HEART)
             .board(board)
             .boardComment(boardComment)
-            .build(), boardComment.getMember().getId());
+            .build(), boardComment.getWriter().getId());
         // TODO 알림 데이터베이스 저장
     }
 }

--- a/src/main/java/com/server/capple/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/server/capple/domain/report/repository/ReportRepository.java
@@ -1,16 +1,9 @@
 package com.server.capple.domain.report.repository;
 
 import com.server.capple.domain.answer.entity.Answer;
-import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.report.entity.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface ReportRepository extends JpaRepository<Report, Long> {
     Boolean existsReportByAnswer(Answer answer);
-
-    List<Report> findByMember(Member member);
 }

--- a/src/main/java/com/server/capple/dummy/DummyService.java
+++ b/src/main/java/com/server/capple/dummy/DummyService.java
@@ -27,11 +27,10 @@ public class DummyService {
 
     @Transactional
     public void generateDummyData(int memberCount, int boardCount) {
-        em.createNativeQuery("select generate_dummy_data(:memberCount, :boardCount)")
+        em.createNativeQuery("call generate_dummy_data(:memberCount, :boardCount)")
                 .setParameter("memberCount", memberCount)
                 .setParameter("boardCount", boardCount)
-                .getSingleResult(); //프로시저 수행 후 아무것도 반환하지 않음
-        //executeUpdate() 수행시 int 값을 반환해야하는데, 반환하지 않아서 Error -> getSingleResult() 사용해서 null값 받음
+                .executeUpdate();
     }
 
 

--- a/src/main/java/com/server/capple/dummy/generate_dummy_data.sql
+++ b/src/main/java/com/server/capple/dummy/generate_dummy_data.sql
@@ -1,9 +1,9 @@
-create function generate_dummy_data(member_count integer, board_count integer) returns void
+create procedure generate_dummy_data(IN member_count integer, IN board_count integer)
     language plpgsql
 as
 $$
 DECLARE
-    member_id INT;
+member_id INT;
     board_id INT;
     random_content TEXT;
     random_comment_count INT;
@@ -29,17 +29,17 @@ FOR board_id IN 1..board_count LOOP
             random_comment_count := FLOOR(RANDOM() * 100);
 
             -- FREEBOARD와 HOTBOARD를 번갈아가며 설정 (0은 FREEBOARD, 1은 HOTBOARD)
-            IF board_id % 2 = 0 THEN
+            /*IF board_id % 2 = 0 THEN
                 random_board_type := 0;
             ELSE
                 random_board_type := 1;
-            END IF;
+            END IF;*/
 
             -- 보드 데이터 삽입
 INSERT INTO board (member_id, board_type, content, comment_count, created_at, updated_at)
 VALUES (
            FLOOR(RANDOM() * member_count) + 1,
-           random_board_type,
+           0,
            random_content,
            random_comment_count,
            NOW(),
@@ -60,9 +60,12 @@ FOR board_id IN 1..board_count LOOP
                                    NOW(),
                                    NULL
                                );
-                    END IF;
-            END LOOP;
+END IF;
+END LOOP;
 END LOOP;
 
 END;
 $$;
+
+alter procedure generate_dummy_data(integer, integer) owner to capple;
+

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -4,7 +4,6 @@ import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.entity.BoardComment;
-import com.server.capple.domain.boardComment.service.BoardCommentService;
 import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardCommentReport/service/BoardCommentReportServiceTest.java
@@ -1,4 +1,4 @@
-package com.server.capple.domain.boardCommentRe.service;
+package com.server.capple.domain.boardCommentReport.service;
 
 import com.server.capple.domain.boardCommentReport.entity.BoardCommentReport;
 import com.server.capple.domain.boardCommentReport.entity.BoardCommentReportType;

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -135,7 +135,7 @@ public abstract class ServiceTestConfig {
     protected BoardComment createBoardComment() {
         return boardCommentRepository.save(
                 BoardComment.builder()
-                        .member(member)
+                        .writer(member)
                         .board(board)
                         .content("게시글 댓글")
                         .heartCount(0)

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -132,6 +132,8 @@ public abstract class ServiceTestConfig {
                         .writer(member)
                         .content("오늘 밥먹을 사람!")
                         .commentCount(0)
+                        .heartCount(0)
+                        .isReport(FALSE)
                         .build());
     }
     protected BoardComment createBoardComment() {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 리팩토링

### 반영 브랜치
ex) refactor/#156/queryOptimization-> develop

### 변경 사항
* 게시글 조회에서 isLike 여부 확인 시 N+1문제가 발생하기 때문에, 조인과 프로젝션을 통해 게시글 조회시 isLiked, isMine을 함께 BoardInfoInterface로 받아옵니다.
* 게시글댓글 조회도 마찬가지로 수정하였습니다.
* boardComment의 member 필드명을 writer로 바꿨습니다. (권한 체크 시 혼란 방지)
* 프로시저 저장 방식을 수정하였습니다. function이 아닌 procedure로 저장하여 수행하도록 하였습니다. [function과 procedure의 차이](https://bongra.tistory.com/52)
* request dto의 content null체크는 @valid 어노테이션으로 합니다.
* 신고함 구현에 따라 isReport를 반환하도록 하였습니다. boardComment에 구현되어있는대로, board에도 isReport 필드를 만들어 저장하도록 하였습니다.

### 안내 사항
* 왜인지 모르겠다만 게시글 수정 API가 없습니다. 게시글 목록 페이징 처리할 때 함께 구현하겠습니다.

### 테스트 결과
<img width="456" alt="스크린샷 2024-09-14 오후 11 24 11" src="https://github.com/user-attachments/assets/b5eee4b2-3eea-42b8-8434-2cde867f9517">
