### PR TITLE
[LOG] logback 설정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <property name="INFO_LOG_FILE_NAME_PATTERN" value="./logs/qapple-info-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="ERROR_LOG_FILE_NAME_PATTERN" value="./logs/qapple-error-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="WARN_LOG_FILE_NAME_PATTERN" value="./logs/qapple-warn-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="DEBUG_LOG_FILE_NAME_PATTERN" value="./logs/qapple-debug-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="TRACE_LOG_FILE_NAME_PATTERN" value="./logs/qapple-trace-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+
+    <property name="INFO_LOG_PATTERN" value="%d{yy-MM-dd} %d{HH:mm:ss.SSS} %boldGreen(%+5p) ---  %magenta([%t]) %cyan(%logger) - %m%n"/>
+    <property name="ERROR_LOG_PATTERN" value="%d{yy-MM-dd} %d{HH:mm:ss.SSS} %boldRed(%+5p)  ---  %magenta([%t]) %cyan(%logger) - %m%n"/>
+    <property name="WARN_LOG_PATTERN" value="%d{yy-MM-dd} %d{HH:mm:ss.SSS} %boldYellow(%+5p) ---  %magenta([%t]) %cyan(%logger) - %m%n"/>
+    <property name="DEBUG_LOG_PATTERN" value="%d{yy-MM-dd} %d{HH:mm:ss.SSS} %boldBlue(%+5p) ---  %magenta([%t]) %cyan(%logger) - %m%n"/>
+    <property name="TRACE_LOG_PATTERN" value="%d{yy-MM-dd} %d{HH:mm:ss.SSS} %gray(%+5p) ---  %magenta([%t]) %cyan(%logger) - %m%n"/>
+
+    <property name="MAX_FILE_SIZE" value="10MB" />
+    <property name="TOTAL_SIZE" value="300MB" />
+    <property name="MAX_HISTORY" value="30" />
+
+    <appender name="INFO_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <Pattern>${INFO_LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+    <appender name="ERROR_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <Pattern>${ERROR_LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+    <appender name="WARN_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <Pattern>${WARN_LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+    <appender name="DEBUG_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <Pattern>${DEBUG_LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+    <appender name="TRACE_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>TRACE</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <Pattern>${TRACE_LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/qapple-info.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <pattern>${INFO_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${INFO_LOG_FILE_NAME_PATTERN}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+            <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
+            <totalSizeCap>${TOTAL_SIZE}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/qapple-error.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <pattern>${ERROR_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${ERROR_LOG_FILE_NAME_PATTERN}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+            <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
+            <totalSizeCap>${TOTAL_SIZE}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+    <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/qapple-warn.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <pattern>${WARN_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${WARN_LOG_FILE_NAME_PATTERN}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+            <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
+            <totalSizeCap>${TOTAL_SIZE}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+    <appender name="DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/qapple-debug.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <pattern>${DEBUG_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${DEBUG_LOG_FILE_NAME_PATTERN}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+            <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
+            <totalSizeCap>${TOTAL_SIZE}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+    <appender name="TRACE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/qapple-trace.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>TRACE</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <charset>utf8</charset>
+            <pattern>${TRACE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${TRACE_LOG_FILE_NAME_PATTERN}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+            <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
+            <totalSizeCap>${TOTAL_SIZE}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="DEBUG_CONSOLE"/>
+        <appender-ref ref="DEBUG_FILE"/>
+    </logger>
+
+    <logger name="org.springframework.security" level="DEBUG" additivity="false">
+        <appender-ref ref="DEBUG_CONSOLE"/>
+        <appender-ref ref="DEBUG_FILE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="INFO_CONSOLE"/>
+        <appender-ref ref="ERROR_CONSOLE"/>
+        <appender-ref ref="WARN_CONSOLE"/>
+        <appender-ref ref="DEBUG_CONSOLE"/>
+        <appender-ref ref="TRACE_CONSOLE"/>
+        <appender-ref ref="INFO_FILE"/>
+        <appender-ref ref="ERROR_FILE"/>
+        <appender-ref ref="WARN_FILE"/>
+        <appender-ref ref="DEBUG_FILE"/>
+        <appender-ref ref="TRACE_FILE"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -73,7 +73,7 @@
     </appender>
 
     <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./log/qapple-info.log</file>
+        <file>./logs/qapple-info.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>ACCEPT</onMatch>
@@ -91,7 +91,7 @@
         </rollingPolicy>
     </appender>
     <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./log/qapple-error.log</file>
+        <file>./logs/qapple-error.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <onMatch>ACCEPT</onMatch>
@@ -109,7 +109,7 @@
         </rollingPolicy>
     </appender>
     <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./log/qapple-warn.log</file>
+        <file>./logs/qapple-warn.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>
             <onMatch>ACCEPT</onMatch>
@@ -127,7 +127,7 @@
         </rollingPolicy>
     </appender>
     <appender name="DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./log/qapple-debug.log</file>
+        <file>./logs/qapple-debug.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>
             <onMatch>ACCEPT</onMatch>
@@ -145,7 +145,7 @@
         </rollingPolicy>
     </appender>
     <appender name="TRACE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./log/qapple-trace.log</file>
+        <file>./logs/qapple-trace.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>TRACE</level>
             <onMatch>ACCEPT</onMatch>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
-    <property name="INFO_LOG_FILE_NAME_PATTERN" value="./logs/qapple-info-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
-    <property name="ERROR_LOG_FILE_NAME_PATTERN" value="./logs/qapple-error-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
-    <property name="WARN_LOG_FILE_NAME_PATTERN" value="./logs/qapple-warn-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
-    <property name="DEBUG_LOG_FILE_NAME_PATTERN" value="./logs/qapple-debug-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
-    <property name="TRACE_LOG_FILE_NAME_PATTERN" value="./logs/qapple-trace-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="INFO_LOG_FILE_NAME_PATTERN" value="./logs/info/qapple-info-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="ERROR_LOG_FILE_NAME_PATTERN" value="./logs/error/qapple-error-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="WARN_LOG_FILE_NAME_PATTERN" value="./logs/warn/qapple-warn-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="DEBUG_LOG_FILE_NAME_PATTERN" value="./logs/debug/qapple-debug-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
+    <property name="TRACE_LOG_FILE_NAME_PATTERN" value="./logs/trace/qapple-trace-%d{yyyy-MM-dd, Asia/Seoul}.%i.log" />
 
     <property name="INFO_LOG_PATTERN" value="%d{yy-MM-dd} %d{HH:mm:ss.SSS} %boldGreen(%+5p) ---  %magenta([%t]) %cyan(%logger) - %m%n"/>
     <property name="ERROR_LOG_PATTERN" value="%d{yy-MM-dd} %d{HH:mm:ss.SSS} %boldRed(%+5p)  ---  %magenta([%t]) %cyan(%logger) - %m%n"/>


### PR DESCRIPTION

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 로그 설정
### 반영 브랜치
ex) feat/#161/log -> develop

### 변경 사항
로그 설정을 추가해서 파일에 각각 저장하도록 했습니다.
일단 AOP 적용하지 않은 관계로
hibernate sql과 security 로그는 DEBUG로 설정하여 보여지도록 했습니다.
<img width="1197" alt="스크린샷 2024-09-16 오후 7 19 41" src="https://github.com/user-attachments/assets/76953d59-ad11-44e7-9020-4a16070e3b7c">

이런식으로, API 요청 경로가 출력되고 SQL발생 시 출력됩니닷
AOP 적용은 어떤 걸 출력하면 좋을지 더 고민해보겠습니다....
좋은 의견 환영입니다... 어떻게 하면 좋을지 이야기해주세욤
