### PR TITLE
[FIX] 알림 회원 연관관계 설정 및 가입 전 알림 조회 차단

### DIFF
--- a/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.notifiaction.entity;
 
+import com.server.capple.domain.member.entity.Member;
 import com.server.capple.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +14,9 @@ public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long memberId;
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private NotificationLog notificationLog;
     @Enumerated(EnumType.ORDINAL)

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -2,6 +2,7 @@ package com.server.capple.domain.notifiaction.mapper;
 
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.notifiaction.dto.NotificationResponse.NotificationInfo;
 import com.server.capple.domain.notifiaction.entity.Notification;
 import com.server.capple.domain.notifiaction.entity.NotificationLog;
@@ -15,9 +16,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class NotificationMapper {
-    public Notification toNotification(Long memberId, NotificationLog notificationLog, NotificationType type) {
+    public Notification toNotification(Member member, NotificationLog notificationLog, NotificationType type) {
         return Notification.builder()
-            .memberId(memberId)
+            .member(member)
             .notificationLog(notificationLog)
             .type(type)
             .build();

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.notifiaction.repository;
 
+import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.notifiaction.entity.Notification;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,13 +18,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         "where " +
         "(n.id < :lastIndex OR :lastIndex IS NULL) AND " +
         "(" +
-        "n.memberId = :memberId " +
+        "n.member = :member " +
         "OR " +
-        "n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_PUBLISHED " +
+        "((n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_PUBLISHED " +
         "OR " +
-        "n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_CLOSED" +
+        "n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_CLOSED) " +
+        "AND n.createdAt > (select m.createdAt from Member m where m = :member))" +
         ")"
     )
-    Slice<Notification> findByMemberId(Long memberId, Long lastIndex, Pageable pageable);
+    Slice<Notification> findByMemberId(Member member, Long lastIndex, Pageable pageable);
     void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#223/removeBeforeRegisterNoti -> develop

### 변경 사항
- 알림 회원 연관관계 설정
  - 식별번로로만 처리하던 알림을 수신한 회원의 정보를 연관관계를 추가해줬습니다.
- 가입 전 알림 조회 차단
  - 가입 전에 발생한 공통알림(오늘의 질문 시작/종료)이 보이던 오류를 서브쿼리를 이용해 생성일 기준으로 처리했습니다.