### PR TITLE
[FEAT] 질문 생성/종료 원격 알림 구현 및 알림 엔티티 구성방식 변경

### DIFF
--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.notifiaction.entity.NotificationType;
+import com.server.capple.domain.question.entity.Question;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -107,6 +108,50 @@ public class ApnsClientRequest {
                 .build();
             this.boardId = board.getId().toString();
             this.boardCommentId = boardComment.getId().toString();
+        }
+
+        @ToString
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class Aps {
+            private Alert alert;
+            private Integer badge;
+            @Schema(defaultValue = "default")
+            private String sound; // Library/Sounds 폴더 내의 파일 이름
+            @JsonProperty("thread-id")
+            private String threadId;
+
+            @ToString
+            @Getter
+            @Builder
+            @AllArgsConstructor
+            @NoArgsConstructor
+            public static class Alert {
+                private String title;
+                private String subtitle;
+                private String body;
+            }
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class QuestionNotificationBody {
+        private Aps aps;
+        private String questionId;
+        @Builder
+        public QuestionNotificationBody(NotificationType type, Question question) {
+            this.aps = Aps.builder().threadId("question")
+                .alert(Aps.Alert.builder()
+                    .title(type.getTitle())
+                    .subtitle(type.getContent().replace("\n", " "))
+                    .body(question.getContent())
+                    .build())
+                .build();
+            this.questionId = question.getId().toString();
         }
 
         @ToString

--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -147,7 +147,6 @@ public class ApnsClientRequest {
             this.aps = Aps.builder().threadId("question")
                 .alert(Aps.Alert.builder()
                     .title(type.getTitle())
-                    .subtitle(type.getContent().replace("\n", " "))
                     .body(question.getContent())
                     .build())
                 .build();

--- a/src/main/java/com/server/capple/config/apns/service/ApnsService.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsService.java
@@ -7,4 +7,5 @@ public interface ApnsService {
     <T> Boolean sendApns(T request, List<String> deviceTokenList);
     <T> Boolean sendApnsToMembers(T request, Long ... memberIds);
     <T> Boolean sendApnsToMembers(T request, List<Long> memberIdList);
+    <T> Boolean sendApnsToAllMembers(T request);
 }

--- a/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
@@ -58,7 +58,7 @@ public class ApnsServiceImpl implements ApnsService {
 
         deviceToken.parallelStream()
             .forEach(token -> {
-                if (token.isBlank()) return;
+                if (token == null || token.isBlank() || token.equals("string")) return;
                 tmpWebClient
                     .method(HttpMethod.POST)
                     .uri(token)

--- a/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
+++ b/src/main/java/com/server/capple/config/apns/service/ApnsServiceImpl.java
@@ -99,4 +99,9 @@ public class ApnsServiceImpl implements ApnsService {
     public <T> Boolean sendApnsToMembers(T request, List<Long> memberIdList) {
         return sendApns(request, deviceTokenRedisRepository.getDeviceTokens(memberIdList));
     }
+
+    @Override
+    public <T> Boolean sendApnsToAllMembers(T request) {
+        return sendApns(request, deviceTokenRedisRepository.getAllDeviceTokens());
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/DeviceTokenRedisRepository.java
@@ -30,6 +30,10 @@ public class DeviceTokenRedisRepository {
         return valueOperations.multiGet(keys.stream().map(key -> DEVICE_TOKEN_KEY + key.toString()).toList());
     }
 
+    public List<String> getAllDeviceTokens() {
+        return valueOperations.multiGet(redisTemplate.keys(DEVICE_TOKEN_KEY + "*"));
+    }
+
     public void deleteDeviceToken(Long memberId) {
         redisTemplate.delete(DEVICE_TOKEN_KEY + memberId.toString());
     }

--- a/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
@@ -26,6 +26,6 @@ public class NotificationController {
     @Operation(summary = "알림 리스트 조회 API", description = "API를 호출한 사용자가 받은 알림 리스트를 조회합니다. 알림은 최신순으로 정렬되어 반환됩니다.")
     @GetMapping
     public BaseResponse<SliceResponse<NotificationInfo>> getNotifications(@AuthMember Member member, @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(new SliceResponse<>(notificationService.getNotifications(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt")))));
+        return BaseResponse.onSuccess(notificationService.getNotifications(member, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
@@ -17,6 +17,7 @@ public class NotificationResponse {
         private String subtitle;
         private String content;
         private String boardId;
+        private String questionId;
         private String boardCommentId;
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
@@ -1,8 +1,5 @@
 package com.server.capple.domain.notifiaction.entity;
 
-import com.server.capple.domain.board.entity.Board;
-import com.server.capple.domain.boardComment.entity.BoardComment;
-import com.server.capple.domain.question.entity.Question;
 import com.server.capple.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,12 +14,8 @@ public class Notification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long memberId;
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Board board;
-    @ManyToOne(fetch = FetchType.LAZY)
-    private BoardComment boardComment;
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Question question;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private NotificationLog notificationLog;
     @Enumerated(EnumType.ORDINAL)
     private NotificationType type;
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
@@ -1,5 +1,8 @@
 package com.server.capple.domain.notifiaction.entity;
 
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.question.entity.Question;
 import com.server.capple.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,14 +16,13 @@ public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false)
     private Long memberId;
-    @Column(nullable = false)
-    private String title;
-    private String subtitle;
-    @Column(nullable = false)
-    private String content;
-    @Column(nullable = false)
-    private String boardId;
-    private String boardCommentId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Board board;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private BoardComment boardComment;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Question question;
+    @Enumerated(EnumType.ORDINAL)
+    private NotificationType type;
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationLog.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationLog.java
@@ -1,0 +1,24 @@
+package com.server.capple.domain.notifiaction.entity;
+
+import com.server.capple.global.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NotificationLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String subtitle;
+    private String body;
+    private Long boardId;
+    private Long boardCommentId;
+    private Long questionId;
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
     BOARD_HEART("누군가 내 게시글을 좋아했어요", null),
     BOARD_COMMENT("누군가 내 게시글에 댓글을 달았어요", null),
-    BAORD_COMMENT_DUPLCATE("누군가 나와 같은 게시글에 댓글을 달았아요", null),
+    BOARD_COMMENT_DUPLICATE("누군가 같은 게시글에 댓글을 달았어요", null),
     BOARD_COMMENT_HEART("누군가 내 댓글을 좋아했어요", null),
-    TODAY_QUESTION_PUBLISHED("오늘의 질문", "오늘의 질문이 준비 되었어요.\n지금 바로 답변해보세요."),
-    TODAY_QUESTION_CLOSED("오늘의 질문", "오늘의 질문 답변 시간이 마감되었어요.\n다른 러너들은 어떻게 답 했는지 확인해보세요."),
+    TODAY_QUESTION_PUBLISHED("오늘의 질문 준비 완료!", "오늘의 질문이 준비 되었어요.\n지금 바로 답변해보세요."),
+    TODAY_QUESTION_CLOSED("오늘의 질문 마감 알림", "오늘의 질문 답변 시간이 마감되었어요.\n다른 러너들은 어떻게 답 했는지 확인해보세요."),
     ;
     private final String title;
     private final String content;

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
@@ -6,13 +6,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-    BOARD_HEART("누군가 내 게시글을 좋아했어요", null),
-    BOARD_COMMENT("누군가 내 게시글에 댓글을 달았어요", null),
-    BOARD_COMMENT_DUPLICATE("누군가 같은 게시글에 댓글을 달았어요", null),
-    BOARD_COMMENT_HEART("누군가 내 댓글을 좋아했어요", null),
-    TODAY_QUESTION_PUBLISHED("오늘의 질문 준비 완료!", "오늘의 질문이 준비 되었어요.\n지금 바로 답변해보세요."),
-    TODAY_QUESTION_CLOSED("오늘의 질문 마감 알림", "오늘의 질문 답변 시간이 마감되었어요.\n다른 러너들은 어떻게 답 했는지 확인해보세요."),
+    BOARD_HEART("누군가 내 게시글을 좋아했어요"),
+    BOARD_COMMENT("누군가 내 게시글에 댓글을 달았어요"),
+    BOARD_COMMENT_DUPLICATE("누군가 같은 게시글에 댓글을 달았어요"),
+    BOARD_COMMENT_HEART("누군가 내 댓글을 좋아했어요"),
+    TODAY_QUESTION_PUBLISHED("오늘의 질문 준비 완료!"),
+    TODAY_QUESTION_CLOSED("오늘의 질문 답변 마감!"),
     ;
     private final String title;
-    private final String content;
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -1,28 +1,83 @@
 package com.server.capple.domain.notifiaction.mapper;
 
-import com.server.capple.config.apns.dto.ApnsClientRequest;
+import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.notifiaction.dto.NotificationResponse.NotificationInfo;
 import com.server.capple.domain.notifiaction.entity.Notification;
+import com.server.capple.domain.notifiaction.entity.NotificationType;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.global.common.SliceResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class NotificationMapper {
-    public Notification toNotification(Long memberId, ApnsClientRequest.BoardNotificationBody boardNotificationBody) {
+    public Notification toNotification(Long memberId, Board board, NotificationType type) {
         return Notification.builder()
             .memberId(memberId)
-            .title(boardNotificationBody.getAps().getAlert().getTitle())
-            .content(boardNotificationBody.getAps().getAlert().getBody())
-            .boardId(boardNotificationBody.getBoardId())
+            .board(board)
+            .type(type)
             .build();
     }
 
-    public Notification toNotification(Long memberId, ApnsClientRequest.BoardCommentNotificationBody boardCommentNotificationBody) {
+    public Notification toNotification(Long memberId, Board board, BoardComment boardComment, NotificationType type) {
         return Notification.builder()
             .memberId(memberId)
-            .title(boardCommentNotificationBody.getAps().getAlert().getTitle())
-            .subtitle(boardCommentNotificationBody.getAps().getAlert().getSubtitle())
-            .content(boardCommentNotificationBody.getAps().getAlert().getBody())
-            .boardId(boardCommentNotificationBody.getBoardId())
-            .boardCommentId(boardCommentNotificationBody.getBoardCommentId())
+            .board(board)
+            .boardComment(boardComment)
+            .type(type)
+            .build();
+    }
+
+    public Notification toNotification(Question question, NotificationType type) {
+        return Notification.builder()
+            .question(question)
+            .type(type)
+            .build();
+    }
+
+    public SliceResponse<NotificationInfo> toNotificationInfoSlice(Slice<Notification> notification) {
+        return SliceResponse.toSliceResponse(notification, notification.stream().map(this::toNotificationInfo).toList());
+    }
+
+    private NotificationInfo toNotificationInfo(Notification notification) {
+        return switch (notification.getType()) {
+            case BOARD_HEART -> toBoardNotificationInfo(notification);
+            case BOARD_COMMENT, BOARD_COMMENT_DUPLICATE, BOARD_COMMENT_HEART ->
+                toBoardCommentNotificationInfo(notification);
+            case TODAY_QUESTION_PUBLISHED, TODAY_QUESTION_CLOSED -> toQuestionNotificationInfo(notification);
+        };
+    }
+
+    private NotificationInfo toBoardNotificationInfo(Notification notification) {
+        return NotificationInfo.builder()
+            .title(notification.getType().getTitle())
+            .content(notification.getBoard().getContent())
+            .boardId(notification.getBoard().getId().toString())
+            .createdAt(notification.getCreatedAt())
+            .build();
+    }
+
+    private NotificationInfo toBoardCommentNotificationInfo(Notification notification) {
+        return NotificationInfo.builder()
+            .title(notification.getType().getTitle())
+            .subtitle(notification.getBoardComment().getContent())
+            .content(notification.getBoard().getContent())
+            .boardId(notification.getBoard().getId().toString())
+            .boardCommentId(notification.getBoardComment().getId().toString())
+            .createdAt(notification.getCreatedAt())
+            .build();
+    }
+
+    private NotificationInfo toQuestionNotificationInfo(Notification notification) {
+        return NotificationInfo.builder()
+            .title(notification.getType().getTitle())
+            .subtitle(notification.getType().getContent())
+            .content(notification.getQuestion().getContent())
+            .questionId(notification.getQuestion().getId().toString())
+            .createdAt(notification.getCreatedAt())
             .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -89,7 +89,6 @@ public class NotificationMapper {
     private NotificationInfo toQuestionNotificationInfo(Notification notification) {
         return NotificationInfo.builder()
             .title(notification.getType().getTitle())
-            .subtitle(notification.getType().getContent())
             .content(notification.getNotificationLog().getBody())
             .questionId(notification.getNotificationLog().getQuestionId().toString())
             .createdAt(notification.getCreatedAt())

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -4,6 +4,7 @@ import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.notifiaction.dto.NotificationResponse.NotificationInfo;
 import com.server.capple.domain.notifiaction.entity.Notification;
+import com.server.capple.domain.notifiaction.entity.NotificationLog;
 import com.server.capple.domain.notifiaction.entity.NotificationType;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.global.common.SliceResponse;
@@ -14,27 +15,41 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class NotificationMapper {
-    public Notification toNotification(Long memberId, Board board, NotificationType type) {
+    public Notification toNotification(Long memberId, NotificationLog notificationLog, NotificationType type) {
         return Notification.builder()
             .memberId(memberId)
-            .board(board)
+            .notificationLog(notificationLog)
             .type(type)
             .build();
     }
 
-    public Notification toNotification(Long memberId, Board board, BoardComment boardComment, NotificationType type) {
+    public Notification toNotification(NotificationLog notificationLog, NotificationType type) {
         return Notification.builder()
-            .memberId(memberId)
-            .board(board)
-            .boardComment(boardComment)
+            .notificationLog(notificationLog)
             .type(type)
             .build();
     }
 
-    public Notification toNotification(Question question, NotificationType type) {
-        return Notification.builder()
-            .question(question)
-            .type(type)
+    public NotificationLog toNotificationLog(Board board) {
+        return NotificationLog.builder()
+            .body(board.getContent())
+            .boardId(board.getId())
+            .build();
+    }
+
+    public NotificationLog toNotificationLog(Board board, BoardComment boardComment) {
+        return NotificationLog.builder()
+            .subtitle(boardComment.getContent())
+            .body(board.getContent())
+            .boardId(board.getId())
+            .boardCommentId(boardComment.getId())
+            .build();
+    }
+
+    public NotificationLog toNotificationLog(Question question) {
+        return NotificationLog.builder()
+            .body(question.getContent())
+            .questionId(question.getId())
             .build();
     }
 
@@ -54,8 +69,8 @@ public class NotificationMapper {
     private NotificationInfo toBoardNotificationInfo(Notification notification) {
         return NotificationInfo.builder()
             .title(notification.getType().getTitle())
-            .content(notification.getBoard().getContent())
-            .boardId(notification.getBoard().getId().toString())
+            .content(notification.getNotificationLog().getBody())
+            .boardId(notification.getNotificationLog().getBoardId().toString())
             .createdAt(notification.getCreatedAt())
             .build();
     }
@@ -63,10 +78,10 @@ public class NotificationMapper {
     private NotificationInfo toBoardCommentNotificationInfo(Notification notification) {
         return NotificationInfo.builder()
             .title(notification.getType().getTitle())
-            .subtitle(notification.getBoardComment().getContent())
-            .content(notification.getBoard().getContent())
-            .boardId(notification.getBoard().getId().toString())
-            .boardCommentId(notification.getBoardComment().getId().toString())
+            .subtitle(notification.getNotificationLog().getSubtitle())
+            .content(notification.getNotificationLog().getBody())
+            .boardId(notification.getNotificationLog().getBoardId().toString())
+            .boardCommentId(notification.getNotificationLog().getBoardCommentId().toString())
             .createdAt(notification.getCreatedAt())
             .build();
     }
@@ -75,8 +90,8 @@ public class NotificationMapper {
         return NotificationInfo.builder()
             .title(notification.getType().getTitle())
             .subtitle(notification.getType().getContent())
-            .content(notification.getQuestion().getContent())
-            .questionId(notification.getQuestion().getId().toString())
+            .content(notification.getNotificationLog().getBody())
+            .questionId(notification.getNotificationLog().getQuestionId().toString())
             .createdAt(notification.getCreatedAt())
             .build();
     }

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -4,10 +4,21 @@ import com.server.capple.domain.notifiaction.entity.Notification;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    <T> Slice<T> findByMemberId(Long memberId, Pageable pageable, Class<T> type);
+    @Query("select " +
+        "n " +
+        "from Notification n " +
+        "where " +
+        "n.memberId = :memberId " +
+        "OR " +
+        "n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_PUBLISHED " +
+        "OR " +
+        "n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_CLOSED"
+    )
+    Slice<Notification> findByMemberId(Long memberId, Pageable pageable);
     void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/scheduler/NotificationScheduler.java
@@ -15,7 +15,7 @@ public class NotificationScheduler {
     private final NotificationService notificationService;
     private final long NOTIFICATION_CACHE_WEEK = 1L;
 
-    @Scheduled(cron = "0 0 * * * *") //매 0분에
+    @Scheduled(cron = "0 0 * * * *") // 정각마다
     public void deleteNotifications() {
         LocalDateTime targetTime = LocalDateTime.now().minusWeeks(NOTIFICATION_CACHE_WEEK);
         notificationService.deleteNotificationsByCreatedAtBefore(targetTime);

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
@@ -4,8 +4,9 @@ import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.notifiaction.dto.NotificationResponse;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.global.common.SliceResponse;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 
@@ -13,6 +14,8 @@ public interface NotificationService {
     void sendBoardHeartNotification(Long actorId, Board board);
     void sendBoardCommentNotification(Long actorId, Board board, BoardComment boardComment);
     void sendBoardCommentHeartNotification(Long actorId, Board board, BoardComment boardComment);
-    Slice<NotificationResponse.NotificationInfo> getNotifications(Member member, Pageable pageable);
+    void sendLiveQuestionOpenNotification(Question question);
+    void sendLiveQuestionCloseNotification(Question question);
+    SliceResponse<NotificationResponse.NotificationInfo> getNotifications(Member member, Pageable pageable);
     void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime);
 }

--- a/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
@@ -1,5 +1,7 @@
 package com.server.capple.domain.question.scheduler;
 
+import com.server.capple.domain.notifiaction.service.NotificationService;
+import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.service.AdminQuestionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,17 +13,21 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class QuestionScheduler {
     private final AdminQuestionService adminQuestionService;
+    private final NotificationService notificationService;
 
     //초 분 시 일 월 요일
     @Scheduled(cron = "0 0 7,18 * * *") //매일 오전 7시에, 오후 6시에
     public void setLiveQuestion() {
-        adminQuestionService.setLiveQuestion();
+        Question question = adminQuestionService.setLiveQuestion();
+        notificationService.sendLiveQuestionOpenNotification(question);
         log.info("live question이 등록되었습니다.");
     }
 
     @Scheduled(cron = "0 0 1,14 * * *") //매일 오전 1시에, 오후 14시에
     public void closeLiveQuestion() {
         //question을 닫음
+        Question question = adminQuestionService.closeLiveQuestion();
+        notificationService.sendLiveQuestionCloseNotification(question);
         log.info("live question이 닫혔습니다.");
     }
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionService.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionService.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.question.service;
 
 import com.server.capple.domain.question.dto.request.QuestionRequest.QuestionCreate;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionId;
+import com.server.capple.domain.question.entity.Question;
 
 public interface AdminQuestionService {
 
@@ -9,7 +10,7 @@ public interface AdminQuestionService {
 
     QuestionId deleteQuestion(Long questionId);
 
-    QuestionId setLiveQuestion();
-    QuestionId closeLiveQuestion();
+    Question setLiveQuestion();
+    Question closeLiveQuestion();
 
 }

--- a/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/AdminQuestionServiceImpl.java
@@ -39,22 +39,22 @@ public class AdminQuestionServiceImpl implements AdminQuestionService {
     }
 
     @Transactional
-    public QuestionId setLiveQuestion() {
+    public Question setLiveQuestion() {
         Question newQuestion = adminQuestionRepository.findFirstByQuestionStatusOrderByIdAsc(QuestionStatus.PENDING)
                 .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_PENDING_NOT_FOUND));
 
         newQuestion.setQuestionStatus(QuestionStatus.LIVE);
 
-        return new QuestionId(newQuestion.getId());
+        return newQuestion;
 
     }
 
     @Transactional
-    public QuestionId closeLiveQuestion() {
+    public Question closeLiveQuestion() {
         Question question = adminQuestionRepository.findFirstByQuestionStatusOrderByIdAsc(QuestionStatus.LIVE)
                 .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_LIVE_NOT_FOUND));
         question.setQuestionStatus(QuestionStatus.OLD);
 
-        return new QuestionId(question.getId());
+        return question;
     }
 }

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -1,6 +1,5 @@
 package com.server.capple.domain.question.service;
 
-import com.server.capple.domain.question.dto.response.QuestionResponse;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
@@ -30,8 +29,8 @@ public class QuestionServiceTest extends ServiceTestConfig {
     @Transactional
     public void setLiveQuestionTest() {
         //given & when
-        QuestionResponse.QuestionId questionId = adminQuestionService.setLiveQuestion();
-        Question question = questionService.findQuestion(questionId.getQuestionId());
+        Long questionId = adminQuestionService.setLiveQuestion().getId();
+        Question question = questionService.findQuestion(questionId);
 
         //then
         assertEquals(question.getContent(), "가장 좋아하는 음식은 무엇인가요?");
@@ -43,8 +42,8 @@ public class QuestionServiceTest extends ServiceTestConfig {
     @Transactional
     public void closeLiveQuestionTest() {
         //given & when
-        QuestionResponse.QuestionId questionId = adminQuestionService.closeLiveQuestion();
-        Question question = questionService.findQuestion(questionId.getQuestionId());
+        Long questionId = adminQuestionService.closeLiveQuestion().getId();
+        Question question = questionService.findQuestion(questionId);
 
         //then
         assertEquals(question.getContent(), "아카데미 러너 중 가장 마음에 드는 유형이 있나요?");


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#173/questionNotification -> develop

### 변경 사항
- 질문 생성/종료 원격 알림 구현 및 알림 엔티티 구성방식 변경
  - 기존의 질문 생성, 종료 상태 변경 스케줄링 메서드에서 알림 메서드를 호출하여 구현했습니다.
    - 알림 엔티티의 중복 데이터를 저장하기 위해 하위 엔티티를 새로 생성하여 정규화 작업 진행했습니다.
    - `CascadeType.ALL` 옵션을 이용해 연관관계 매핑을 하여 부모 엔티티인 `Notification`이 생성, 삭제가 될 때 자식엔티티인 `NotificationLog`도 함께 적용되도록 하였습니다.
- 질문 생성시 프론트에게 보내지는 객체
```json
{
  "aps" : {
    "alert" : {
      "title" : "오늘의 질문 준비 완료!",
      "body" : "{질문 내용}"
    }
    "sound" : "default",
    "thread-id" : "question"
  },
  "questionId" : "{questionId}"
}
```
- 질문 종료시 프론트에게 보내지는 객체
```json
{
  "aps" : {
    "alert" : {
      "title" : "오늘의 질문 답변 마감!",
      "body" : "{질문 내용}"
    }
    "sound" : "default",
    "thread-id" : "question"
  },
  "questionId" : "{questionId}"
}
```
- 질문 부제목은 잘려나와서 기획측이랑 내용을 협의해야할거 같네요

### 테스트 결과
<img src="https://github.com/user-attachments/assets/0576df67-26e5-4ab7-ad56-a5c42b6f4ebd" width="180">
<img src="https://github.com/user-attachments/assets/b2002770-4b22-4517-912e-ad3527cc16df" width="180">
<img src="https://github.com/user-attachments/assets/cf84a168-a290-425e-a8fa-afbc24102670" width="180">
<img src="https://github.com/user-attachments/assets/34dd308f-de95-4fe7-a58f-0c7118e4fed5" width="180">
