### PR TITLE
[FIX] 노오프셋 페이징 기법으로 변경

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -35,17 +35,17 @@ public class AnswerController {
     }
 
     @Operation(summary = "질문에 대한 답변 조회 API", description = "특정 질문에 대한 답변리스트를 조회하는 API입니다."
-        + "pathVariable으로 questionId를 주세요.")
+        + "pathVariable으로 questionId를 주세요.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @GetMapping("/question/{questionId}")
     public BaseResponse<SliceResponse<AnswerInfo>> getAnswerList(
         @AuthMember Member member,
         @Parameter(description = "질문 식별자")
         @PathVariable(value = "questionId") Long questionId,
         @Parameter(description = "이전 조회의 마지막 index")
-        @RequestParam(required = false) Long threshold,
+        @RequestParam(required = false, name = "threshold") Long lastIndex,
         @Parameter(description = "조회할 페이지 크기")
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(answerService.getAnswerList(member.getId(), questionId, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(answerService.getAnswerList(member.getId(), questionId, lastIndex, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "답변 수정 API", description = " 답변 수정 API 입니다." +
@@ -70,25 +70,25 @@ public class AnswerController {
         return BaseResponse.onSuccess(answerService.toggleAnswerHeart(member, answerId));
     }
 
-    @Operation(summary = "작성한 답변 조회 API", description = " 작성한 답변 조회 API 입니다.")
+    @Operation(summary = "작성한 답변 조회 API", description = " 작성한 답변 조회 API 입니다.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @GetMapping
     public BaseResponse<SliceResponse<MemberAnswerInfo>> getMemberAnswer(
         @AuthMember Member member,
         @Parameter(description = "이전 조회의 마지막 index")
-        @RequestParam(required = false) Long threshold,
+        @RequestParam(required = false, name = "threshold") Long lastIndex,
         @Parameter(description = "조회할 페이지 크기")
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(answerService.getMemberAnswer(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(answerService.getMemberAnswer(member, lastIndex, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
-    @Operation(summary = "좋아한 답변 조회 API", description = " 좋아한 답변 조회 API 입니다.")
+    @Operation(summary = "좋아한 답변 조회 API", description = " 좋아한 답변 조회 API 입니다.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @GetMapping("/heart")
     public BaseResponse<SliceResponse<MemberAnswerInfo>> getMemberHeartAnswer(
         @AuthMember Member member,
         @Parameter(description = "이전 조회의 마지막 index")
-        @RequestParam(required = false) Long threshold,
+        @RequestParam(required = false, name = "threshold") Long lastIndex,
         @Parameter(description = "조회할 페이지 크기")
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(member, lastIndex, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/server/capple/domain/answer/controller/AnswerController.java
@@ -41,13 +41,11 @@ public class AnswerController {
         @AuthMember Member member,
         @Parameter(description = "질문 식별자")
         @PathVariable(value = "questionId") Long questionId,
-        @Parameter(description = "Pull to Refresh 후 마지막 index")
+        @Parameter(description = "이전 조회의 마지막 index")
         @RequestParam(required = false) Long threshold,
-        @Parameter(description = "조회할 페이지 번호<br>0부터 시작")
-        @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
         @Parameter(description = "조회할 페이지 크기")
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(answerService.getAnswerList(member.getId(), questionId, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(answerService.getAnswerList(member.getId(), questionId, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "답변 수정 API", description = " 답변 수정 API 입니다." +
@@ -76,25 +74,21 @@ public class AnswerController {
     @GetMapping
     public BaseResponse<SliceResponse<MemberAnswerInfo>> getMemberAnswer(
         @AuthMember Member member,
-        @Parameter(description = "Pull to Refresh 후 마지막 index")
+        @Parameter(description = "이전 조회의 마지막 index")
         @RequestParam(required = false) Long threshold,
-        @Parameter(description = "조회할 페이지 번호<br>0부터 시작")
-        @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
         @Parameter(description = "조회할 페이지 크기")
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(answerService.getMemberAnswer(member, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(answerService.getMemberAnswer(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "좋아한 답변 조회 API", description = " 좋아한 답변 조회 API 입니다.")
     @GetMapping("/heart")
     public BaseResponse<SliceResponse<MemberAnswerInfo>> getMemberHeartAnswer(
         @AuthMember Member member,
-        @Parameter(description = "Pull to Refresh 후 마지막 index")
+        @Parameter(description = "이전 조회의 마지막 index")
         @RequestParam(required = false) Long threshold,
-        @Parameter(description = "조회할 페이지 번호<br>0부터 시작")
-        @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
         @Parameter(description = "조회할 페이지 크기")
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(member, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(answerService.getMemberHeartAnswer(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -16,7 +16,8 @@ import java.util.Set;
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findById(Long answerId);
 
-    Slice<Answer> findByIdInAndIdIsLessThanEqual(Set<Long> answerIds, Long lastIndex, Pageable pageable);
+    @Query("SELECT a FROM Answer a WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.id IN :answerIds")
+    Slice<Answer> findByIdInAndIdIsLessThan(Set<Long> answerIds, Long lastIndex, Pageable pageable);
 
     boolean existsByQuestionAndMember(Question question, Member member);
 
@@ -24,10 +25,11 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         "FROM Answer a " +
         "LEFT JOIN " +
         "Report r ON r.answer = a " +
-        "WHERE a.id <= :lastIndex AND a.question.id = :questionId")
+        "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
     Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, Long lastIndex, Pageable pageable);
 
-    Slice<Answer> findByMemberAndIdIsLessThanEqual(@Param("member") Member member, Long lastIndex, Pageable pageable);
+    @Query("SELECT a FROM Answer a WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.member = :member")
+    Slice<Answer> findByMemberAndIdIsLessThan(@Param("member") Member member, Long lastIndex, Pageable pageable);
 
     @Query("SELECT COUNT(a) FROM Answer a WHERE a.question.id = :questionId")
     Integer getAnswerCountByQuestionId(Long questionId);

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -49,7 +49,7 @@ public class BoardController {
         return BaseResponse.onSuccess(boardService.updateBoard(member, request.getBoardId(), request.getContent()));
     }
 
-    @Operation(summary = "카테고리별 게시글 조회 with REDIS API(프론트 사용 X, 성능 테스트 용)", description = "카테고리별 게시글을 조회합니다.")
+    @Operation(summary = "카테고리별 게시글 조회 with REDIS API(프론트 사용 X, 성능 테스트 용)", description = "카테고리별 게시글을 조회합니다.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
@@ -58,13 +58,13 @@ public class BoardController {
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType,
             @Parameter(description = "이전 조회의 마지막 index")
-            @RequestParam(required = false) Long threshold,
+            @RequestParam(required = false, name = "threshold") Long lastIndex,
             @RequestParam(defaultValue = "1000", required = false) Integer pageSize
     ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRedis(member, boardType, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRedis(member, boardType, lastIndex, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
-    @Operation(summary = "카테고리별 게시글 조회", description = "카테고리별 게시글을 조회합니다.")
+    @Operation(summary = "카테고리별 게시글 조회", description = "카테고리별 게시글을 조회합니다.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
@@ -73,13 +73,13 @@ public class BoardController {
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType,
             @Parameter(description = "이전 조회의 마지막 index")
-            @RequestParam(required = false) Long threshold,
+            @RequestParam(required = false, name = "threshold") Long lastIndex,
             @RequestParam(defaultValue = "1000", required = false) Integer pageSize
     ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType, lastIndex, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
-    @Operation(summary = "게시글 검색 API", description = "게시글을 검색합니다. 자유게시판에서만 검색이 가능합니다.")
+    @Operation(summary = "게시글 검색 API", description = "게시글을 검색합니다. 자유게시판에서만 검색이 가능합니다.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
@@ -87,9 +87,9 @@ public class BoardController {
     public BaseResponse<SliceResponse<BoardInfo>> searchBoardsByKeyword(
             @AuthMember Member member, @RequestParam(name = "keyword") String keyword,
             @Parameter(description = "이전 조회의 마지막 index")
-            @RequestParam(required = false) Long threshold,
+            @RequestParam(required = false, name = "threshold") Long lastIndex,
             @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword, lastIndex, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
 

--- a/src/main/java/com/server/capple/domain/board/controller/BoardController.java
+++ b/src/main/java/com/server/capple/domain/board/controller/BoardController.java
@@ -57,11 +57,11 @@ public class BoardController {
     public BaseResponse<SliceResponse<BoardInfo>> getBoardsByBoardTypeWithRedis(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType,
-            @Parameter(description = "Pull to Refresh 후 마지막 index")
+            @Parameter(description = "이전 조회의 마지막 index")
             @RequestParam(required = false) Long threshold,
-            @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize
+            @RequestParam(defaultValue = "1000", required = false) Integer pageSize
     ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRedis(member, boardType, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardTypeWithRedis(member, boardType, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "카테고리별 게시글 조회", description = "카테고리별 게시글을 조회합니다.")
@@ -72,11 +72,11 @@ public class BoardController {
     public BaseResponse<SliceResponse<BoardInfo>> getBoardsByBoardType(
             @AuthMember Member member,
             @RequestParam(name = "boardType", required = false) BoardType boardType,
-            @Parameter(description = "Pull to Refresh 후 마지막 index")
+            @Parameter(description = "이전 조회의 마지막 index")
             @RequestParam(required = false) Long threshold,
-            @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize
+            @RequestParam(defaultValue = "1000", required = false) Integer pageSize
     ) {
-        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(boardService.getBoardsByBoardType(member, boardType, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
     @Operation(summary = "게시글 검색 API", description = "게시글을 검색합니다. 자유게시판에서만 검색이 가능합니다.")
@@ -86,11 +86,10 @@ public class BoardController {
     @GetMapping("/search")
     public BaseResponse<SliceResponse<BoardInfo>> searchBoardsByKeyword(
             @AuthMember Member member, @RequestParam(name = "keyword") String keyword,
-            @Parameter(description = "Pull to Refresh 후 마지막 index")
+            @Parameter(description = "이전 조회의 마지막 index")
             @RequestParam(required = false) Long threshold,
-            @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
             @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(boardService.searchBoardsByKeyword(member, keyword, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 
 

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -16,16 +16,16 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
-            "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND b.id <= :lastIndex")
-    Slice<BoardInfoInterface> findBoardInfosByMemberAndBoardTypeAndIdIsLessThanEqual(Member member, BoardType boardType, Long lastIndex, Pageable pageable);
+            "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND (b.id < :lastIndex OR :lastIndex IS NULL)")
+    Slice<BoardInfoInterface> findBoardInfosByMemberAndBoardTypeAndIdIsLessThan(Member member, BoardType boardType, Long lastIndex, Pageable pageable);
 
     @Query("SELECT DISTINCT b AS board, " +
             "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
-            "WHERE b.id <= :lastIndex AND b.content LIKE %:keyword% AND b.boardType = 0") //FREETYPE = 0
-    Slice<BoardInfoInterface> findBoardInfosByMemberAndKeywordAndIdIsLessThanEqual(Member member, String keyword, Long lastIndex, Pageable pageable);
+            "WHERE (b.id < :lastIndex OR :lastIndex IS NULL) AND b.content LIKE %:keyword% AND b.boardType = 0") //FREETYPE = 0
+    Slice<BoardInfoInterface> findBoardInfosByMemberAndKeywordAndIdIsLessThan(Member member, String keyword, Long lastIndex, Pageable pageable);
 
 
     @Query("SELECT b AS board, " +
@@ -40,8 +40,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT DISTINCT b AS board, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM Board b " +
-            "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND b.id <= :lastIndex")
-    Slice<BoardInfoInterface> findBoardInfosForRedisAndIdIsLessThanEqual(Member member, BoardType boardType, Long lastIndex, Pageable pageable);
+            "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND (b.id < :lastIndex OR :lastIndex IS NULL)")
+    Slice<BoardInfoInterface> findBoardInfosForRedisAndIdIsLessThan(Member member, BoardType boardType, Long lastIndex, Pageable pageable);
 
     @Query("SELECT COUNT(b) FROM Board b")
     Integer getBoardCount();

--- a/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
+++ b/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
@@ -57,11 +57,10 @@ public class BoardCommentController {
     @Operation(summary = "게시글 댓글 리스트 조회 API", description = " 게시글 댓글 리스트 조회 API 입니다. pathVariable 으로 boardId를 주세요.")
     @GetMapping("/{boardId}")
     public BaseResponse<SliceResponse<BoardCommentInfo>> getBoardCommentInfos(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId,
-                                                                              @Parameter(description = "Pull to Refresh 후 마지막 index")
+                                                                              @Parameter(description = "이전 조회의 마지막 index")
                                                                               @RequestParam(required = false) Long threshold,
-                                                                              @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
                                                                               @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId, threshold, PageRequest.of(pageNumber,pageSize, Sort.by(Sort.Direction.ASC, "createdAt"))));
+        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId, threshold, PageRequest.of(0,pageSize, Sort.by(Sort.Direction.ASC, "createdAt"))));
     }
 
 }

--- a/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
+++ b/src/main/java/com/server/capple/domain/boardComment/controller/BoardCommentController.java
@@ -54,13 +54,13 @@ public class BoardCommentController {
         return BaseResponse.onSuccess(boardCommentService.toggleBoardCommentHeart(member, commentId));
     }
 
-    @Operation(summary = "게시글 댓글 리스트 조회 API", description = " 게시글 댓글 리스트 조회 API 입니다. pathVariable 으로 boardId를 주세요.")
+    @Operation(summary = "게시글 댓글 리스트 조회 API", description = " 게시글 댓글 리스트 조회 API 입니다. pathVariable 으로 boardId를 주세요.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @GetMapping("/{boardId}")
     public BaseResponse<SliceResponse<BoardCommentInfo>> getBoardCommentInfos(@AuthMember Member member, @PathVariable(value = "boardId") Long boardId,
                                                                               @Parameter(description = "이전 조회의 마지막 index")
-                                                                              @RequestParam(required = false) Long threshold,
+                                                                              @RequestParam(required = false, name = "threshold") Long lastIndex,
                                                                               @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId, threshold, PageRequest.of(0,pageSize, Sort.by(Sort.Direction.ASC, "createdAt"))));
+        return BaseResponse.onSuccess(boardCommentService.getBoardCommentInfos(member,boardId, lastIndex, PageRequest.of(0,pageSize, Sort.by(Sort.Direction.ASC, "createdAt"))));
     }
 
 }

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
@@ -14,6 +14,6 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
             "(CASE WHEN bc.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
             "FROM BoardComment bc " +
             "LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment AND bch.member = :member " +
-            "WHERE bc.board.id = :boardId AND bc.id <= :lastIndex")
-    Slice<BoardCommentInfoInterface> findBoardCommentInfosByMemberAndBoardIdAndIdIsLessThanEqual(Member member, Long boardId, Long lastIndex, Pageable pageable);
+            "WHERE bc.board.id = :boardId AND (bc.id > :lastIndex OR :lastIndex IS NULL)")
+    Slice<BoardCommentInfoInterface> findBoardCommentInfosByMemberAndBoardIdAndIdIsGreaterThan(Member member, Long boardId, Long lastIndex, Pageable pageable);
 }

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -98,8 +98,8 @@ public class BoardCommentServiceImpl implements BoardCommentService {
 
     @Override
     public SliceResponse<BoardCommentInfo> getBoardCommentInfos(Member member, Long boardId, Long lastIndex, Pageable pageable) {
-        lastIndex = getLastIndex(lastIndex);
-        Slice<BoardCommentInfoInterface> sliceBoardCommentInfos = boardCommentRepository.findBoardCommentInfosByMemberAndBoardIdAndIdIsLessThanEqual(member, boardId, lastIndex, pageable);
+        Slice<BoardCommentInfoInterface> sliceBoardCommentInfos = boardCommentRepository.findBoardCommentInfosByMemberAndBoardIdAndIdIsGreaterThan(member, boardId, lastIndex, pageable);
+        lastIndex = getLastIndexFromBoardCommentInfoInterface(sliceBoardCommentInfos);
         return SliceResponse.toSliceResponse(sliceBoardCommentInfos, sliceBoardCommentInfos.getContent().stream().map(sliceBoardCommentInfo ->
                         boardCommentMapper.toBoardCommentInfo(
                                 sliceBoardCommentInfo.getBoardComment(),
@@ -120,13 +120,9 @@ public class BoardCommentServiceImpl implements BoardCommentService {
                 () -> new RestApiException(CommentErrorCode.COMMENT_NOT_FOUND));
     }
 
-    private Long getLastIndex(Long lastIndex) {
-        return lastIndex == null ? Long.MAX_VALUE : lastIndex;
-    }
-
-    private Long getLastIndexFromBoardCommentInfoInterface(Long lastIndex, Slice<BoardCommentInfoInterface> sliceBoardCommentInfos) {
-        if(sliceBoardCommentInfos.hasContent() && lastIndex == Long.MAX_VALUE)
+    private Long getLastIndexFromBoardCommentInfoInterface(Slice<BoardCommentInfoInterface> sliceBoardCommentInfos) {
+        if(sliceBoardCommentInfos.hasContent())
             return sliceBoardCommentInfos.stream().map(BoardCommentInfoInterface::getBoardComment).map(BoardComment::getId).max(Long::compareTo).get();
-        return lastIndex;
+        return Long.MAX_VALUE;
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
@@ -24,13 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
     private final NotificationService notificationService;
 
-    @Operation(summary = "알림 리스트 조회 API", description = "API를 호출한 사용자가 받은 알림 리스트를 조회합니다. 알림은 최신순으로 정렬되어 반환됩니다.")
+    @Operation(summary = "알림 리스트 조회 API", description = "API를 호출한 사용자가 받은 알림 리스트를 조회합니다. 알림은 최신순으로 정렬되어 반환됩니다.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @GetMapping
     public BaseResponse<SliceResponse<NotificationInfo>> getNotifications(
         @AuthMember Member member,
         @Parameter(description = "이전 조회의 마지막 index")
-        @RequestParam(required = false) Long threshold,
+        @RequestParam(required = false, name = "threshold") Long lastIndex,
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(notificationService.getNotifications(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        return BaseResponse.onSuccess(notificationService.getNotifications(member, lastIndex, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/controller/NotificationController.java
@@ -28,9 +28,9 @@ public class NotificationController {
     @GetMapping
     public BaseResponse<SliceResponse<NotificationInfo>> getNotifications(
         @AuthMember Member member,
-        @Parameter(description = "Pull to Refresh 후 마지막 index")
+        @Parameter(description = "이전 조회의 마지막 index")
         @RequestParam(required = false) Long threshold,
-        @RequestParam(defaultValue = "0", required = false) Integer pageNumber, @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
-        return BaseResponse.onSuccess(notificationService.getNotifications(member, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
+        @RequestParam(defaultValue = "1000", required = false) Integer pageSize) {
+        return BaseResponse.onSuccess(notificationService.getNotifications(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))));
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -13,7 +13,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         "n " +
         "from Notification n " +
         "where " +
-        "n.id <= :lastIndex AND " +
+        "(n.id < :lastIndex OR :lastIndex IS NULL) AND " +
         "(" +
         "n.memberId = :memberId " +
         "OR " +

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -135,9 +135,8 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public SliceResponse<NotificationInfo> getNotifications(Member member, Long lastIndex, Pageable pageable) {
-        lastIndex = getLastIndex(lastIndex);
         Slice<Notification> notifications = notificationRepository.findByMemberId(member.getId(), lastIndex, pageable);
-        lastIndex = getLastIndexFromNotification(lastIndex, notifications);
+        lastIndex = getLastIndexFromNotification(notifications);
         return notificationMapper.toNotificationInfoSlice(notifications, lastIndex);
     }
 
@@ -147,13 +146,9 @@ public class NotificationServiceImpl implements NotificationService {
         notificationRepository.deleteNotificationsByCreatedAtBefore(targetTime);
     }
 
-    private long getLastIndex(Long lastIndex) {
-        return lastIndex == null ? Long.MAX_VALUE : lastIndex;
-    }
-
-    private Long getLastIndexFromNotification(Long lastIndex, Slice<Notification> notifications) {
-        if(notifications.hasContent() && lastIndex == Long.MAX_VALUE)
-            return notifications.stream().map(Notification::getId).max(Long::compareTo).get();
-        return lastIndex;
+    private Long getLastIndexFromNotification(Slice<Notification> notifications) {
+        if(notifications.hasContent())
+            return notifications.stream().map(Notification::getId).min(Long::compareTo).get();
+        return -1L;
     }
 }

--- a/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
@@ -37,7 +37,7 @@ public class QuestionController {
         return BaseResponse.onSuccess(questionService.getMainQuestion(member));
     }
 
-    @Operation(summary = "모든 질문 조회 API", description = "모든 질문을 조회합니다.")
+    @Operation(summary = "모든 질문 조회 API", description = "모든 질문을 조회합니다.<BR>**첫 번째 조회 시 threshold를 비워 보내고, 이후 조회 시 앞선 조회의 반환값으로 받은 threshold를 보내주세요.**")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "COMMON200", description = "성공"),
     })
@@ -45,10 +45,10 @@ public class QuestionController {
     private BaseResponse<SliceResponse<QuestionInfo>> getQuestions(
         @AuthMember Member member,
         @Parameter(description = "이전 조회의 마지막 데이터의 시각")
-        @RequestParam(required = false) LocalDateTime threshold,
+        @RequestParam(required = false, name = "threshold") LocalDateTime lastDateTime,
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize
         ) {
-        return BaseResponse.onSuccess(questionService.getQuestions(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
+        return BaseResponse.onSuccess(questionService.getQuestions(member, lastDateTime, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
     }
 
     @Operation(summary = "질문 좋아요/취소 API", description = " 질문 좋아요/취소 API 입니다." +

--- a/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
@@ -44,12 +44,11 @@ public class QuestionController {
     @GetMapping
     private BaseResponse<SliceResponse<QuestionInfo>> getQuestions(
         @AuthMember Member member,
-        @Parameter(description = "최근의 Pull to Refresh 시각")
+        @Parameter(description = "이전 조회의 마지막 데이터의 시각")
         @RequestParam(required = false) LocalDateTime threshold,
-        @RequestParam(defaultValue = "0", required = false) Integer pageNumber,
         @RequestParam(defaultValue = "1000", required = false) Integer pageSize
         ) {
-        return BaseResponse.onSuccess(questionService.getQuestions(member, threshold, PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
+        return BaseResponse.onSuccess(questionService.getQuestions(member, threshold, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
     }
 
     @Operation(summary = "질문 좋아요/취소 API", description = " 질문 좋아요/취소 API 입니다." +

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -26,8 +26,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT q AS question, (a IS NOT NULL) AS isAnsweredByMember " +
         "FROM Question q LEFT JOIN Answer a ON q = a.question AND a.deletedAt is NULL AND a.member = :member " +
-        "WHERE (q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE') AND q.livedAt <= :thresholdDate")
-    Slice<QuestionInfoInterface> findAllByLivedAtBefore(@Param("member") Member member, @Param("thresholdDate") LocalDateTime thresholdDate, Pageable pageable);
+        "WHERE (q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE') AND q.livedAt < :thresholdDate")
+    Slice<QuestionInfoInterface> findQuestionsByLivedAtBefore(@Param("member") Member member, @Param("thresholdDate") LocalDateTime thresholdDate, Pageable pageable);
 
     @Query("SELECT COUNT(q) FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE'")
     Integer getLiveOrOldQuestionCount();

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -26,8 +26,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT q AS question, (a IS NOT NULL) AS isAnsweredByMember " +
         "FROM Question q LEFT JOIN Answer a ON q = a.question AND a.deletedAt is NULL AND a.member = :member " +
-        "WHERE (q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE') AND q.livedAt < :thresholdDate")
-    Slice<QuestionInfoInterface> findQuestionsByLivedAtBefore(@Param("member") Member member, @Param("thresholdDate") LocalDateTime thresholdDate, Pageable pageable);
+        "WHERE (q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE') AND q.livedAt < :lastDateTime")
+    Slice<QuestionInfoInterface> findQuestionsByLivedAtBefore(@Param("member") Member member, @Param("lastDateTime") LocalDateTime lastDateTime, Pageable pageable);
 
     @Query("SELECT COUNT(q) FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE'")
     Integer getLiveOrOldQuestionCount();

--- a/src/main/java/com/server/capple/domain/question/service/QuestionService.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionService.java
@@ -15,7 +15,7 @@ public interface QuestionService {
 
     QuestionSummary getMainQuestion(Member member);
 
-    SliceResponse<QuestionInfo> getQuestions(Member member, LocalDateTime thresholdDate, Pageable pageable);
+    SliceResponse<QuestionInfo> getQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable);
 
     QuestionResponse.QuestionToggleHeart toggleQuestionHeart(Member member, Long questionId);
 }

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -48,13 +48,13 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
-    public SliceResponse<QuestionInfo> getQuestions(Member member, LocalDateTime thresholdDate, Pageable pageable) {
-        thresholdDate = getThresholdDate(thresholdDate);
-        Slice<QuestionInfoInterface> questionSlice = questionRepository.findQuestionsByLivedAtBefore(member, thresholdDate, pageable);
-        thresholdDate = getThresholdDateFromQuestionInfoInterface(questionSlice);
+    public SliceResponse<QuestionInfo> getQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable) {
+        lastDateTime = getThresholdDate(lastDateTime);
+        Slice<QuestionInfoInterface> questionSlice = questionRepository.findQuestionsByLivedAtBefore(member, lastDateTime, pageable);
+        lastDateTime = getThresholdDateFromQuestionInfoInterface(questionSlice);
         return SliceResponse.toSliceResponse(questionSlice, questionSlice.getContent().stream()
             .map(questionInfoInterface -> questionMapper.toQuestionInfo(questionInfoInterface.getQuestion(), questionInfoInterface.getIsAnsweredByMember())
-            ).toList(), thresholdDate.toString(), questionCountService.getLiveOrOldQuestionCount());
+            ).toList(), lastDateTime.toString(), questionCountService.getLiveOrOldQuestionCount());
     }
 
     @Override

--- a/src/main/java/com/server/capple/global/common/SliceResponse.java
+++ b/src/main/java/com/server/capple/global/common/SliceResponse.java
@@ -11,31 +11,25 @@ import java.util.List;
 @NoArgsConstructor
 public class SliceResponse<T> {
     Integer total;
-    int number;
     int size;
     List<T> content;
     int numberOfElements;
     String threshold;
-    boolean hasPrevious;
     boolean hasNext;
 
     public SliceResponse(Slice<T> sliceObject) {
-        number = sliceObject.getNumber();
         size = sliceObject.getSize();
         content = sliceObject.getContent();
         numberOfElements = sliceObject.getNumberOfElements();
-        hasPrevious = sliceObject.hasPrevious();
         hasNext = sliceObject.hasNext();
     }
 
     @Builder
-    public SliceResponse(int number, int size, List<T> content, int numberOfElements, String threshold, boolean hasPrevious, boolean hasNext, Integer total) {
-        this.number = number;
+    public SliceResponse(int size, List<T> content, int numberOfElements, String threshold, boolean hasNext, Integer total) {
         this.size = size;
         this.content = content;
         this.numberOfElements = numberOfElements;
         this.threshold = threshold;
-        this.hasPrevious = hasPrevious;
         this.hasNext = hasNext;
         this.total = total;
     }
@@ -46,12 +40,10 @@ public class SliceResponse<T> {
      */
     public static <P, R> SliceResponse<R> toSliceResponse(Slice<P> sliceObject, List<R> content, String threshold, Integer total) {
         return SliceResponse.<R>builder()
-            .number(sliceObject.getNumber())
             .size(sliceObject.getSize())
             .content(content)
             .numberOfElements(sliceObject.getNumberOfElements())
             .threshold(threshold)
-            .hasPrevious(sliceObject.hasPrevious())
             .hasNext(sliceObject.hasNext())
             .total(total)
             .build();

--- a/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/controller/BoardCommentControllerTest.java
@@ -149,7 +149,6 @@ public class BoardCommentControllerTest extends ControllerTestConfig {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("COMMON200"))
                 .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
-                .andExpect(jsonPath("$.result.number").value(0))
                 .andExpect(jsonPath("$.result.size").value(10))
                 .andExpect(jsonPath("$.result.numberOfElements").value(1))
                 .andExpect(jsonPath("$.result.content[0].boardCommentId").value(1L))

--- a/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/boardComment/service/BoardCommentServiceTest.java
@@ -123,7 +123,6 @@ public class BoardCommentServiceTest extends ServiceTestConfig {
         assertEquals(0, response.getContent().get(0).getHeartCount());
         assertEquals(false, response.getContent().get(0).getIsLiked());
         assertEquals(true, response.getContent().get(0).getIsMine());
-        assertEquals(0, response.getNumber());
         assertEquals(10, response.getSize());
         assertEquals(1, response.getNumberOfElements());
     }

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -108,11 +108,9 @@ public abstract class ControllerTestConfig {
             .build());
 
         return SliceResponse.<MemberAnswerInfo>builder()
-            .number(0)
             .size(1000)
             .content(memberAnswerInfos)
             .numberOfElements(1)
-            .hasPrevious(FALSE)
             .hasNext(FALSE)
             .build();
     }
@@ -135,11 +133,9 @@ public abstract class ControllerTestConfig {
 
 
         return SliceResponse.<BoardCommentInfo>builder()
-                .number(0)
                 .size(10)
                 .content(commentInfos)
                 .numberOfElements(1)
-                .hasPrevious(false)
                 .hasNext(true)
                 .build();
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#208/noOffsetPagination -> develop

### 변경 사항
- 페이지네이션 방식을 노오프셋 페이징 기법으로 변경하였습니다. [No Offeset 이란](https://liltdevs.tistory.com/196)
- 기존의 방법의 컨텐츠 제한선을 둔 컨텐츠 고정 방식은 잘 쓰지 않는 방법이라 판단하였으며, 마지막으로 조회한 데이터의 마지막 인덱스를 이용한 페이지네이션 방식인 노오프셋 방식이 무한스크롤에서 더 적합하다고 판단하여 수정하게 되었습니다.
- 페이지네이션을 사용하는 API의 요청,반환값의 수정이 있습니다.
  - 요청값
    - `pageNumber` 제거 : 노오프셋 방식은 이전의 인덱스를 기준으로 다음 컨텐츠를 조회하는 방식으로 현재 페이지 위치가 필요하지 않게 되었습니다.
  - 반환값
    - `hasPrevious` 제거 : 노오프셋 방식과 무한 스크롤 방식의 특징상 앞선 데이터가 있는지는 중요하지 않아 제거하였습니다.
    - `number` 제거 : 요청값의 설명과 동일합니다.
- JPQL로 사용해도 되지만 Pageable을 이용하는 이유
  - JPA의 Slice를 사용하기 위해서는 Pageable 객체를 argument로 주어져야 한다는 조건이 있는것으로 파악하였습니다.
  - `Slice`를 써야하는 이유로는 다음의 컨텐츠가 존재하는지(`hasNext`), 실제로 불러와진 데이터가 몇개인지(`numberOfElements`)을 자바 코드로 작성하지 않고 반환받을 수 있다는점입니다.
- 수정된 페이지네이션 플로우는 다음과 같습니다.
```mermaid
sequenceDiagram
actor u as customer
participant c as client
participant s as server
u ->>+ c : Pull to Refresh
c ->>+ s : infiniteScroll API<br>with pageSize<br>without threshold
s ->>- c : API result<BR>with threshold, hasNext
c ->> c : save threshold per API

loop hasNext == true
u ->>+ c : Scroll
c ->>+ s : infiniteScroll API<br>with pageSize, threshold
s ->>- c : API result<BR>with threshold, hasNext
c ->> c : save threshold per API

break hasNext == false
c --> u : end of content
end
end
```

### 테스트 결과
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2a9bdba1-cff6-4004-99f4-43c3e812ef9d">
<BR>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/67361660-c94e-4dca-9d82-19ce5fee76ae">

