### PR TITLE
[HOTFIX] 질문, 댓글 원격 알림의 알림 사운드 설정

### DIFF
--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -117,8 +117,8 @@ public class ApnsClientRequest {
         public static class Aps {
             private Alert alert;
             private Integer badge;
-            @Schema(defaultValue = "default")
-            private String sound; // Library/Sounds 폴더 내의 파일 이름
+            @Builder.Default
+            private String sound = "default"; // Library/Sounds 폴더 내의 파일 이름
             @JsonProperty("thread-id")
             private String threadId;
 
@@ -160,8 +160,8 @@ public class ApnsClientRequest {
         public static class Aps {
             private Alert alert;
             private Integer badge;
-            @Schema(defaultValue = "default")
-            private String sound; // Library/Sounds 폴더 내의 파일 이름
+            @Builder.Default
+            private String sound = "default"; // Library/Sounds 폴더 내의 파일 이름
             @JsonProperty("thread-id")
             private String threadId;
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hotfix/#229/remoteNotiSoundless -> master

### 변경 사항
질문과 댓글 원격 알림이 알림 사운드가 발생하지 않던 버그를 수정했습니다.
- 기존의 컨트롤러를 통한 원격 알림 테스트시 사용하던 `@Schema(defaultValue = "default")` 를 통해 알림 사운드의 기본값을 지정하던 방식으로 인해 실제 서비스 구현에서 사용하는 `Builder` 패턴 방식의 기본값 설정법이 맞지 않아 사운드 값이 null로 전달되었습니다.
- `@Builder.Default` 를 이용해 기본 알림사운드를 설정하는 방식으로 완료했습니다.
