### PR TITLE
[REFACTOR] 게시글 조회 N+1문제 해결

### DIFF
--- a/src/main/java/com/server/capple/domain/board/dao/BoardInfoInterface.java
+++ b/src/main/java/com/server/capple/domain/board/dao/BoardInfoInterface.java
@@ -6,4 +6,5 @@ public interface BoardInfoInterface {
     Board getBoard();
     Boolean getIsLike();
     Boolean getIsMine();
+    String getWriterNickname();
 }

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -21,11 +21,11 @@ public class BoardMapper {
     }
 
     //redis
-    public BoardInfo toBoardInfo(Board board, Integer boardHeartsCount, Boolean isLiked, Boolean isMine) {
+    public BoardInfo toBoardInfo(Board board, String writerNickname, Integer boardHeartsCount, Boolean isLiked, Boolean isMine) {
         return BoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
-                .writerNickname(board.getWriter().getNickname())
+                .writerNickname(writerNickname)
                 .content(board.getContent())
                 .heartCount(boardHeartsCount)
                 .commentCount(board.getCommentCount())
@@ -37,11 +37,11 @@ public class BoardMapper {
     }
 
     //rdb
-    public BoardInfo toBoardInfo(Board board, Boolean isLiked, Boolean isMine) {
+    public BoardInfo toBoardInfo(Board board, String writerNickname, Boolean isLiked, Boolean isMine) {
         return BoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
-                .writerNickname(board.getWriter().getNickname())
+                .writerNickname(writerNickname)
                 .content(board.getContent())
                 .heartCount(board.getHeartCount())
                 .commentCount(board.getCommentCount())

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -13,7 +13,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT DISTINCT b AS board, " +
             "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
-            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
+            "b.writer.nickname AS writerNickname " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
             "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND b.id <= :lastIndex")
@@ -21,7 +22,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT DISTINCT b AS board, " +
             "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
-            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
+            "b.writer.nickname AS writerNickname " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
             "WHERE b.id <= :lastIndex AND b.content LIKE %:keyword% AND b.boardType = 0") //FREETYPE = 0
@@ -30,7 +32,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT b AS board, " +
             "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
-            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
+            "b.writer.nickname AS writerNickname " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
             "WHERE b.id = :boardId")
@@ -38,7 +41,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     //redis 성능 테스트용
     @Query("SELECT DISTINCT b AS board, " +
-            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
+            "b.writer.nickname AS writerNickname " +
             "FROM Board b " +
             "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND b.id <= :lastIndex")
     Slice<BoardInfoInterface> findBoardInfosForRedisAndIdIsLessThanEqual(Member member, BoardType boardType, Long lastIndex, Pageable pageable);

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -67,6 +67,7 @@ public class BoardServiceImpl implements BoardService {
         return SliceResponse.toSliceResponse(sliceBoardInfos, sliceBoardInfos.getContent().stream().map(sliceBoardInfo ->
                         boardMapper.toBoardInfo(
                                 sliceBoardInfo.getBoard(),
+                                sliceBoardInfo.getWriterNickname(),
                                 sliceBoardInfo.getIsLike(),
                                 sliceBoardInfo.getIsMine()))
                 .toList(), lastIndex.toString(), boardCountService.getBoardCount()
@@ -81,6 +82,7 @@ public class BoardServiceImpl implements BoardService {
         return SliceResponse.toSliceResponse(sliceBoardInfos, sliceBoardInfos.getContent().stream().map(sliceBoardInfo ->
                         boardMapper.toBoardInfo(
                                 sliceBoardInfo.getBoard(),
+                                sliceBoardInfo.getWriterNickname(),
                                 sliceBoardInfo.getIsLike(),
                                 sliceBoardInfo.getIsMine()))
                 .toList(), lastIndex.toString(), null
@@ -100,6 +102,7 @@ public class BoardServiceImpl implements BoardService {
                     boolean isLiked = boardHeartRedisRepository.isMemberLikedBoard(member.getId(), sliceBoardInfo.getBoard().getId());
                     return boardMapper.toBoardInfo(
                             sliceBoardInfo.getBoard(),
+                            sliceBoardInfo.getWriterNickname(),
                             heartCount,
                             isLiked,
                             sliceBoardInfo.getIsMine());
@@ -113,6 +116,7 @@ public class BoardServiceImpl implements BoardService {
 
         return boardMapper.toBoardInfo(
                 boardInfo.getBoard(),
+                boardInfo.getWriterNickname(),
                 boardInfo.getIsLike(),
                 boardInfo.getIsMine()
         );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/#212/getBoardN+1 -> develop

### 변경 사항
- 게시글 조회 시 게시글의 글쓴이의 닉네임이 Member 엔티티와의 LAZY fetch 전략으로 인해 N+1 문제가 발생했습니다.
- Projection을 이용하여 한 쿼리로 반환에 필요한 데이터만 join후 불러오도록 구현했습니다.

### 테스트 결과
#### 변경 전 쿼리
```sql
select
    distinct b1_0.id,
    b1_0.board_type,
    b1_0.comment_count,
    b1_0.content,
    b1_0.created_at,
    b1_0.deleted_at,
    b1_0.heart_count,
    b1_0.is_report,
    b1_0.updated_at,
    b1_0.member_id,
    case 
        when bh1_0.is_liked=true 
            then true 
        else false 
    end,
    case 
        when b1_0.member_id=? 
            then true 
        else false 
    end 
from
    board b1_0 
left join
    board_heart bh1_0 
        on b1_0.id=bh1_0.board_id 
        and bh1_0.member_id=? 
where
    (
        b1_0.deleted_at is null
    ) 
    and (
        ? is null 
        or b1_0.board_type=?
    ) 
    and b1_0.id<=? 
order by
    b1_0.created_at desc 
offset
    ? rows 
fetch
    first ? rows only
```
LAZY fetch 전략으로 인해 추가적으로 발생하는 N개의 쿼리
```sql
select
    m1_0.member_id,
    m1_0.created_at,
    m1_0.deleted_at,
    m1_0.email,
    m1_0.nickname,
    m1_0.profile_image,
    m1_0.role,
    m1_0.sub,
    m1_0.updated_at 
from
    member m1_0 
where
    m1_0.member_id=?
```
#### 변경 후 쿼리
```sql
    select
        distinct b1_0.id,
        b1_0.board_type,
        b1_0.comment_count,
        b1_0.content,
        b1_0.created_at,
        b1_0.deleted_at,
        b1_0.heart_count,
        b1_0.is_report,
        b1_0.updated_at,
        b1_0.member_id,
        case 
            when bh1_0.is_liked=true 
                then true 
            else false 
        end,
        case 
            when b1_0.member_id=? 
                then true 
            else false 
        end,
        w1_0.nickname 
    from
        board b1_0 
    left join
        board_heart bh1_0 
            on b1_0.id=bh1_0.board_id 
            and bh1_0.member_id=? 
    left join
        member w1_0 
            on w1_0.member_id=b1_0.member_id 
    where
        (
            b1_0.deleted_at is null
        ) 
        and (
            ? is null 
            or b1_0.board_type=?
        ) 
        and b1_0.id<=? 
    order by
        b1_0.created_at desc 
    offset
        ? rows 
    fetch
        first ? rows only
```