### PR TITLE
[FIX] 질문별 조회시 답변 총 개수 반환 값 추가 및 lastIndex 생성 오류 수정

### DIFF
--- a/src/main/java/com/server/capple/config/RedisConfig.java
+++ b/src/main/java/com/server/capple/config/RedisConfig.java
@@ -54,6 +54,15 @@ public class RedisConfig {
     }
 
     @Bean
+    public CacheManager oneDayExpireCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofDays(1));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    }
+
+    @Bean
     public CacheManager apnsJwtCacheManager(RedisConnectionFactory redisCloudConnectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -28,4 +28,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, Long lastIndex, Pageable pageable);
 
     Slice<Answer> findByMemberAndIdIsLessThanEqual(@Param("member") Member member, Long lastIndex, Pageable pageable);
+
+    @Query("SELECT COUNT(a) FROM Answer a WHERE a.question.id = :questionId")
+    Integer getAnswerCountByQuestionId(Long questionId);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerCountService.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerCountService.java
@@ -1,0 +1,27 @@
+package com.server.capple.domain.answer.service;
+
+import com.server.capple.domain.answer.repository.AnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerCountService {
+    private final AnswerRepository answerRepository;
+
+    @Cacheable(value = "questionAnswer", key = "#questionId", cacheManager = "oneDayExpireCacheManager")
+    public Integer getQuestionAnswerCount(Long questionId) {
+        return answerRepository.getAnswerCountByQuestionId(questionId);
+    }
+
+    @Async
+    @CachePut(value = "questionAnswer", key = "#questionId", cacheManager = "oneDayExpireCacheManager")
+    public CompletableFuture<Integer> updateQuestionAnswerCount(Long questionId) {
+        return CompletableFuture.completedFuture(answerRepository.getAnswerCountByQuestionId(questionId));
+    }
+}

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -164,11 +164,15 @@ public class AnswerServiceImpl implements AnswerService {
     }
 
     private Long getLastIndexFromAnswerInfoInterface(Long lastIndex, Slice<AnswerInfoInterface> answerInfoSliceInterface) {
-        return (!answerInfoSliceInterface.getContent().isEmpty() && lastIndex == Long.MAX_VALUE) ? answerInfoSliceInterface.stream().map(AnswerInfoInterface::getAnswer).map(Answer::getId).max(Long::compareTo).get() : lastIndex;
+        if(answerInfoSliceInterface.hasContent() && lastIndex == Long.MAX_VALUE)
+            return answerInfoSliceInterface.stream().map(AnswerInfoInterface::getAnswer).map(Answer::getId).max(Long::compareTo).get();
+        return lastIndex;
     }
 
     private Long getLastIndexFromAnswer(Long lastIndex, Slice<Answer> answerSlice) {
-        return (!answerSlice.getContent().isEmpty() && lastIndex == Long.MAX_VALUE) ? answerSlice.stream().map(Answer::getId).max(Long::compareTo).get() : lastIndex;
+        if (answerSlice.hasContent() && lastIndex == Long.MAX_VALUE)
+            return answerSlice.stream().map(Answer::getId).max(Long::compareTo).get();
+        return lastIndex;
     }
 
     @Getter

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -158,10 +158,10 @@ public class AnswerServiceImpl implements AnswerService {
     }
 
     private Long getLastIndexFromAnswerInfoInterface(Long lastIndex, Slice<AnswerInfoInterface> answerInfoSliceInterface) {
-        return lastIndex == Long.MAX_VALUE ? answerInfoSliceInterface.stream().map(AnswerInfoInterface::getAnswer).map(Answer::getId).max(Long::compareTo).get() : lastIndex;
+        return (!answerInfoSliceInterface.getContent().isEmpty() && lastIndex == Long.MAX_VALUE) ? answerInfoSliceInterface.stream().map(AnswerInfoInterface::getAnswer).map(Answer::getId).max(Long::compareTo).get() : lastIndex;
     }
 
     private Long getLastIndexFromAnswer(Long lastIndex, Slice<Answer> answerSlice) {
-        return lastIndex == Long.MAX_VALUE ? answerSlice.stream().map(Answer::getId).max(Long::compareTo).get() : lastIndex;
+        return (!answerSlice.getContent().isEmpty() && lastIndex == Long.MAX_VALUE) ? answerSlice.stream().map(Answer::getId).max(Long::compareTo).get() : lastIndex;
     }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -126,6 +126,8 @@ public class BoardCommentServiceImpl implements BoardCommentService {
     }
 
     private Long getLastIndexFromBoardCommentInfoInterface(Long lastIndex, Slice<BoardCommentInfoInterface> sliceBoardCommentInfos) {
-        return (!sliceBoardCommentInfos.isEmpty() && lastIndex == Long.MAX_VALUE) ? sliceBoardCommentInfos.stream().map(BoardCommentInfoInterface::getBoardComment).map(BoardComment::getId).max(Long::compareTo).get() : lastIndex;
+        if(sliceBoardCommentInfos.hasContent() && lastIndex == Long.MAX_VALUE)
+            return sliceBoardCommentInfos.stream().map(BoardCommentInfoInterface::getBoardComment).map(BoardComment::getId).max(Long::compareTo).get();
+        return lastIndex;
     }
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -126,6 +126,6 @@ public class BoardCommentServiceImpl implements BoardCommentService {
     }
 
     private Long getLastIndexFromBoardCommentInfoInterface(Long lastIndex, Slice<BoardCommentInfoInterface> sliceBoardCommentInfos) {
-        return lastIndex == Long.MAX_VALUE ? sliceBoardCommentInfos.stream().map(BoardCommentInfoInterface::getBoardComment).map(BoardComment::getId).max(Long::compareTo).get() : lastIndex;
+        return (!sliceBoardCommentInfos.isEmpty() && lastIndex == Long.MAX_VALUE) ? sliceBoardCommentInfos.stream().map(BoardCommentInfoInterface::getBoardComment).map(BoardComment::getId).max(Long::compareTo).get() : lastIndex;
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -152,6 +152,6 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private Long getLastIndexFromNotification(Long lastIndex, Slice<Notification> notifications) {
-        return lastIndex == Long.MAX_VALUE ? notifications.stream().map(Notification::getId).max(Long::compareTo).get() : lastIndex;
+        return (!notifications.isEmpty() && lastIndex == Long.MAX_VALUE) ? notifications.stream().map(Notification::getId).max(Long::compareTo).get() : lastIndex;
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -152,6 +152,8 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private Long getLastIndexFromNotification(Long lastIndex, Slice<Notification> notifications) {
-        return (!notifications.isEmpty() && lastIndex == Long.MAX_VALUE) ? notifications.stream().map(Notification::getId).max(Long::compareTo).get() : lastIndex;
+        if(notifications.hasContent() && lastIndex == Long.MAX_VALUE)
+            return notifications.stream().map(Notification::getId).max(Long::compareTo).get();
+        return lastIndex;
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#199/getAnswerFix -> develop

### 변경 사항
- 질문별 조회시 답변 총 개수 반환 값 추가
  - 질문별 조회, 삭제, 생성 시 캐싱을 진행하여 반환값을 저장, 반환하도록 했습니다.
- 컨텐츠가 없을 시 반환할 lastIndex 생성 오류 수정
  - `Slice`로 레포지토리 메서드 반환값을 선언하고 stream을 통해 인덱스의 최대값을 가져오는 과정에서 list가 비어있더라도 데이터를 get 해오게 되어 Exception이 발생함

### 추가 개발 요구사항
- `/answers/question/{questionId}`
  - 자신이 쓴 답변인지 확인하기 위해 답변별로 글쓴이를 따로 조회하여 N+1 문제가 발생함
