### PR TITLE
[FEAT] 질문, 답변 목록 페이지네이션 구현

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -83,7 +83,12 @@ public class AnswerController {
 
     @Operation(summary = "좋아한 답변 조회 API", description = " 좋아한 답변 조회 API 입니다.")
     @GetMapping("/heart")
-    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberHeartAnswer(@AuthMember Member member) {
-        return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(member));
+    public BaseResponse<SliceResponse<MemberAnswerInfo>> getMemberHeartAnswer(
+        @AuthMember Member member,
+        @Parameter(description = "조회할 페이지 번호<br>0부터 시작")
+        @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
+        @Parameter(description = "조회할 페이지 크기")
+        @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -4,6 +4,7 @@ import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.service.AnswerService;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseResponse;
@@ -71,8 +72,13 @@ public class AnswerController {
 
     @Operation(summary = "작성한 답변 조회 API", description = " 작성한 답변 조회 API 입니다.")
     @GetMapping
-    public BaseResponse<AnswerResponse.MemberAnswerList> getMemberAnswer(@AuthMember Member member) {
-        return BaseResponse.onSuccess(answerService.getMemberAnswer(member));
+    public BaseResponse<SliceResponse<MemberAnswerInfo>> getMemberAnswer(
+        @AuthMember Member member,
+        @Parameter(description = "조회할 페이지 번호<br>0부터 시작")
+        @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
+        @Parameter(description = "조회할 페이지 크기")
+        @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(answerService.getMemberAnswer(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "좋아한 답변 조회 API", description = " 좋아한 답변 조회 API 입니다.")

--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -3,18 +3,18 @@ package com.server.capple.domain.answer.controller;
 import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.service.AnswerService;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseResponse;
+import com.server.capple.global.common.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "답변 API", description = "답변 API입니다.")
@@ -26,7 +26,7 @@ public class AnswerController {
     private final AnswerService answerService;
 
     @Operation(summary = "답변 생성 API", description = " 답변 생성 API 입니다." +
-            "pathvariable 으로 questionId를 주세요.")
+        "pathvariable 으로 questionId를 주세요.")
     @PostMapping("/question/{questionId}")
     public BaseResponse<AnswerResponse.AnswerId> createAnswer(@AuthMember Member member, @PathVariable(value = "questionId") Long questionId,
                                                               @RequestBody @Valid AnswerRequest request) {
@@ -34,25 +34,21 @@ public class AnswerController {
     }
 
     @Operation(summary = "질문에 대한 답변 조회 API", description = "특정 질문에 대한 답변리스트를 조회하는 API입니다."
-            + "pathVariable으로 questionId를 주세요."
-            + "조회할 질문의 개수를 param으로 입력해주세요.")
-    @Parameters(value = {
-            @Parameter(name = "keyword", description = "검색"),
-            @Parameter(name = "size", description = "조회할 질문의 개수를 입력하세요."),
-    })
+        + "pathVariable으로 questionId를 주세요.")
     @GetMapping("/question/{questionId}")
-    public BaseResponse<AnswerResponse.AnswerList> getAnswerList(
-            @AuthMember Member member,
-            @PathVariable(value = "questionId") Long questionId,
-            @RequestParam(name = "keyword", required = false) String keyword,
-            @PageableDefault
-            @Parameter(hidden = true) Pageable pageable) {
-        Pageable tempPageable = PageRequest.of(pageable.getPageNumber(), 250);
-        return BaseResponse.onSuccess(answerService.getAnswerList(member.getId(), questionId, keyword, tempPageable));
+    public BaseResponse<SliceResponse<AnswerInfo>> getAnswerList(
+        @AuthMember Member member,
+        @Parameter(description = "질문 식별자")
+        @PathVariable(value = "questionId") Long questionId,
+        @Parameter(description = "조회할 페이지 번호<br>0부터 시작")
+        @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
+        @Parameter(description = "조회할 페이지 크기")
+        @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(answerService.getAnswerList(member.getId(), questionId, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "답변 수정 API", description = " 답변 수정 API 입니다." +
-            "pathvariable 으로 answerId를 주세요.")
+        "pathvariable 으로 answerId를 주세요.")
     @PatchMapping("/{answerId}")
     public BaseResponse<AnswerResponse.AnswerId> updateAnswer(@AuthMember Member member, @PathVariable(value = "answerId") Long answerId,
                                                               @RequestBody @Valid AnswerRequest request) {
@@ -60,14 +56,14 @@ public class AnswerController {
     }
 
     @Operation(summary = "답변 삭제 API", description = " 답변 삭제 API 입니다." +
-            "pathvariable 으로 answerId를 주세요.")
+        "pathvariable 으로 answerId를 주세요.")
     @DeleteMapping("/{answerId}")
     public BaseResponse<AnswerResponse.AnswerId> deleteAnswer(@AuthMember Member member, @PathVariable(value = "answerId") Long answerId) {
         return BaseResponse.onSuccess(answerService.deleteAnswer(member, answerId));
     }
 
     @Operation(summary = "답변 좋아요/취소 API", description = " 답변 좋아요/취소 API 입니다." +
-            "pathvariable 으로 answerId를 주세요.")
+        "pathvariable 으로 answerId를 주세요.")
     @PostMapping("/{answerId}/heart")
     public BaseResponse<AnswerResponse.AnswerLike> toggleAnswerHeart(@AuthMember Member member, @PathVariable(value = "answerId") Long answerId) {
         return BaseResponse.onSuccess(answerService.toggleAnswerHeart(member, answerId));

--- a/src/main/java/com/server/capple/domain/answer/dao/AnswerRDBDao.java
+++ b/src/main/java/com/server/capple/domain/answer/dao/AnswerRDBDao.java
@@ -1,0 +1,10 @@
+package com.server.capple.domain.answer.dao;
+
+import com.server.capple.domain.answer.entity.Answer;
+
+public class AnswerRDBDao {
+    public interface AnswerInfoInterface {
+        public Answer getAnswer();
+        public Boolean getIsReported();
+    }
+}

--- a/src/main/java/com/server/capple/domain/answer/dto/AnswerResponse.java
+++ b/src/main/java/com/server/capple/domain/answer/dto/AnswerResponse.java
@@ -1,7 +1,5 @@
 package com.server.capple.domain.answer.dto;
 
-import java.util.List;
-
 import lombok.*;
 
 public class AnswerResponse {
@@ -27,14 +25,6 @@ public class AnswerResponse {
     }
 
     @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class AnswerList {
-        private List<AnswerInfo> answerInfos;
-    }
-
-    @Getter
     @AllArgsConstructor
     public static class AnswerLike {
         private Long answerId;
@@ -54,11 +44,5 @@ public class AnswerResponse {
         private int heartCount;
         private String writeAt;
         private Boolean isLiked;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class MemberAnswerList {
-        private List<MemberAnswerInfo> memberAnswerInfos;
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
@@ -2,9 +2,7 @@ package com.server.capple.domain.answer.mapper;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
-import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
-import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
@@ -19,12 +17,6 @@ public class AnswerMapper {
                 .member(member)
                 .question(question)
                 .content(request.getAnswer())
-                .build();
-    }
-
-    public AnswerList toAnswerList(List<AnswerInfo> answerInfoList) {
-        return AnswerList.builder()
-                .answerInfos(answerInfoList)
                 .build();
     }
 
@@ -54,9 +46,5 @@ public class AnswerMapper {
                 .writeAt(answer.getCreatedAt().toString())
                 .isLiked(isLiked)
                 .build();
-    }
-
-    public MemberAnswerList toMemberAnswerList(List<MemberAnswerInfo> memberAnswerInfos) {
-        return new MemberAnswerList(memberAnswerInfos);
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
@@ -1,6 +1,5 @@
 package com.server.capple.domain.answer.mapper;
 
-import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
@@ -9,8 +8,6 @@ import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
-import com.server.capple.global.common.SliceResponse;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -61,16 +58,5 @@ public class AnswerMapper {
 
     public MemberAnswerList toMemberAnswerList(List<MemberAnswerInfo> memberAnswerInfos) {
         return new MemberAnswerList(memberAnswerInfos);
-    }
-
-    public SliceResponse<AnswerInfo> toAnswerInfoSliceResponse(Slice<AnswerInfoInterface> answerInfoSliceInterface, List<AnswerInfo> content) {
-        return SliceResponse.<AnswerInfo>builder()
-            .number(answerInfoSliceInterface.getNumber())
-            .size(answerInfoSliceInterface.getSize())
-            .content(content)
-            .numberOfElements(answerInfoSliceInterface.getNumberOfElements())
-            .hasPrevious(answerInfoSliceInterface.hasPrevious())
-            .hasNext(answerInfoSliceInterface.hasNext())
-            .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.answer.mapper;
 
+import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
@@ -8,6 +9,8 @@ import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
+import com.server.capple.global.common.SliceResponse;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -60,4 +63,14 @@ public class AnswerMapper {
         return new MemberAnswerList(memberAnswerInfos);
     }
 
+    public SliceResponse<AnswerInfo> toAnswerInfoSliceResponse(Slice<AnswerInfoInterface> answerInfoSliceInterface, List<AnswerInfo> content) {
+        return SliceResponse.<AnswerInfo>builder()
+            .number(answerInfoSliceInterface.getNumber())
+            .size(answerInfoSliceInterface.getSize())
+            .content(content)
+            .numberOfElements(answerInfoSliceInterface.getNumberOfElements())
+            .hasPrevious(answerInfoSliceInterface.hasPrevious())
+            .hasNext(answerInfoSliceInterface.hasNext())
+            .build();
+    }
 }

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -11,9 +11,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
+import java.util.Set;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findById(Long answerId);
+
+    Slice<Answer> findByIdIn(Set<Long> answerIds, Pageable pageable);
 
     boolean existsByQuestionAndMember(Question question, Member member);
 

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -1,11 +1,13 @@
 package com.server.capple.domain.answer.repository;
 
+import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -16,8 +18,13 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     boolean existsByQuestionAndMember(Question question, Member member);
 
-    @Query("SELECT a FROM Answer a WHERE a.question.id = :questionId ORDER BY a.createdAt DESC")
-    Optional<List<Answer>> findByQuestion(
+    @Query("SELECT a AS answer, (r IS NOT NULL) AS isReported " +
+        "FROM Answer a " +
+        "LEFT JOIN " +
+        "Report r ON r.answer = a " +
+        "WHERE a.question.id = :questionId " +
+        "ORDER BY a.createdAt DESC")
+    Optional<Slice<AnswerInfoInterface>> findByQuestion(
             @Param("questionId") Long questionId,
             Pageable pageable);
 

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -24,12 +24,11 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         "FROM Answer a " +
         "LEFT JOIN " +
         "Report r ON r.answer = a " +
-        "WHERE a.question.id = :questionId " +
-        "ORDER BY a.createdAt DESC")
-    Optional<Slice<AnswerInfoInterface>> findByQuestion(
+        "WHERE a.question.id = :questionId")
+    Slice<AnswerInfoInterface> findByQuestion(
         @Param("questionId") Long questionId,
         Pageable pageable);
 
-    @Query("SELECT a FROM Answer a WHERE a.member = :member and a.deletedAt is null ORDER BY a.createdAt DESC")
+    @Query("SELECT a FROM Answer a WHERE a.member = :member and a.deletedAt is null")
     Slice<Answer> findByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -5,7 +5,6 @@ import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
 import io.lettuce.core.dynamic.annotation.Param;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,15 +24,9 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         "WHERE a.question.id = :questionId " +
         "ORDER BY a.createdAt DESC")
     Optional<Slice<AnswerInfoInterface>> findByQuestion(
-            @Param("questionId") Long questionId,
-            Pageable pageable);
-
-    @Query("SELECT a FROM Answer a WHERE a.question.id = :questionId AND a.content LIKE %:keyword%")
-    Optional<List<Answer>> findByQuestionAndKeyword(
-            @Param("questionId") Long questionId,
-            @Param("keyword") String keyword,
-            Pageable pageable);
+        @Param("questionId") Long questionId,
+        Pageable pageable);
 
     @Query("SELECT a FROM Answer a WHERE a.member = :member and a.deletedAt is null ORDER BY a.createdAt DESC")
-    Optional<List<Answer>> findByMember(@Param("member") Member member);
+    Slice<Answer> findByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
@@ -3,6 +3,7 @@ package com.server.capple.domain.answer.service;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
@@ -23,7 +24,7 @@ public interface AnswerService {
 
     SliceResponse<AnswerInfo> getAnswerList(Long memberId, Long questionId, Pageable pageable);
 
-    MemberAnswerList getMemberAnswer(Member member);
+    SliceResponse<MemberAnswerInfo> getMemberAnswer(Member member, Pageable pageable);
 
     MemberAnswerList getMemberHeartAnswer(Member member);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
@@ -2,10 +2,11 @@ package com.server.capple.domain.answer.service;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
-import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
+import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
 import org.springframework.data.domain.Pageable;
 
 
@@ -20,7 +21,7 @@ public interface AnswerService {
 
     AnswerResponse.AnswerLike toggleAnswerHeart(Member loginMember, Long answerId);
 
-    AnswerList getAnswerList(Long memberId, Long questionId, String keyword, Pageable pageable);
+    SliceResponse<AnswerInfo> getAnswerList(Long memberId, Long questionId, Pageable pageable);
 
     MemberAnswerList getMemberAnswer(Member member);
 

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerService.java
@@ -4,7 +4,6 @@ import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
-import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.SliceResponse;
@@ -26,5 +25,5 @@ public interface AnswerService {
 
     SliceResponse<MemberAnswerInfo> getMemberAnswer(Member member, Pageable pageable);
 
-    MemberAnswerList getMemberHeartAnswer(Member member);
+    SliceResponse<MemberAnswerInfo> getMemberHeartAnswer(Member member, Pageable pageable);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -1,9 +1,10 @@
 package com.server.capple.domain.answer.service;
 
+import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerLike;
-import com.server.capple.domain.answer.dto.AnswerResponse.AnswerList;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.mapper.AnswerMapper;
@@ -14,10 +15,12 @@ import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.service.QuestionService;
 import com.server.capple.domain.report.repository.ReportRepository;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.AnswerErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,24 +94,18 @@ public class AnswerServiceImpl implements AnswerService {
     }
 
     @Override
-    public AnswerList getAnswerList(Long memberId, Long questionId, String keyword, Pageable pageable) {
-
-        if (keyword == null) {
-            return answerMapper.toAnswerList(
-                    answerRepository.findByQuestion(questionId, pageable).orElseThrow(()
-                                    -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND))
-                            .stream()
-                            .map(answer -> answerMapper.toAnswerInfo(answer, memberId, reportRepository.existsReportByAnswer(answer), answerHeartRedisRepository.isMemberLikedAnswer(memberId, answer.getId()), answer.getMember().getId().equals(memberId)))
-                            .toList());
-        } else {
-            return answerMapper.toAnswerList(
-                    answerRepository.findByQuestionAndKeyword(questionId, keyword, pageable).orElseThrow(()
-                                    -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND))
-                            .stream()
-                            .map(answer -> answerMapper.toAnswerInfo(answer, memberId, reportRepository.existsReportByAnswer(answer), answerHeartRedisRepository.isMemberLikedAnswer(memberId, answer.getId()), answer.getMember().getId().equals(memberId)))
-                            .toList());
-        }
-
+    public SliceResponse<AnswerInfo> getAnswerList(Long memberId, Long questionId, Pageable pageable) {
+        Slice<AnswerInfoInterface> answerInfoSliceInterface = answerRepository.findByQuestion(questionId, pageable).orElseThrow(()
+            -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND));
+        return answerMapper.toAnswerInfoSliceResponse(answerInfoSliceInterface, answerInfoSliceInterface.getContent().stream().map(
+            answerInfoDto -> answerMapper.toAnswerInfo(
+                answerInfoDto.getAnswer(),
+                memberId,
+                answerInfoDto.getIsReported(),
+                answerHeartRedisRepository.isMemberLikedAnswer(memberId, answerInfoDto.getAnswer().getId()),
+                answerInfoDto.getAnswer().getMember().getId().equals(memberId)
+            )
+        ).toList());
     }
 
     // 유저가 작성한 답변 조회
@@ -116,9 +113,9 @@ public class AnswerServiceImpl implements AnswerService {
     public MemberAnswerList getMemberAnswer(Member member) {
         List<Answer> answers = answerRepository.findByMember(member).orElse(null);
         return answerMapper.toMemberAnswerList(
-                answers.stream()
-                        .map(answer -> answerMapper.toMemberAnswerInfo(answer, answerHeartRedisRepository.getAnswerHeartsCount(answer.getId()), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answer.getId())))
-                        .toList()
+            answers.stream()
+                .map(answer -> answerMapper.toMemberAnswerInfo(answer, answerHeartRedisRepository.getAnswerHeartsCount(answer.getId()), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answer.getId())))
+                .toList()
         );
     }
 
@@ -126,10 +123,10 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public MemberAnswerList getMemberHeartAnswer(Member member) {
         return answerMapper.toMemberAnswerList(
-                answerHeartRedisRepository.getMemberHeartsAnswer(member.getId())
-                        .stream()
-                        .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer((answerId)), answerHeartRedisRepository.getAnswerHeartsCount(answerId), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answerId)))
-                        .toList()
+            answerHeartRedisRepository.getMemberHeartsAnswer(member.getId())
+                .stream()
+                .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer((answerId)), answerHeartRedisRepository.getAnswerHeartsCount(answerId), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answerId)))
+                .toList()
         );
     }
 
@@ -144,7 +141,7 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public Answer findAnswer(Long answerId) {
         return answerRepository.findById(answerId).orElseThrow(
-                () -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND)
+            () -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND)
         );
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -97,7 +97,7 @@ public class AnswerServiceImpl implements AnswerService {
     public SliceResponse<AnswerInfo> getAnswerList(Long memberId, Long questionId, Pageable pageable) {
         Slice<AnswerInfoInterface> answerInfoSliceInterface = answerRepository.findByQuestion(questionId, pageable).orElseThrow(()
             -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND));
-        return answerMapper.toAnswerInfoSliceResponse(answerInfoSliceInterface, answerInfoSliceInterface.getContent().stream().map(
+        return SliceResponse.toSliceResponse(answerInfoSliceInterface, answerInfoSliceInterface.getContent().stream().map(
             answerInfoDto -> answerMapper.toAnswerInfo(
                 answerInfoDto.getAnswer(),
                 memberId,

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -93,8 +93,7 @@ public class AnswerServiceImpl implements AnswerService {
 
     @Override
     public SliceResponse<AnswerInfo> getAnswerList(Long memberId, Long questionId, Pageable pageable) {
-        Slice<AnswerInfoInterface> answerInfoSliceInterface = answerRepository.findByQuestion(questionId, pageable).orElseThrow(()
-            -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND));
+        Slice<AnswerInfoInterface> answerInfoSliceInterface = answerRepository.findByQuestion(questionId, pageable);
         return SliceResponse.toSliceResponse(answerInfoSliceInterface, answerInfoSliceInterface.getContent().stream().map(
             answerInfoDto -> answerMapper.toAnswerInfo(
                 answerInfoDto.getAnswer(),

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -5,6 +5,7 @@ import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerLike;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.mapper.AnswerMapper;
@@ -110,12 +111,15 @@ public class AnswerServiceImpl implements AnswerService {
 
     // 유저가 작성한 답변 조회
     @Override
-    public MemberAnswerList getMemberAnswer(Member member) {
-        List<Answer> answers = answerRepository.findByMember(member).orElse(null);
-        return answerMapper.toMemberAnswerList(
-            answers.stream()
-                .map(answer -> answerMapper.toMemberAnswerInfo(answer, answerHeartRedisRepository.getAnswerHeartsCount(answer.getId()), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answer.getId())))
-                .toList()
+    public SliceResponse<MemberAnswerInfo> getMemberAnswer(Member member, Pageable pageable) {
+        Slice<Answer> answerSlice = answerRepository.findByMember(member, pageable);
+        return SliceResponse.toSliceResponse(
+            answerSlice, answerSlice.getContent().stream()
+                .map(answer -> answerMapper.toMemberAnswerInfo(
+                    answer,
+                    answerHeartRedisRepository.getAnswerHeartsCount(answer.getId()),
+                    answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answer.getId())
+                )).toList()
         );
     }
 

--- a/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
@@ -3,15 +3,18 @@ package com.server.capple.domain.question.controller;
 import com.server.capple.config.security.AuthMember;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
-import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfos;
+import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.service.QuestionService;
 import com.server.capple.global.common.BaseResponse;
+import com.server.capple.global.common.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "질문 API", description = "질문 관련 API")
@@ -24,7 +27,7 @@ public class QuestionController {
 
     @Operation(summary = "메인 질문 조회 API", description = "메인 질문을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+        @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping("/main")
     private BaseResponse<QuestionSummary> getMainQuestion(@AuthMember Member member) {
@@ -33,15 +36,15 @@ public class QuestionController {
 
     @Operation(summary = "모든 질문 조회 API", description = "모든 질문을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+        @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
     @GetMapping
-    private BaseResponse<QuestionInfos> getQuestions(@AuthMember Member member) {
-        return BaseResponse.onSuccess(questionService.getQuestions(member));
+    private BaseResponse<SliceResponse<QuestionInfo>> getQuestions(@AuthMember Member member, @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(questionService.getQuestions(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "질문 좋아요/취소 API", description = " 질문 좋아요/취소 API 입니다." +
-            "pathvariable 으로 questionId를 주세요.")
+        "pathvariable 으로 questionId를 주세요.")
     @PostMapping("/{questionId}/heart")
     public BaseResponse<QuestionResponse.QuestionToggleHeart> toggleBoardHeart(@AuthMember Member member, @PathVariable(value = "questionId") Long questionId) {
         return BaseResponse.onSuccess(questionService.toggleQuestionHeart(member, questionId));

--- a/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
@@ -40,7 +40,7 @@ public class QuestionController {
     })
     @GetMapping
     private BaseResponse<SliceResponse<QuestionInfo>> getQuestions(@AuthMember Member member, @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(questionService.getQuestions(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(questionService.getQuestions(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
     }
 
     @Operation(summary = "질문 좋아요/취소 API", description = " 질문 좋아요/취소 API 입니다." +

--- a/src/main/java/com/server/capple/domain/question/dto/response/QuestionResponse.java
+++ b/src/main/java/com/server/capple/domain/question/dto/response/QuestionResponse.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class QuestionResponse {
 
@@ -44,13 +43,6 @@ public class QuestionResponse {
     @Builder
     public static class QuestionId {
         private Long questionId;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @Builder
-    public static class QuestionInfos {
-        private List<QuestionInfo> questionInfos;
     }
 
     @Getter

--- a/src/main/java/com/server/capple/domain/question/mapper/QuestionMapper.java
+++ b/src/main/java/com/server/capple/domain/question/mapper/QuestionMapper.java
@@ -1,52 +1,59 @@
 package com.server.capple.domain.question.mapper;
 
+import com.server.capple.domain.question.dao.QuestionInfoInterface;
 import com.server.capple.domain.question.dto.request.QuestionRequest.QuestionCreate;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
-import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfos;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.entity.Question;
+import com.server.capple.global.common.SliceResponse;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 public class QuestionMapper {
 
     public Question toQuestion(QuestionCreate request) {
         return Question.builder()
-                .questionStatus(request.getQuestionStatus())
-                .content(request.getContent())
+            .questionStatus(request.getQuestionStatus())
+            .content(request.getContent())
 //                .commentCount(0)
-                .build();
+            .build();
     }
 
 
     public QuestionSummary toQuestionSummary(Question question, boolean isAnswered/*, Integer likeCount*/) {
         return QuestionSummary.builder()
-                .questionId(question.getId())
-                .questionStatus(question.getQuestionStatus())
-                .content(question.getContent())
-                .isAnswered(isAnswered)
+            .questionId(question.getId())
+            .questionStatus(question.getQuestionStatus())
+            .content(question.getContent())
+            .isAnswered(isAnswered)
 //                .likeCount(likeCount)
 //                .commentCount(question.getCommentCount())
-                .build();
+            .build();
     }
 
     public QuestionInfo toQuestionInfo(Question question, boolean isAnswered/*, Integer likeCount*/) {
         return QuestionInfo.builder()
-                .questionId(question.getId())
-                .questionStatus(question.getQuestionStatus())
-                .livedAt(question.getLivedAt())
-                .content(question.getContent())
+            .questionId(question.getId())
+            .questionStatus(question.getQuestionStatus())
+            .livedAt(question.getLivedAt())
+            .content(question.getContent())
 //                .likeCount(likeCount)
 //                .commentCount(question.getCommentCount())
-                .isAnswered(isAnswered)
-                .build();
+            .isAnswered(isAnswered)
+            .build();
     }
 
-    public QuestionInfos toQuestionInfos(List<QuestionInfo> questionInfoList) {
-        return QuestionInfos.builder()
-                .questionInfos(questionInfoList)
-                .build();
+    public SliceResponse<QuestionInfo> toSliceQuestionInfo(Slice<QuestionInfoInterface> questionSlice) {
+        return SliceResponse.<QuestionInfo>builder()
+            .number(questionSlice.getNumber())
+            .size(questionSlice.getSize())
+            .content(questionSlice.getContent().stream()
+                .map(questionInfoInterface -> toQuestionInfo(questionInfoInterface.getQuestion(), questionInfoInterface.getIsAnsweredByMember())
+                ).toList())
+            .numberOfElements(questionSlice.getNumberOfElements())
+            .hasPrevious(questionSlice.hasPrevious())
+            .hasNext(questionSlice.hasNext())
+            .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/question/mapper/QuestionMapper.java
+++ b/src/main/java/com/server/capple/domain/question/mapper/QuestionMapper.java
@@ -1,12 +1,9 @@
 package com.server.capple.domain.question.mapper;
 
-import com.server.capple.domain.question.dao.QuestionInfoInterface;
 import com.server.capple.domain.question.dto.request.QuestionRequest.QuestionCreate;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.entity.Question;
-import com.server.capple.global.common.SliceResponse;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -41,19 +38,6 @@ public class QuestionMapper {
 //                .likeCount(likeCount)
 //                .commentCount(question.getCommentCount())
             .isAnswered(isAnswered)
-            .build();
-    }
-
-    public SliceResponse<QuestionInfo> toSliceQuestionInfo(Slice<QuestionInfoInterface> questionSlice) {
-        return SliceResponse.<QuestionInfo>builder()
-            .number(questionSlice.getNumber())
-            .size(questionSlice.getSize())
-            .content(questionSlice.getContent().stream()
-                .map(questionInfoInterface -> toQuestionInfo(questionInfoInterface.getQuestion(), questionInfoInterface.getIsAnsweredByMember())
-                ).toList())
-            .numberOfElements(questionSlice.getNumberOfElements())
-            .hasPrevious(questionSlice.hasPrevious())
-            .hasNext(questionSlice.hasNext())
             .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -23,8 +23,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT q AS question, (a IS NOT NULL) AS isAnsweredByMember " +
         "FROM Question q LEFT JOIN Answer a ON q = a.question AND a.deletedAt is NULL AND a.member = :member " +
-        "WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' " +
-        "ORDER BY q.livedAt DESC")
+        "WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE'")
     Slice<QuestionInfoInterface> findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(@Param("member") Member member, Pageable pageable);
 
 }

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -3,17 +3,12 @@ package com.server.capple.domain.question.repository;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.dao.QuestionInfoInterface;
 import com.server.capple.domain.question.entity.Question;
-import com.server.capple.domain.question.entity.QuestionStatus;
 import io.lettuce.core.dynamic.annotation.Param;
-
-import java.util.List;
-
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Objects;
 import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
@@ -27,10 +22,10 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
 
     @Query("SELECT q AS question, (a IS NOT NULL) AS isAnsweredByMember " +
-            "FROM Question q LEFT JOIN Answer a ON q = a.question AND a.deletedAt is NULL AND a.member = :member " +
-            "WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' " +
-            "ORDER BY q.livedAt DESC")
-    List<QuestionInfoInterface> findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(@Param("member") Member member);
+        "FROM Question q LEFT JOIN Answer a ON q = a.question AND a.deletedAt is NULL AND a.member = :member " +
+        "WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE' " +
+        "ORDER BY q.livedAt DESC")
+    Slice<QuestionInfoInterface> findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(@Param("member") Member member, Pageable pageable);
 
 }
 

--- a/src/main/java/com/server/capple/domain/question/service/QuestionService.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionService.java
@@ -2,15 +2,17 @@ package com.server.capple.domain.question.service;
 
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
-import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfos;
+import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.entity.Question;
+import com.server.capple.global.common.SliceResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface QuestionService {
     Question findQuestion(Long questionId);
     QuestionSummary getMainQuestion(Member member);
 
-    QuestionInfos getQuestions(Member member);
+    SliceResponse<QuestionInfo> getQuestions(Member member, Pageable pageable);
 
     QuestionResponse.QuestionToggleHeart toggleQuestionHeart(Member member, Long questionId);
 }

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.question.service;
 
 import com.server.capple.domain.answer.repository.AnswerRepository;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.question.dao.QuestionInfoInterface;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
@@ -14,6 +15,7 @@ import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.QuestionErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +46,10 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public SliceResponse<QuestionInfo> getQuestions(Member member, Pageable pageable) {
-        return questionMapper.toSliceQuestionInfo(questionRepository.findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(member, pageable));
+        Slice<QuestionInfoInterface> questionSlice = questionRepository.findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(member, pageable);
+        return SliceResponse.toSliceResponse(questionSlice, questionSlice.getContent().stream()
+            .map(questionInfoInterface -> questionMapper.toQuestionInfo(questionInfoInterface.getQuestion(), questionInfoInterface.getIsAnsweredByMember())
+            ).toList());
     }
 
     @Override

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -1,23 +1,21 @@
 package com.server.capple.domain.question.service;
 
 import com.server.capple.domain.answer.repository.AnswerRepository;
-import com.server.capple.domain.answerComment.repository.AnswerCommentHeartRedisRepository;
 import com.server.capple.domain.member.entity.Member;
-import com.server.capple.domain.question.dao.QuestionInfoInterface;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
-import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfos;
+import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionSummary;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.mapper.QuestionMapper;
 import com.server.capple.domain.question.repository.QuestionHeartRedisRepository;
 import com.server.capple.domain.question.repository.QuestionRepository;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.QuestionErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,34 +25,26 @@ public class QuestionServiceImpl implements QuestionService {
     private final AnswerRepository answerRepository;
     private final QuestionMapper questionMapper;
     private final QuestionHeartRedisRepository questionHeartRepository;
-    private final AnswerCommentHeartRedisRepository answerCommentHeartRepository;
 
     @Override
     public Question findQuestion(Long questionId) {
         return questionRepository.findById(questionId).orElseThrow(()
-                -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND));
+            -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND));
     }
 
     @Override
     public QuestionSummary getMainQuestion(Member member) {
         Question mainQuestion = questionRepository.findByQuestionStatusIsLiveAndOldOrderByLivedAt()
-                .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         boolean isAnswered = answerRepository.existsByQuestionAndMember(mainQuestion, member);
 
-        return questionMapper.toQuestionSummary(mainQuestion, isAnswered/*, questionHeartRepository.getQuestionHeartsCount(mainQuestion.getId())*/);
+        return questionMapper.toQuestionSummary(mainQuestion, isAnswered);
     }
 
     @Override
-    public QuestionInfos getQuestions(Member member) {
-        List<QuestionInfoInterface> questions = questionRepository.findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(member);
-
-        return questionMapper.toQuestionInfos(questions.stream()
-                .map(questionInfo ->
-                        questionMapper.toQuestionInfo(questionInfo.getQuestion(),
-                                questionInfo.getIsAnsweredByMember()/*,
-                                questionHeartRepository.getQuestionHeartsCount(questionInfo.getQuestion().getId())*/)
-                ).toList());
+    public SliceResponse<QuestionInfo> getQuestions(Member member, Pageable pageable) {
+        return questionMapper.toSliceQuestionInfo(questionRepository.findAllByQuestionStatusIsLiveAndOldOrderByLivedAtDesc(member, pageable));
     }
 
     @Override

--- a/src/main/java/com/server/capple/global/common/SliceResponse.java
+++ b/src/main/java/com/server/capple/global/common/SliceResponse.java
@@ -35,4 +35,19 @@ public class SliceResponse<T> {
         this.hasPrevious = hasPrevious;
         this.hasNext = hasNext;
     }
+
+    /**
+     * P : 데이터베이스에서 반환 받은 데이터 타입<BR>
+     * R : 사용자게에 반환할 데이터 타입
+     */
+    public static <P, R> SliceResponse<R> toSliceResponse(Slice<P> sliceObject, List<R> content) {
+        return SliceResponse.<R>builder()
+            .number(sliceObject.getNumber())
+            .size(sliceObject.getSize())
+            .content(content)
+            .numberOfElements(sliceObject.getNumberOfElements())
+            .hasPrevious(sliceObject.hasPrevious())
+            .hasNext(sliceObject.hasNext())
+            .build();
+    }
 }

--- a/src/main/java/com/server/capple/global/common/SliceResponse.java
+++ b/src/main/java/com/server/capple/global/common/SliceResponse.java
@@ -1,5 +1,6 @@
 package com.server.capple.global.common;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -15,6 +16,7 @@ public class SliceResponse<T> {
     int numberOfElements;
     boolean hasPrevious;
     boolean hasNext;
+
     public SliceResponse(Slice<T> sliceObject) {
         number = sliceObject.getNumber();
         size = sliceObject.getSize();
@@ -22,5 +24,15 @@ public class SliceResponse<T> {
         numberOfElements = sliceObject.getNumberOfElements();
         hasPrevious = sliceObject.hasPrevious();
         hasNext = sliceObject.hasNext();
+    }
+
+    @Builder
+    public SliceResponse(int number, int size, List<T> content, int numberOfElements, boolean hasPrevious, boolean hasNext) {
+        this.number = number;
+        this.size = size;
+        this.content = content;
+        this.numberOfElements = numberOfElements;
+        this.hasPrevious = hasPrevious;
+        this.hasNext = hasNext;
     }
 }

--- a/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
@@ -2,14 +2,17 @@ package com.server.capple.domain.answer.controller;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.service.AnswerService;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.support.ControllerTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -135,8 +138,8 @@ public class AnswerControllerTest extends ControllerTestConfig {
     public void getMyPageMemberAnswerTest() throws Exception {
         //given
         final String url = "/answers";
-        AnswerResponse.MemberAnswerList response = getMemberAnswerList();
-        given(answerService.getMemberAnswer(any(Member.class))).willReturn(response);
+        SliceResponse<MemberAnswerInfo> response = getSliceMemberAnswerInfos();
+        given(answerService.getMemberAnswer(any(Member.class), any(PageRequest.class))).willReturn(response);
 
         //when
         ResultActions resultActions = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON)
@@ -150,7 +153,7 @@ public class AnswerControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.code").value("COMMON200"))
                 .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
 //                .andExpect(jsonPath("$.result.memberAnswerInfos[0].nickname").value("루시"))
-                .andExpect(jsonPath("$.result.memberAnswerInfos[0].content").value("나는 무자비한 사람이 좋아"));
+                .andExpect(jsonPath("$.result.content[0].content").value("나는 무자비한 사람이 좋아"));
     }
 
     @Test

--- a/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/server/capple/domain/answer/controller/AnswerControllerTest.java
@@ -161,8 +161,8 @@ public class AnswerControllerTest extends ControllerTestConfig {
     public void getMyPageMemberHeartAnswerTest() throws Exception {
         //given
         final String url = "/answers/heart";
-        AnswerResponse.MemberAnswerList response = getMemberAnswerList();
-        given(answerService.getMemberHeartAnswer(any(Member.class))).willReturn(response);
+        SliceResponse<MemberAnswerInfo> response = getSliceMemberAnswerInfos();
+        given(answerService.getMemberHeartAnswer(any(Member.class), any(PageRequest.class))).willReturn(response);
 
         //when
         ResultActions resultActions = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON)
@@ -175,7 +175,7 @@ public class AnswerControllerTest extends ControllerTestConfig {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("COMMON200"))
                 .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
-                .andExpect(jsonPath("$.result.memberAnswerInfos[0].heartCount").value(1))
-                .andExpect(jsonPath("$.result.memberAnswerInfos[0].answerId").value(1));
+                .andExpect(jsonPath("$.result.content[0].heartCount").value(1))
+                .andExpect(jsonPath("$.result.content[0].answerId").value(1));
     }
 }

--- a/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
@@ -2,14 +2,18 @@ package com.server.capple.domain.answer.service;
 
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.tag.service.TagService;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -121,9 +125,9 @@ public class AnswerServiceTest extends ServiceTestConfig {
     @Transactional
     public void getMemberAnswerTest() {
         //when
-        AnswerResponse.MemberAnswerList memberAnswer = answerService.getMemberAnswer(member);
+        SliceResponse<MemberAnswerInfo> memberAnswer = answerService.getMemberAnswer(member, PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "createdAt")));
         //then
-        assertEquals(memberAnswer.getMemberAnswerInfos().get(0).getContent(), "나는 무자비한 사람이 좋아");
+        assertEquals(memberAnswer.getContent().get(0).getContent(), "나는 무자비한 사람이 좋아");
     }
 
     @Test

--- a/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
@@ -138,9 +138,9 @@ public class AnswerServiceTest extends ServiceTestConfig {
         answerService.toggleAnswerHeart(member, answer.getId());
 
         //when
-        AnswerResponse.MemberAnswerList memberHeartAnswer = answerService.getMemberHeartAnswer(member);
+        SliceResponse<MemberAnswerInfo> memberHeartAnswer = answerService.getMemberHeartAnswer(member, PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "createdAt")));
 
         //then
-        assertEquals(memberHeartAnswer.getMemberAnswerInfos().get(0).getHeartCount(), 1);
+        assertEquals(memberHeartAnswer.getContent().get(0).getHeartCount(), 1);
     }
 }

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -56,7 +56,7 @@ public class QuestionServiceTest extends ServiceTestConfig {
     @Transactional
     public void getQuestionsTest() {
         //given & when
-        List<QuestionInfo> questionInfos = questionService.getQuestions(member, PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
+        List<QuestionInfo> questionInfos = questionService.getQuestions(member, PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "livedAt"))).getContent();
 
         //then
         assertEquals(questionInfos.size(), 2);

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -8,6 +8,8 @@ import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -54,7 +56,7 @@ public class QuestionServiceTest extends ServiceTestConfig {
     @Transactional
     public void getQuestionsTest() {
         //given & when
-        List<QuestionInfo> questionInfos = questionService.getQuestions(member).getQuestionInfos();
+        List<QuestionInfo> questionInfos = questionService.getQuestions(member, PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
 
         //then
         assertEquals(questionInfos.size(), 2);

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -5,11 +5,12 @@ import com.server.capple.config.security.auth.CustomUserDetails;
 import com.server.capple.config.security.auth.service.JpaUserDetailService;
 import com.server.capple.config.security.jwt.service.JwtService;
 import com.server.capple.domain.answer.dto.AnswerRequest;
-import com.server.capple.domain.answer.dto.AnswerResponse;
+import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answerComment.dto.AnswerCommentRequest;
-import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.*;
+import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.AnswerCommentInfo;
+import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.AnswerCommentInfos;
 import com.server.capple.domain.boardComment.dto.BoardCommentRequest;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfos;
@@ -17,6 +18,7 @@ import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
+import com.server.capple.global.common.SliceResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -60,14 +62,14 @@ public abstract class ControllerTestConfig {
 
     protected Member createMember() {
         return Member.builder()
-                .id(1L)
-                .role(Role.ROLE_ACADEMIER)
-                .sub("2384973284")
-                .email("tnals2384@gmail.com")
-                .profileImage("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png")
-                .email("ksm@naver.com")
-                .nickname("루시")
-                .build();
+            .id(1L)
+            .role(Role.ROLE_ACADEMIER)
+            .sub("2384973284")
+            .email("tnals2384@gmail.com")
+            .profileImage("https://owori.s3.ap-northeast-2.amazonaws.com/story/capple_default_image_10635d7a-5f8c-4af2-b062-9a9420634eb3.png")
+            .email("ksm@naver.com")
+            .nickname("루시")
+            .build();
     }
 
     protected String createJwt(Member member) {
@@ -76,38 +78,58 @@ public abstract class ControllerTestConfig {
 
     protected Question createQuestion() {
         return Question.builder()
-                .id(1L)
-                .content("아카데미 러너 중 가장 마음에 드는 유형이 있나요?")
-                .questionStatus(QuestionStatus.LIVE)
-                .build();
+            .id(1L)
+            .content("아카데미 러너 중 가장 마음에 드는 유형이 있나요?")
+            .questionStatus(QuestionStatus.LIVE)
+            .build();
     }
 
     protected Answer createAnswer() {
         return Answer.builder()
-                .id(1L)
-                .content("나는 무자비한 사람이 좋아")
-                .question(question)
-                .member(member)
-                .build();
+            .id(1L)
+            .content("나는 무자비한 사람이 좋아")
+            .question(question)
+            .member(member)
+            .build();
     }
 
     protected AnswerRequest getAnswerRequest() {
         return AnswerRequest.builder()
-                .answer("나는 와플을 좋아하는 사람이 좋아")
-                .build();
+            .answer("나는 와플을 좋아하는 사람이 좋아")
+            .build();
     }
 
-    protected MemberAnswerList getMemberAnswerList () {
-        List<AnswerResponse.MemberAnswerInfo> memberAnswerInfos = List.of(AnswerResponse.MemberAnswerInfo.builder()
-                .questionId(answer.getQuestion().getId())
-                .answerId(answer.getId())
-                .writerId(member.getId())
-                .profileImage(answer.getMember().getProfileImage())
-                .content(answer.getContent())
-                .heartCount(1)
-                .build());
+    protected MemberAnswerList getMemberAnswerList() {
+        List<MemberAnswerInfo> memberAnswerInfos = List.of(MemberAnswerInfo.builder()
+            .questionId(answer.getQuestion().getId())
+            .answerId(answer.getId())
+            .writerId(member.getId())
+            .profileImage(answer.getMember().getProfileImage())
+            .content(answer.getContent())
+            .heartCount(1)
+            .build());
 
         return new MemberAnswerList(memberAnswerInfos);
+    }
+
+    protected SliceResponse<MemberAnswerInfo> getSliceMemberAnswerInfos() {
+        List<MemberAnswerInfo> memberAnswerInfos = List.of(MemberAnswerInfo.builder()
+            .questionId(answer.getQuestion().getId())
+            .answerId(answer.getId())
+            .writerId(member.getId())
+            .profileImage(answer.getMember().getProfileImage())
+            .content(answer.getContent())
+            .heartCount(1)
+            .build());
+
+        return SliceResponse.<MemberAnswerInfo>builder()
+            .number(0)
+            .size(1000)
+            .content(memberAnswerInfos)
+            .numberOfElements(1)
+            .hasPrevious(FALSE)
+            .hasNext(FALSE)
+            .build();
     }
 
     protected BoardCommentRequest getBoardCommentRequest() {
@@ -116,33 +138,33 @@ public abstract class ControllerTestConfig {
 
     protected BoardCommentInfos getBoardCommentInfos() {
         List<BoardCommentInfo> commentInfos =
-                List.of(BoardCommentInfo.builder()
-                        .boardCommentId(1L)
-                        .writerId(member.getId())
-                        .content("댓글")
-                        .createdAt(LocalDateTime.now())
-                        .heartCount(2)
-                        .isLiked(TRUE)
-                        .isReport(FALSE)
-                        .build());
+            List.of(BoardCommentInfo.builder()
+                .boardCommentId(1L)
+                .writerId(member.getId())
+                .content("댓글")
+                .createdAt(LocalDateTime.now())
+                .heartCount(2)
+                .isLiked(TRUE)
+                .isReport(FALSE)
+                .build());
 
         return new BoardCommentInfos(commentInfos);
     }
 
     protected AnswerCommentRequest getAnswerCommentRequest() {
         return AnswerCommentRequest.builder()
-                .answerComment("댓글이 잘 달렸으면 좋겠어 . .")
-                .build();
+            .answerComment("댓글이 잘 달렸으면 좋겠어 . .")
+            .build();
     }
 
-    protected AnswerCommentInfos getAnswerCommentInfos () {
+    protected AnswerCommentInfos getAnswerCommentInfos() {
         List<AnswerCommentInfo> answerCommentInfos = List.of(AnswerCommentInfo.builder()
-                .answerCommentId(1L)
-                .writerId(member.getId())
-                .content("댓글 1")
-                .createdAt(LocalDateTime.of(2022, 11, 1, 12, 02))
-                .heartCount(3L)
-                .build());
+            .answerCommentId(1L)
+            .writerId(member.getId())
+            .content("댓글 1")
+            .createdAt(LocalDateTime.of(2022, 11, 1, 12, 02))
+            .heartCount(3L)
+            .build());
 
         return new AnswerCommentInfos(answerCommentInfos);
     }

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -6,7 +6,6 @@ import com.server.capple.config.security.auth.service.JpaUserDetailService;
 import com.server.capple.config.security.jwt.service.JwtService;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
-import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerList;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answerComment.dto.AnswerCommentRequest;
 import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.AnswerCommentInfo;
@@ -97,19 +96,6 @@ public abstract class ControllerTestConfig {
         return AnswerRequest.builder()
             .answer("나는 와플을 좋아하는 사람이 좋아")
             .build();
-    }
-
-    protected MemberAnswerList getMemberAnswerList() {
-        List<MemberAnswerInfo> memberAnswerInfos = List.of(MemberAnswerInfo.builder()
-            .questionId(answer.getQuestion().getId())
-            .answerId(answer.getId())
-            .writerId(member.getId())
-            .profileImage(answer.getMember().getProfileImage())
-            .content(answer.getContent())
-            .heartCount(1)
-            .build());
-
-        return new MemberAnswerList(memberAnswerInfos);
     }
 
     protected SliceResponse<MemberAnswerInfo> getSliceMemberAnswerInfos() {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#159/questionAnswerPagination -> develop

### 변경 사항
- pagination 공통
  - Slice를 이용한 pagination을 적용하였습니다.
  - 요청 값으로 `pageNumber(오프셋; 기본 0)`, `pageSize(크기; 기본 1000)`를 비필수값으로 받습니다.
  - 기존의 리스트로 단건 response를 감싼 dto를 만들던 방식에서 Slice의 여러 데이터를 가진 반환 dto 템플릿을 만들어 적용했습니다.
    ```java
    class Slice<T> {
    int number; // 조회할 페이지의 위치
    int size; // 조회할 페이지의 크기 (요청한 크기)
    List<T> content; // 단건 조회 dto의 리스트 (변경 전의 result 반환값)
    int numberOfElements; // 실제 조회된 데이터의 개수
    boolean hasPrevious; // 앞선 페이지의 추가 데이터 유무
    boolean hasNext; // 이후의 페이지의 추가 데이터 유무
    }
    ```
  - 프론트 측에서의 pagination 도입의 연기에 따라 page의 size를 1000으로 기본값을 설정하여 기능이 구현되기 전에도 사용이 가능하도록 하였습니다.
- 질문 조회 API
- 질문에 대한 답변 조회 API
  - 질문에 대한 답변과 질문에 대한 답변 중의 키워드 검색이 함께 사용되던 것을 질문에 대한 답변 조회 단일 엔드포인트로 재구성하였습니다.
- 본인이 작성한 답변 조회 API
- 좋아요한 답변 조회 API
  - 기존의 stream 내에서 repository 메서드가 사용되어 하나의 요청에 좋아요한 개수만큼의 답변 조회 쿼리가 나가던 문제점을 `IN` 절을 사용하여 하나의 쿼리만 발생하도록 개선하였습니다.
  - 기존의 코드
    ```java
    public MemberAnswerList getMemberHeartAnswer(Member member) {
        return answerMapper.toMemberAnswerList(
                answerHeartRedisRepository.getMemberHeartsAnswer(member.getId())
                        .stream()
                        .map(answerId -> answerMapper.toMemberAnswerInfo(findAnswer((answerId)), answerHeartRedisRepository.getAnswerHeartsCount(answerId), answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answerId)))
                        .toList()
        );
    }
    ```
  - 변경된 코드
    ```java
    public SliceResponse<MemberAnswerInfo> getMemberHeartAnswer(Member member, Pageable pageable) {
        Slice<Answer> answerSlice = answerRepository.findByIdIn(answerHeartRedisRepository.getMemberHeartsAnswer(member.getId()), pageable);
        return SliceResponse.toSliceResponse(answerSlice, answerSlice.getContent().stream()
            .map(answer -> answerMapper.toMemberAnswerInfo(
                answer,
                answerHeartRedisRepository.getAnswerHeartsCount(answer.getId()),
                answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), answer.getId())
            )).toList()
        );
    }
    ```

- 최대한 검수했지만 제가 작성한 비즈니스 로직이 아니다보니 빠트린부분이 있을수도 있습니다. 보완점이 존재한다면 얘기해주세요!

### 테스트 결과
- 질문 조회 API
  ![image](https://github.com/user-attachments/assets/febf4a3d-d446-43d0-be6a-2d272bbf60f2)
- 질문에 대한 답변 조회 API
  - 테스트 코드가 존재하지 않음
  - Swagger로 작동을 확인했습니다.
- 본인이 작성한 답변 조회 API
  ![image](https://github.com/user-attachments/assets/c09ebbfb-749e-4349-b5ad-5a9d3d155b83)
  ![image](https://github.com/user-attachments/assets/53254bf0-77f7-49df-820f-2a652f28a910)
- 좋아요한 답변 조회 API
  ![image](https://github.com/user-attachments/assets/9479236d-efaa-48b4-9b05-6b4ad898bd5a)
  ![image](https://github.com/user-attachments/assets/ebba7efd-3060-4aae-8eca-48aa7fc178cd)