### PR TITLE
[FEAT] 게시글, 댓글 목록 페이지네이션 구현

### DIFF
--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -3,18 +3,21 @@ package com.server.capple.domain.board.controller;
 import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.board.dto.BoardRequest;
 import com.server.capple.domain.board.dto.BoardResponse.BoardId;
-import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfos;
+import com.server.capple.domain.board.dto.BoardResponse.BoardInfo;
 import com.server.capple.domain.board.dto.BoardResponse.ToggleBoardHeart;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.board.service.BoardService;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseResponse;
+import com.server.capple.global.common.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "게시판 API", description = "게시판 관련 API")
@@ -40,13 +43,12 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/redis")
-    private BaseResponse<BoardsGetBoardInfos> getBoardsByBoardTypeWithRedis(
+    private BaseResponse<SliceResponse<BoardInfo>> getBoardsByBoardTypeWithRedis(
             @AuthMember Member member,
-            @RequestParam(name = "boardType", required = false) BoardType boardType
-            // TODO: 페이징 프론트 이슈로 추후 구현
-//            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) @Parameter(hidden = true) Pageable pageable
-            ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRedis(member, boardType));
+            @RequestParam(name = "boardType", required = false) BoardType boardType,
+            @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize
+    ) {
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRedis(member, boardType, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "카테고리별 게시글 조회", description = "카테고리별 게시글을 조회합니다.")
@@ -54,13 +56,12 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping()
-    private BaseResponse<BoardsGetBoardInfos> getBoardsByBoardType(
+    private BaseResponse<SliceResponse<BoardInfo>> getBoardsByBoardType(
             @AuthMember Member member,
-            @RequestParam(name = "boardType", required = false) BoardType boardType
-            // TODO: 페이징 프론트 이슈로 추후 구현
-//            @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC) @Parameter(hidden = true) Pageable pageable
+            @RequestParam(name = "boardType", required = false) BoardType boardType,
+            @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize
     ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType));
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "게시글 검색 API", description = "게시글을 검색합니다. 자유게시판에서만 검색이 가능합니다.")
@@ -68,9 +69,11 @@ public class BoardController {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/search")
-    private BaseResponse<BoardsGetBoardInfos> searchBoardsByKeyword(@AuthMember Member member,
-                                                                    @RequestParam(name = "keyword") String keyword) {
-        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword));
+    private BaseResponse<SliceResponse<BoardInfo>> searchBoardsByKeyword(
+            @AuthMember Member member, @RequestParam(name = "keyword") String keyword,
+            @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
+            @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
 

--- a/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class BoardResponse {
 
@@ -15,20 +14,11 @@ public class BoardResponse {
     public static class BoardId {
         private Long boardId;
     }
-
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class BoardsGetBoardInfos {
-        private List<BoardsGetBoardInfo> boards;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class BoardsGetBoardInfo {
+    public static class BoardInfo {
         private Long boardId;
         private Long writerId;
         private String content;

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -42,23 +42,6 @@ public class BoardMapper {
                 .build();
     }
 
-    public SliceResponse<BoardInfo> toSliceBoardInfoForRedis(Member member, Slice<BoardInfoInterface> boardSlice) {
-        return SliceResponse.<BoardInfo>builder()
-                .number(boardSlice.getNumber())
-                .size(boardSlice.getSize())
-                .content(boardSlice.getContent().stream().map(boardInfoInterface -> {
-                                    int heartCount = boardHeartRedisRepository.getBoardHeartsCount(boardInfoInterface.getBoard().getId());
-                                    boolean isLiked = boardHeartRedisRepository.isMemberLikedBoard(member.getId(), boardInfoInterface.getBoard().getId());
-                                    return toBoardInfo(boardInfoInterface.getBoard(), heartCount, isLiked, boardInfoInterface.getIsMine());
-                                })
-                                .toList()
-                )
-                .numberOfElements(boardSlice.getNumberOfElements())
-                .hasPrevious(boardSlice.hasPrevious())
-                .hasNext(boardSlice.hasNext())
-                .build();
-    }
-
     //rdb
     public BoardInfo toBoardInfo(Board board, Boolean isLiked, Boolean isMine) {
         return BoardInfo.builder()
@@ -71,20 +54,6 @@ public class BoardMapper {
                 .isLiked(isLiked)
                 .isMine(isMine)
                 .isReported(board.getIsReport())
-                .build();
-    }
-
-    public SliceResponse<BoardInfo> toSliceBoardInfo(Slice<BoardInfoInterface> boardSlice) {
-        return SliceResponse.<BoardInfo>builder()
-                .number(boardSlice.getNumber())
-                .size(boardSlice.getSize())
-                .content(boardSlice.getContent().stream().map(boardInfoInterface ->
-                        toBoardInfo(boardInfoInterface.getBoard(), boardInfoInterface.getIsLike(), boardInfoInterface.getIsMine()))
-                        .toList()
-                )
-                .numberOfElements(boardSlice.getNumberOfElements())
-                .hasPrevious(boardSlice.hasPrevious())
-                .hasNext(boardSlice.hasNext())
                 .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -1,13 +1,20 @@
 package com.server.capple.domain.board.mapper;
 
-import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfo;
+import com.server.capple.domain.board.dao.BoardInfoInterface;
+import com.server.capple.domain.board.dto.BoardResponse.BoardInfo;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
+import com.server.capple.domain.board.repository.BoardHeartRedisRepository;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class BoardMapper {
+    private final BoardHeartRedisRepository boardHeartRedisRepository;
 
     public Board toBoard(Member member, BoardType boardType, String content) {
         return Board.builder()
@@ -21,8 +28,8 @@ public class BoardMapper {
     }
 
     //redis
-    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Integer boardHeartsCount, Boolean isLiked, Boolean isMine) {
-        return BoardsGetBoardInfo.builder()
+    public BoardInfo toBoardInfo(Board board, Integer boardHeartsCount, Boolean isLiked, Boolean isMine) {
+        return BoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
                 .content(board.getContent())
@@ -35,9 +42,26 @@ public class BoardMapper {
                 .build();
     }
 
+    public SliceResponse<BoardInfo> toSliceBoardInfoForRedis(Member member, Slice<BoardInfoInterface> boardSlice) {
+        return SliceResponse.<BoardInfo>builder()
+                .number(boardSlice.getNumber())
+                .size(boardSlice.getSize())
+                .content(boardSlice.getContent().stream().map(boardInfoInterface -> {
+                                    int heartCount = boardHeartRedisRepository.getBoardHeartsCount(boardInfoInterface.getBoard().getId());
+                                    boolean isLiked = boardHeartRedisRepository.isMemberLikedBoard(member.getId(), boardInfoInterface.getBoard().getId());
+                                    return toBoardInfo(boardInfoInterface.getBoard(), heartCount, isLiked, boardInfoInterface.getIsMine());
+                                })
+                                .toList()
+                )
+                .numberOfElements(boardSlice.getNumberOfElements())
+                .hasPrevious(boardSlice.hasPrevious())
+                .hasNext(boardSlice.hasNext())
+                .build();
+    }
+
     //rdb
-    public BoardsGetBoardInfo toBoardsGetBoardInfo(Board board, Boolean isLiked, Boolean isMine) {
-        return BoardsGetBoardInfo.builder()
+    public BoardInfo toBoardInfo(Board board, Boolean isLiked, Boolean isMine) {
+        return BoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
                 .content(board.getContent())
@@ -49,4 +73,19 @@ public class BoardMapper {
                 .isReported(board.getIsReport())
                 .build();
     }
+
+    public SliceResponse<BoardInfo> toSliceBoardInfo(Slice<BoardInfoInterface> boardSlice) {
+        return SliceResponse.<BoardInfo>builder()
+                .number(boardSlice.getNumber())
+                .size(boardSlice.getSize())
+                .content(boardSlice.getContent().stream().map(boardInfoInterface ->
+                        toBoardInfo(boardInfoInterface.getBoard(), boardInfoInterface.getIsLike(), boardInfoInterface.getIsMine()))
+                        .toList()
+                )
+                .numberOfElements(boardSlice.getNumberOfElements())
+                .hasPrevious(boardSlice.hasPrevious())
+                .hasNext(boardSlice.hasNext())
+                .build();
+    }
 }
+

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -1,20 +1,13 @@
 package com.server.capple.domain.board.mapper;
 
-import com.server.capple.domain.board.dao.BoardInfoInterface;
 import com.server.capple.domain.board.dto.BoardResponse.BoardInfo;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
-import com.server.capple.domain.board.repository.BoardHeartRedisRepository;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.global.common.SliceResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class BoardMapper {
-    private final BoardHeartRedisRepository boardHeartRedisRepository;
 
     public Board toBoard(Member member, BoardType boardType, String content) {
         return Board.builder()

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -4,6 +4,8 @@ import com.server.capple.domain.board.dao.BoardInfoInterface;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.member.entity.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,21 +13,28 @@ import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    @Query("SELECT b AS board, " +
-            "(CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+    @Query("SELECT DISTINCT b AS board, " +
+            "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM Board b " +
-            "LEFT JOIN BoardHeart bh ON b = bh.board " +
-            "WHERE :boardType IS NULL OR b.boardType = :boardType ORDER BY b.createdAt DESC")
-    List<BoardInfoInterface> findBoardInfosByMemberAndBoardType(Member member, BoardType boardType);
+            "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
+            "WHERE :boardType IS NULL OR b.boardType = :boardType")
+    Slice<BoardInfoInterface> findBoardInfosByMemberAndBoardType(Member member, BoardType boardType, Pageable pageable);
 
-    @Query("SELECT b AS board, " +
-            "(CASE WHEN bh.member = :member AND bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+    @Query("SELECT DISTINCT b AS board, " +
+            "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM Board b " +
-            "LEFT JOIN BoardHeart bh ON b = bh.board " +
+            "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
             "WHERE b.content LIKE %:keyword% AND b.boardType = 0 ORDER BY b.createdAt DESC") //FREETYPE = 0
-    List<BoardInfoInterface> findBoardInfosByMemberAndKeyword(Member member, String keyword);
+    Slice<BoardInfoInterface> findBoardInfosByMemberAndKeyword(Member member, String keyword, Pageable pageable);
 
-    List<Board> findBoardsByBoardType(BoardType boardType);
+
+    //redis 성능 테스트용
+    @Query("SELECT DISTINCT b AS board, " +
+            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "FROM Board b " +
+            "WHERE :boardType IS NULL OR b.boardType = :boardType ORDER BY b.createdAt DESC")
+    Slice<BoardInfoInterface> findBoardInfosForRedis(Member member, BoardType boardType, Pageable pageable);
+
 }

--- a/src/main/java/com/server/capple/domain/board/service/BoardService.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardService.java
@@ -1,22 +1,25 @@
 package com.server.capple.domain.board.service;
 
 import com.server.capple.domain.board.dto.BoardResponse.BoardId;
-import com.server.capple.domain.board.dto.BoardResponse.BoardsGetBoardInfos;
+import com.server.capple.domain.board.dto.BoardResponse.BoardInfo;
 import com.server.capple.domain.board.dto.BoardResponse.ToggleBoardHeart;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
+import org.springframework.data.domain.Pageable;
+
 
 public interface BoardService {
     BoardId createBoard(Member member, BoardType boardType, String content);
 
-    BoardsGetBoardInfos getBoardsByBoardTypeWithRedis(Member member, BoardType boardType);
+    SliceResponse<BoardInfo> getBoardsByBoardTypeWithRedis(Member member, BoardType boardType, Pageable pageable);
 
-    BoardsGetBoardInfos getBoardsByBoardType(Member member, BoardType boardType);
+    SliceResponse<BoardInfo> getBoardsByBoardType(Member member, BoardType boardType, Pageable pageable);
+
+    SliceResponse<BoardInfo> searchBoardsByKeyword(Member member, String keyword, Pageable pageable);
 
     BoardId deleteBoard(Member member, Long boardId);
-
-    BoardsGetBoardInfos searchBoardsByKeyword(Member member, String keyword);
 
     ToggleBoardHeart toggleBoardHeart(Member member, Long boardId);
 

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -29,7 +29,6 @@ import static com.server.capple.domain.board.dto.BoardResponse.BoardInfo;
 public class BoardServiceImpl implements BoardService {
 
     private final BoardRepository boardRepository;
-    private final BoardHeartRedisRepository boardHeartRedisRepository;
     private final BoardMapper boardMapper;
     private final BoardHeartRepository boardHeartRepository;
     private final BoardHeartMapper boardHeartMapper;

--- a/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
+++ b/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
@@ -3,16 +3,19 @@ package com.server.capple.domain.boardComment.controller;
 
 import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentId;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.service.BoardCommentService;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseResponse;
+import com.server.capple.global.common.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "게시글 댓글 API", description = "게시글 댓글 API입니다.")
@@ -52,8 +55,10 @@ public class BoardCommentController {
 
     @Operation(summary = "게시글 댓글 리스트 조회 API", description = " 게시글 댓글 리스트 조회 API 입니다. pathVariable 으로 boardId를 주세요.")
     @GetMapping("/{boardId}")
-    public BaseResponse<BoardCommentInfos> getBoardCommentInfos(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId) {
-        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId));
+    public BaseResponse<SliceResponse<BoardCommentInfo>> getBoardCommentInfos(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId,
+                                                                              @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
+                                                                              @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId, PageRequest.of(pageNumber,pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
 }

--- a/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
+++ b/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
@@ -34,10 +34,4 @@ public class BoardCommentResponse {
         private Boolean isReport;
         private LocalDateTime createdAt;
     }
-
-    @Getter
-    @AllArgsConstructor
-    public static class BoardCommentInfos {
-        private List<BoardCommentInfo> boardCommentInfos;
-    }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -32,20 +32,4 @@ public class BoardCommentMapper {
                 .createdAt(comment.getCreatedAt())
                 .build();
     }
-
-    public SliceResponse<BoardCommentInfo> toSliceBoardCommentInfo(Slice<BoardCommentInfoInterface> boardCommentSlice) {
-        return SliceResponse.<BoardCommentInfo>builder()
-                .number(boardCommentSlice.getNumber())
-                .size(boardCommentSlice.getSize())
-                .content(boardCommentSlice.getContent().stream().map(boardCommentInfoInterface ->
-                                toBoardCommentInfo(boardCommentInfoInterface.getBoardComment(),
-                                        boardCommentInfoInterface.getIsLike(),
-                                        boardCommentInfoInterface.getIsMine()))
-                        .toList()
-                )
-                .numberOfElements(boardCommentSlice.getNumberOfElements())
-                .hasPrevious(boardCommentSlice.hasPrevious())
-                .hasNext(boardCommentSlice.hasNext())
-                .build();
-    }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -1,12 +1,9 @@
 package com.server.capple.domain.boardComment.mapper;
 
 import com.server.capple.domain.board.entity.Board;
-import com.server.capple.domain.boardComment.dao.BoardCommentInfoInterface;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.global.common.SliceResponse;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -1,9 +1,7 @@
 package com.server.capple.domain.boardComment.mapper;
 
-import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.dao.BoardCommentInfoInterface;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
@@ -22,7 +20,6 @@ public class BoardCommentMapper {
                 .build();
     }
 
-    //rdb
     public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked, Boolean isMine) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -1,9 +1,14 @@
 package com.server.capple.domain.boardComment.mapper;
 
+import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.boardComment.dao.BoardCommentInfoInterface;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -28,6 +33,22 @@ public class BoardCommentMapper {
                 .isMine(isMine)
                 .isReport(comment.getIsReport())
                 .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+    public SliceResponse<BoardCommentInfo> toSliceBoardCommentInfo(Slice<BoardCommentInfoInterface> boardCommentSlice) {
+        return SliceResponse.<BoardCommentInfo>builder()
+                .number(boardCommentSlice.getNumber())
+                .size(boardCommentSlice.getSize())
+                .content(boardCommentSlice.getContent().stream().map(boardCommentInfoInterface ->
+                                toBoardCommentInfo(boardCommentInfoInterface.getBoardComment(),
+                                        boardCommentInfoInterface.getIsLike(),
+                                        boardCommentInfoInterface.getIsMine()))
+                        .toList()
+                )
+                .numberOfElements(boardCommentSlice.getNumberOfElements())
+                .hasPrevious(boardCommentSlice.hasPrevious())
+                .hasNext(boardCommentSlice.hasNext())
                 .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
@@ -10,10 +10,10 @@ import java.util.List;
 
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
     @Query("SELECT bc AS boardComment, " +
-            "(CASE WHEN bch.member = :member AND bch.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
+            "(CASE WHEN bch.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN bc.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM BoardComment bc " +
-            "LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment " +
+            "LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment AND bch.member = :member " +
             "WHERE bc.board.id = :boardId ORDER BY bc.createdAt DESC")
     List<BoardCommentInfoInterface> findBoardCommentInfosByMemberAndBoardId(Member member, Long boardId);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
@@ -3,6 +3,8 @@ package com.server.capple.domain.boardComment.repository;
 import com.server.capple.domain.boardComment.dao.BoardCommentInfoInterface;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -15,5 +17,5 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
             "FROM BoardComment bc " +
             "LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment AND bch.member = :member " +
             "WHERE bc.board.id = :boardId ORDER BY bc.createdAt DESC")
-    List<BoardCommentInfoInterface> findBoardCommentInfosByMemberAndBoardId(Member member, Long boardId);
+    Slice<BoardCommentInfoInterface> findBoardCommentInfosByMemberAndBoardId(Member member, Long boardId, Pageable pageable);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentService.java
@@ -1,17 +1,19 @@
 package com.server.capple.domain.boardComment.service;
 
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentId;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface BoardCommentService {
     BoardCommentId createBoardComment(Member member, Long boardId, BoardCommentRequest request);
     BoardCommentId updateBoardComment(Member member, Long commentId,BoardCommentRequest request);
     BoardCommentId deleteBoardComment(Member member, Long commentId);
     ToggleBoardCommentHeart toggleBoardCommentHeart(Member member, Long commentId);
-    BoardCommentInfos getBoardCommentInfos(Member member, Long boardId);
+    SliceResponse<BoardCommentInfo> getBoardCommentInfos(Member member, Long boardId, Pageable pageable);
     BoardComment findBoardComment(Long commentId);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.boardComment.service;
 
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.service.BoardService;
+import com.server.capple.domain.boardComment.dao.BoardCommentInfoInterface;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentId;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
@@ -21,6 +22,7 @@ import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.CommentErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -96,7 +98,14 @@ public class BoardCommentServiceImpl implements BoardCommentService {
 
     @Override
     public SliceResponse<BoardCommentInfo> getBoardCommentInfos(Member member, Long boardId, Pageable pageable) {
-        return boardCommentMapper.toSliceBoardCommentInfo(boardCommentRepository.findBoardCommentInfosByMemberAndBoardId(member, boardId, pageable));
+        Slice<BoardCommentInfoInterface> sliceBoardCommentInfos = boardCommentRepository.findBoardCommentInfosByMemberAndBoardId(member, boardId, pageable);
+        return SliceResponse.toSliceResponse(sliceBoardCommentInfos, sliceBoardCommentInfos.getContent().stream().map(sliceBoardCommentInfo ->
+                        boardCommentMapper.toBoardCommentInfo(
+                                sliceBoardCommentInfo.getBoardComment(),
+                                sliceBoardCommentInfo.getIsLike(),
+                                sliceBoardCommentInfo.getIsMine()))
+                .toList()
+        );
     }
 
     private void checkPermission(Member member, BoardComment boardComment) {

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -2,10 +2,9 @@ package com.server.capple.domain.boardComment.service;
 
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.service.BoardService;
-import com.server.capple.domain.boardComment.dao.BoardCommentInfoInterface;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentId;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.boardComment.entity.BoardCommentHeart;
@@ -16,15 +15,14 @@ import com.server.capple.domain.boardComment.repository.BoardCommentHeartReposit
 import com.server.capple.domain.boardComment.repository.BoardCommentRepository;
 import com.server.capple.domain.boardSubscribeMember.service.BoardSubscribeMemberService;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.domain.notifiaction.service.NotificationService;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.CommentErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -97,11 +95,8 @@ public class BoardCommentServiceImpl implements BoardCommentService {
 
 
     @Override
-    public BoardCommentInfos getBoardCommentInfos(Member member, Long boardId) {
-        List<BoardCommentInfoInterface> commentInfos = boardCommentRepository.findBoardCommentInfosByMemberAndBoardId(member, boardId);
-
-        return new BoardCommentInfos(commentInfos.stream().map(commentInfo ->
-                boardCommentMapper.toBoardCommentInfo(commentInfo.getBoardComment(), commentInfo.getIsLike(), commentInfo.getIsMine())).toList());
+    public SliceResponse<BoardCommentInfo> getBoardCommentInfos(Member member, Long boardId, Pageable pageable) {
+        return boardCommentMapper.toSliceBoardCommentInfo(boardCommentRepository.findBoardCommentInfosByMemberAndBoardId(member, boardId, pageable));
     }
 
     private void checkPermission(Member member, BoardComment boardComment) {

--- a/src/main/java/com/server/capple/global/common/SliceResponse.java
+++ b/src/main/java/com/server/capple/global/common/SliceResponse.java
@@ -35,4 +35,19 @@ public class SliceResponse<T> {
         this.hasPrevious = hasPrevious;
         this.hasNext = hasNext;
     }
+
+    /**
+     * P : 데이터베이스에서 반환 받은 데이터 타입<BR>
+     * R : 사용자게에 반환할 데이터 타입
+     */
+    public static <P, R> SliceResponse<R> toSliceResponse(Slice<P> sliceObject, List<R> content) {
+        return SliceResponse.<R>builder()
+            .number(sliceObject.getNumber())
+            .size(sliceObject.getSize())
+            .content(content)
+            .numberOfElements(sliceObject.getNumberOfElements())
+            .hasPrevious(sliceObject.hasPrevious())
+            .hasNext(sliceObject.hasNext())
+            .build();
+    }
 }

--- a/src/main/java/com/server/capple/global/common/SliceResponse.java
+++ b/src/main/java/com/server/capple/global/common/SliceResponse.java
@@ -1,5 +1,6 @@
 package com.server.capple.global.common;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -15,6 +16,7 @@ public class SliceResponse<T> {
     int numberOfElements;
     boolean hasPrevious;
     boolean hasNext;
+
     public SliceResponse(Slice<T> sliceObject) {
         number = sliceObject.getNumber();
         size = sliceObject.getSize();
@@ -22,5 +24,15 @@ public class SliceResponse<T> {
         numberOfElements = sliceObject.getNumberOfElements();
         hasPrevious = sliceObject.hasPrevious();
         hasNext = sliceObject.hasNext();
+    }
+
+    @Builder
+    public SliceResponse(int number, int size, List<T> content, int numberOfElements, boolean hasPrevious, boolean hasNext) {
+        this.number = number;
+        this.size = size;
+        this.content = content;
+        this.numberOfElements = numberOfElements;
+        this.hasPrevious = hasPrevious;
+        this.hasNext = hasNext;
     }
 }

--- a/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
@@ -3,12 +3,15 @@ package com.server.capple.domain.boardComment.controller;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.service.BoardCommentService;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.support.ControllerTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static com.server.capple.domain.boardComment.dto.BoardCommentResponse.*;
@@ -133,9 +136,9 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     public void getBoardCommentInfosTest() throws Exception {
         //given
         final String url = "/board-comments/{boardId}";
-        BoardCommentInfos response = getBoardCommentInfos();
+        SliceResponse<BoardCommentInfo> response = getSliceBoardCommentInfos();
 
-        doReturn(response).when(boardCommentService).getBoardCommentInfos(any(Member.class), any(Long.class));
+        doReturn(response).when(boardCommentService).getBoardCommentInfos(any(Member.class), any(Long.class), any(PageRequest.class));
 
         //when
         ResultActions resultActions = this.mockMvc.perform(get(url, 1L)
@@ -148,10 +151,12 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("COMMON200"))
                 .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
-                .andExpect(jsonPath("$.result.boardCommentInfos[0].boardCommentId").value(1L))
-//                .andExpect(jsonPath("$.result.boardCommentInfos[0].writer").value("루시"))
-                .andExpect(jsonPath("$.result.boardCommentInfos[0].content").value("댓글"))
-                .andExpect(jsonPath("$.result.boardCommentInfos[0].heartCount").value(2L))
-                .andExpect(jsonPath("$.result.boardCommentInfos[0].isLiked").value(true));
+                .andExpect(jsonPath("$.result.number").value(0))
+                .andExpect(jsonPath("$.result.size").value(10))
+                .andExpect(jsonPath("$.result.numberOfElements").value(1))
+                .andExpect(jsonPath("$.result.content[0].boardCommentId").value(1L))
+                .andExpect(jsonPath("$.result.content[0].content").value("댓글"))
+                .andExpect(jsonPath("$.result.content[0].heartCount").value(2L))
+                .andExpect(jsonPath("$.result.content[0].isLiked").value(true));
     }
 }

--- a/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
@@ -37,7 +37,6 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     public void createBoardCommentTest() throws Exception {
         //given
         final String url = "/board-comments/board/{boardId}";
-
         BoardCommentRequest request = getBoardCommentRequest();
         BoardCommentId response = new BoardCommentId(1L);
 
@@ -63,7 +62,6 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
     public void updateBoardCommentTest() throws Exception {
         //given
         final String url = "/board-comments/{commentId}";
-
         BoardCommentRequest request = getBoardCommentRequest();
         BoardCommentId response = new BoardCommentId(1L);
 

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -1,14 +1,19 @@
 package com.server.capple.domain.boardComment.service;
 
+import com.server.capple.domain.board.dto.BoardResponse;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse;
+import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.ToggleBoardCommentHeart;
 import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -107,14 +112,19 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
     @DisplayName("게시판 댓글 리스트 조회 테스트")
     @Transactional
     public void getBoardCommentsTest() {
+        //given
+        PageRequest pageRequest = PageRequest.of(0,10, Sort.by(Sort.Direction.DESC,"createdAt"));
         //when
-        BoardCommentInfos response = boardCommentService.getBoardCommentInfos(member, board.getId());
+        SliceResponse<BoardCommentInfo> response = boardCommentService.getBoardCommentInfos(member, board.getId(), pageRequest);
 
         //then
-        assertEquals(member.getId(), response.getBoardCommentInfos().get(0).getWriterId());
-        assertEquals("게시글 댓글", response.getBoardCommentInfos().get(0).getContent());
-        assertEquals(0, response.getBoardCommentInfos().get(0).getHeartCount());
-        assertEquals(false, response.getBoardCommentInfos().get(0).getIsLiked());
-        assertEquals(true, response.getBoardCommentInfos().get(0).getIsMine());
+        assertEquals(member.getId(), response.getContent().get(0).getWriterId());
+        assertEquals("게시글 댓글", response.getContent().get(0).getContent());
+        assertEquals(0, response.getContent().get(0).getHeartCount());
+        assertEquals(false, response.getContent().get(0).getIsLiked());
+        assertEquals(true, response.getContent().get(0).getIsMine());
+        assertEquals(0, response.getNumber());
+        assertEquals(10, response.getSize());
+        assertEquals(1, response.getNumberOfElements());
     }
 }

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -9,14 +9,15 @@ import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answerComment.dto.AnswerCommentRequest;
-import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.*;
+import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.AnswerCommentInfo;
+import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.AnswerCommentInfos;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
-import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
+import com.server.capple.global.common.SliceResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -114,7 +115,7 @@ public abstract class ControllerTestConfig {
         return new BoardCommentRequest("게시글 댓글");
     }
 
-    protected BoardCommentInfos getBoardCommentInfos() {
+    protected SliceResponse<BoardCommentInfo> getSliceBoardCommentInfos() {
         List<BoardCommentInfo> commentInfos =
                 List.of(BoardCommentInfo.builder()
                         .boardCommentId(1L)
@@ -126,7 +127,15 @@ public abstract class ControllerTestConfig {
                         .isReport(FALSE)
                         .build());
 
-        return new BoardCommentInfos(commentInfos);
+
+        return SliceResponse.<BoardCommentInfo>builder()
+                .number(0)
+                .size(10)
+                .content(commentInfos)
+                .numberOfElements(1)
+                .hasPrevious(false)
+                .hasNext(true)
+                .build();
     }
 
     protected AnswerCommentRequest getAnswerCommentRequest() {

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -155,5 +155,4 @@ public abstract class ControllerTestConfig {
 
         return new AnswerCommentInfos(answerCommentInfos);
     }
-
 }

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -136,6 +136,7 @@ public abstract class ServiceTestConfig {
                         .isReport(FALSE)
                         .build());
     }
+
     protected BoardComment createBoardComment() {
         return boardCommentRepository.save(
                 BoardComment.builder()
@@ -150,8 +151,6 @@ public abstract class ServiceTestConfig {
     protected BoardCommentRequest getBoardCommentRequest() {
         return new BoardCommentRequest("게시글 댓글");
     }
-
-
 
     protected AnswerCommentRequest getAnswerCommentRequest() {
         return AnswerCommentRequest.builder()


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#155/boardPagination -> develop

### 변경 사항
* 게시글, 게시글 댓글 페이징을 Slice로 구현했습니다. SliceResponse 이용하여 반환하도록 하였습니다.
* 목록 조회 조건절 설정을 다시해서 중복 조회되던 문제 해결했습니다.

### 테스트 결과
<img width="457" alt="스크린샷 2024-09-16 오후 3 51 08" src="https://github.com/user-attachments/assets/f5a3bbef-c317-4780-8ade-6ac1505d509c">
<img width="460" alt="스크린샷 2024-09-16 오후 3 51 47" src="https://github.com/user-attachments/assets/404289c3-37b1-4846-ae46-4f9b96ccd384">

게시판 테스트코드 주세요!!!!!!!!!!!