### PR TITLE
라이브 질문 시간 수정 및 횟수 변경

### DIFF
--- a/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/server/capple/domain/question/scheduler/QuestionScheduler.java
@@ -16,14 +16,14 @@ public class QuestionScheduler {
     private final NotificationService notificationService;
 
     //초 분 시 일 월 요일
-    @Scheduled(cron = "0 0 7,18 * * *") //매일 오전 7시에, 오후 6시에
+    @Scheduled(cron = "0 30 12 * * *") //매일 오후 12시 30분에
     public void setLiveQuestion() {
         Question question = adminQuestionService.setLiveQuestion();
         notificationService.sendLiveQuestionOpenNotification(question);
         log.info("live question이 등록되었습니다.");
     }
 
-    @Scheduled(cron = "0 0 1,14 * * *") //매일 오전 1시에, 오후 14시에
+    @Scheduled(cron = "59 59 23 * * *") //매일 오후 23시 59분 59초에
     public void closeLiveQuestion() {
         //question을 닫음
         Question question = adminQuestionService.closeLiveQuestion();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#235/questionPeriodChange -> develop

### 변경 사항
- 질문 횟수 변경 (2회 -> 1회)
- 질문 시간 변경 (open) 12:30 / (close) 23:59:59

### 테스트 결과
  ```java
    @Scheduled(cron = "0 30 12 * * *") //매일 오후 12시 30분에
    public void setLiveQuestion() {
        Question question = adminQuestionService.setLiveQuestion();
        notificationService.sendLiveQuestionOpenNotification(question);
        log.info("live question이 등록되었습니다.");
    }

    @Scheduled(cron = "59 59 23 * * *") //매일 오후 23시 59분 59초에
    public void closeLiveQuestion() {
        //question을 닫음
        Question question = adminQuestionService.closeLiveQuestion();
        notificationService.sendLiveQuestionCloseNotification(question);
        log.info("live question이 닫혔습니다.");
    }
```