### PR TITLE
[REFACTOR] 답변 조회 N+1 문제 해결

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/dao/AnswerRDBDao.java
+++ b/src/main/java/com/server/capple/domain/answer/dao/AnswerRDBDao.java
@@ -6,5 +6,8 @@ public class AnswerRDBDao {
     public interface AnswerInfoInterface {
         public Answer getAnswer();
         public Boolean getIsReported();
+        public Long getWriterId();
+        public String getWriterProfileImage();
+        public String getWriterNickname();
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.answer.mapper;
 
+import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
@@ -7,8 +8,6 @@ import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 public class AnswerMapper {
@@ -20,17 +19,17 @@ public class AnswerMapper {
                 .build();
     }
 
-    public AnswerInfo toAnswerInfo(Answer answer, Long memberId, Boolean isReported, Boolean isLiked, Boolean isMine) {
+    public AnswerInfo toAnswerInfo(AnswerInfoInterface answerInfoDto, Long memberId, Boolean isLiked) {
         return AnswerInfo.builder()
-                .answerId(answer.getId())
-                .writerId(answer.getMember().getId())
-                .profileImage(answer.getMember().getProfileImage())
-                .nickname(answer.getMember().getNickname())
-                .content(answer.getContent())
-                .isMine(isMine)
-                .isReported(isReported)
+                .answerId(answerInfoDto.getAnswer().getId())
+                .writerId(answerInfoDto.getWriterId())
+                .profileImage(answerInfoDto.getWriterProfileImage())
+                .nickname(answerInfoDto.getWriterNickname())
+                .content(answerInfoDto.getAnswer().getContent())
+                .isMine(answerInfoDto.getWriterId().equals(memberId))
+                .isReported(answerInfoDto.getIsReported())
                 .isLiked(isLiked)
-                .writeAt(answer.getCreatedAt().toString())
+                .writeAt(answerInfoDto.getAnswer().getCreatedAt().toString())
                 .build();
     }
 

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -20,7 +20,11 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     boolean existsByQuestionAndMember(Question question, Member member);
 
-    @Query("SELECT a AS answer, (r IS NOT NULL) AS isReported " +
+    @Query("SELECT a AS answer, " +
+        "(r IS NOT NULL) AS isReported, " +
+        "a.member.id AS writerId, " +
+        "a.member.profileImage AS writerProfileImage, " +
+        "a.member.nickname AS writerNickname "+
         "FROM Answer a " +
         "LEFT JOIN " +
         "Report r ON r.answer = a " +

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -104,11 +104,9 @@ public class AnswerServiceImpl implements AnswerService {
         lastIndex = getLastIndexFromAnswerInfoInterface(lastIndex, answerInfoSliceInterface);
         return SliceResponse.toSliceResponse(answerInfoSliceInterface, answerInfoSliceInterface.getContent().stream().map(
             answerInfoDto -> answerMapper.toAnswerInfo(
-                answerInfoDto.getAnswer(),
+                answerInfoDto,
                 memberId,
-                answerInfoDto.getIsReported(),
-                answerHeartRedisRepository.isMemberLikedAnswer(memberId, answerInfoDto.getAnswer().getId()),
-                answerInfoDto.getAnswer().getMember().getId().equals(memberId)
+                answerHeartRedisRepository.isMemberLikedAnswer(memberId, answerInfoDto.getAnswer().getId())
             )
         ).toList(), lastIndex.toString(), answerCountService.getQuestionAnswerCount(questionId));
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/#210/getAnswerN+1 -> develop

### 변경 사항
- 답변 조회 시 문제 글쓴이의 id, 프로필 이미지, 닉네임이 Member 엔티티와의 LAZY fetch 전략으로 인해 N+1 문제가 발생했습니다.
- `Projection`을 이용하여 한쿼리로 반환에 필요한 데이터만 join후 불러오도록 구현했습니다.

### 테스트 결과
변경 전 쿼리
```sql
select
    a1_0.id,
    a1_0.content,
    a1_0.created_at,
    a1_0.deleted_at,
    a1_0.member_id,
    a1_0.question_id,
    a1_0.updated_at,
    (r1_0.id is not null) 
from
    answer a1_0 
left join
    report r1_0 
        on r1_0.answer_id=a1_0.id 
where
    (
        a1_0.deleted_at is null
    ) 
    and a1_0.id<=? 
    and a1_0.question_id=? 
order by
    a1_0.created_at desc 
offset
    ? rows 
fetch
    first ? rows only
```
LAZY 전략으로 인한 N개의 추가 쿼리
```sql
select
  m1_0.member_id,
  m1_0.created_at,
  m1_0.deleted_at,
  m1_0.email,
  m1_0.nickname,
  m1_0.profile_image,
  m1_0.role,
  m1_0.sub,
  m1_0.updated_at 
from
  member m1_0 
where
  m1_0.member_id=?
```

변경 후 쿼리
```sql
select
    a1_0.id,
    a1_0.content,
    a1_0.created_at,
    a1_0.deleted_at,
    a1_0.member_id,
    a1_0.question_id,
    a1_0.updated_at,
    (r1_0.id is not null),
    m1_0.profile_image,
    m1_0.nickname 
from
    answer a1_0 
left join
    report r1_0 
        on r1_0.answer_id=a1_0.id 
left join
    member m1_0 
        on m1_0.member_id=a1_0.member_id 
where
    (
        a1_0.deleted_at is null
    ) 
    and a1_0.id<=? 
    and a1_0.question_id=? 
order by
    a1_0.created_at desc 
offset
    ? rows 
fetch
    first ? rows only
```
