### PR TITLE
[FEAT] 메일 주소기반 기수 필터링 기능

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/dao/AnswerRDBDao.java
+++ b/src/main/java/com/server/capple/domain/answer/dao/AnswerRDBDao.java
@@ -1,6 +1,9 @@
 package com.server.capple.domain.answer.dao;
 
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.AcademyGeneration;
+
+import java.util.Optional;
 
 public class AnswerRDBDao {
     public interface AnswerInfoInterface {
@@ -9,5 +12,11 @@ public class AnswerRDBDao {
         public Long getWriterId();
         public String getWriterProfileImage();
         public String getWriterNickname();
+        public Optional<AcademyGeneration> getWriterAcademyGeneration();
+    }
+
+    public interface MemberAnswerInfoDBDto {
+        public Answer getAnswer();
+        public Optional<AcademyGeneration> getWriterAcademyGeneration();
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/dto/AnswerResponse.java
+++ b/src/main/java/com/server/capple/domain/answer/dto/AnswerResponse.java
@@ -17,6 +17,7 @@ public class AnswerResponse {
         private Long writerId;
         private String profileImage;
         private String nickname;
+        private String writerGeneration;
         private String content;
         private Boolean isMine;
         private Boolean isReported;
@@ -40,6 +41,7 @@ public class AnswerResponse {
         private Long writerId;
         private String nickname;
         private String profileImage;
+        private String writerGeneration;
         private String content;
         private int heartCount;
         private String writeAt;

--- a/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
@@ -1,10 +1,12 @@
 package com.server.capple.domain.answer.mapper;
 
 import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
+import com.server.capple.domain.answer.dao.AnswerRDBDao.MemberAnswerInfoDBDto;
 import com.server.capple.domain.answer.dto.AnswerRequest;
 import com.server.capple.domain.answer.dto.AnswerResponse.AnswerInfo;
 import com.server.capple.domain.answer.dto.AnswerResponse.MemberAnswerInfo;
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.AcademyGeneration;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
 import org.springframework.stereotype.Component;
@@ -25,6 +27,7 @@ public class AnswerMapper {
                 .writerId(answerInfoDto.getWriterId())
                 .profileImage(answerInfoDto.getWriterProfileImage())
                 .nickname(answerInfoDto.getWriterNickname())
+                .writerGeneration(answerInfoDto.getWriterAcademyGeneration().orElse(AcademyGeneration.UNKNOWN).getGeneration())
                 .content(answerInfoDto.getAnswer().getContent())
                 .isMine(answerInfoDto.getWriterId().equals(memberId))
                 .isReported(answerInfoDto.getIsReported())
@@ -33,16 +36,17 @@ public class AnswerMapper {
                 .build();
     }
 
-    public MemberAnswerInfo toMemberAnswerInfo(Answer answer, int heartCount, Boolean isLiked) {
+    public MemberAnswerInfo toMemberAnswerInfo(MemberAnswerInfoDBDto memberAnswer, int heartCount, Boolean isLiked) {
         return MemberAnswerInfo.builder()
-                .questionId(answer.getQuestion().getId())
-                .answerId(answer.getId())
-                .writerId(answer.getMember().getId())
-                .nickname(answer.getMember().getNickname())
-                .profileImage(answer.getMember().getProfileImage())
-                .content(answer.getContent())
+                .questionId(memberAnswer.getAnswer().getQuestion().getId())
+                .answerId(memberAnswer.getAnswer().getId())
+                .writerId(memberAnswer.getAnswer().getMember().getId())
+                .nickname(memberAnswer.getAnswer().getMember().getNickname())
+                .profileImage(memberAnswer.getAnswer().getMember().getProfileImage())
+                .writerGeneration(memberAnswer.getWriterAcademyGeneration().orElse(AcademyGeneration.UNKNOWN).getGeneration())
+                .content(memberAnswer.getAnswer().getContent())
                 .heartCount(heartCount)
-                .writeAt(answer.getCreatedAt().toString())
+                .writeAt(memberAnswer.getAnswer().getCreatedAt().toString())
                 .isLiked(isLiked)
                 .build();
     }

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -1,6 +1,8 @@
 package com.server.capple.domain.answer.repository;
 
+import com.server.capple.domain.answer.dao.AnswerRDBDao;
 import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
+import com.server.capple.domain.answer.dao.AnswerRDBDao.MemberAnswerInfoDBDto;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.entity.Question;
@@ -16,8 +18,15 @@ import java.util.Set;
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findById(Long answerId);
 
-    @Query("SELECT a FROM Answer a WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.id IN :answerIds")
-    Slice<Answer> findByIdInAndIdIsLessThan(Set<Long> answerIds, Long lastIndex, Pageable pageable);
+    @Query("""
+        SELECT
+            a AS answer,
+            m.academyGeneration AS writerAcademyGeneration 
+        FROM Answer a
+        LEFT JOIN Member m ON a.member = m
+        WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.id IN :answerIds
+        """)
+    Slice<MemberAnswerInfoDBDto> findByIdInAndIdIsLessThan(Set<Long> answerIds, Long lastIndex, Pageable pageable);
 
     boolean existsByQuestionAndMember(Question question, Member member);
 
@@ -25,15 +34,23 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         "(r IS NOT NULL) AS isReported, " +
         "a.member.id AS writerId, " +
         "a.member.profileImage AS writerProfileImage, " +
-        "a.member.nickname AS writerNickname "+
+        "a.member.nickname AS writerNickname," +
+        "a.member.academyGeneration AS writerAcademyGeneration "+
         "FROM Answer a " +
         "LEFT JOIN " +
         "Report r ON r.answer = a " +
         "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
     Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, Long lastIndex, Pageable pageable);
 
-    @Query("SELECT a FROM Answer a WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.member = :member")
-    Slice<Answer> findByMemberAndIdIsLessThan(@Param("member") Member member, Long lastIndex, Pageable pageable);
+    @Query("""
+        SELECT
+            a AS answer,
+            m.academyGeneration AS writerAcademyGeneration
+        FROM Answer a
+        LEFT JOIN Member m ON a.member = m
+        WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.member = :member
+        """)
+    Slice<MemberAnswerInfoDBDto> findByMemberAndIdIsLessThan(@Param("member") Member member, Long lastIndex, Pageable pageable);
 
     @Query("SELECT COUNT(a) FROM Answer a WHERE a.question.id = :questionId")
     Integer getAnswerCountByQuestionId(Long questionId);

--- a/src/main/java/com/server/capple/domain/board/dao/BoardInfoInterface.java
+++ b/src/main/java/com/server/capple/domain/board/dao/BoardInfoInterface.java
@@ -1,10 +1,14 @@
 package com.server.capple.domain.board.dao;
 
 import com.server.capple.domain.board.entity.Board;
+import com.server.capple.domain.member.entity.AcademyGeneration;
+
+import java.util.Optional;
 
 public interface BoardInfoInterface {
     Board getBoard();
     Boolean getIsLike();
     Boolean getIsMine();
     String getWriterNickname();
+    Optional<AcademyGeneration> getWriterAcademyGeneration();
 }

--- a/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/server/capple/domain/board/dto/BoardResponse.java
@@ -22,6 +22,7 @@ public class BoardResponse {
         private Long boardId;
         private Long writerId;
         private String writerNickname;
+        private String writerGeneration;
         private String content;
         private Integer heartCount;
         private Integer commentCount;

--- a/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/server/capple/domain/board/mapper/BoardMapper.java
@@ -3,8 +3,11 @@ package com.server.capple.domain.board.mapper;
 import com.server.capple.domain.board.dto.BoardResponse.BoardInfo;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.board.entity.BoardType;
+import com.server.capple.domain.member.entity.AcademyGeneration;
 import com.server.capple.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 public class BoardMapper {
@@ -21,11 +24,12 @@ public class BoardMapper {
     }
 
     //redis
-    public BoardInfo toBoardInfo(Board board, String writerNickname, Integer boardHeartsCount, Boolean isLiked, Boolean isMine) {
+    public BoardInfo toBoardInfo(Board board, String writerNickname, Integer boardHeartsCount, Boolean isLiked, Boolean isMine, Optional<AcademyGeneration> writerAcademyGeneration) {
         return BoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
                 .writerNickname(writerNickname)
+                .writerGeneration(writerAcademyGeneration.orElse(AcademyGeneration.UNKNOWN).getGeneration())
                 .content(board.getContent())
                 .heartCount(boardHeartsCount)
                 .commentCount(board.getCommentCount())
@@ -37,11 +41,12 @@ public class BoardMapper {
     }
 
     //rdb
-    public BoardInfo toBoardInfo(Board board, String writerNickname, Boolean isLiked, Boolean isMine) {
+    public BoardInfo toBoardInfo(Board board, String writerNickname, Boolean isLiked, Boolean isMine, Optional<AcademyGeneration> writerAcademyGeneration) {
         return BoardInfo.builder()
                 .boardId(board.getId())
                 .writerId(board.getWriter().getId())
                 .writerNickname(writerNickname)
+                .writerGeneration(writerAcademyGeneration.orElse(AcademyGeneration.UNKNOWN).getGeneration())
                 .content(board.getContent())
                 .heartCount(board.getHeartCount())
                 .commentCount(board.getCommentCount())

--- a/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/capple/domain/board/repository/BoardRepository.java
@@ -14,7 +14,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT DISTINCT b AS board, " +
             "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
-            "b.writer.nickname AS writerNickname " +
+            "b.writer.nickname AS writerNickname, " +
+            "b.writer.academyGeneration AS writerAcademyGeneration " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
             "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND (b.id < :lastIndex OR :lastIndex IS NULL)")
@@ -23,7 +24,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT DISTINCT b AS board, " +
             "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
-            "b.writer.nickname AS writerNickname " +
+            "b.writer.nickname AS writerNickname, " +
+            "b.writer.academyGeneration AS writerAcademyGeneration " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
             "WHERE (b.id < :lastIndex OR :lastIndex IS NULL) AND b.content LIKE %:keyword% AND b.boardType = 0") //FREETYPE = 0
@@ -33,7 +35,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT b AS board, " +
             "(CASE WHEN bh.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
-            "b.writer.nickname AS writerNickname " +
+            "b.writer.nickname AS writerNickname, " +
+            "b.writer.academyGeneration AS writerAcademyGeneration " +
             "FROM Board b " +
             "LEFT JOIN BoardHeart bh ON b = bh.board AND bh.member = :member " +
             "WHERE b.id = :boardId")
@@ -42,7 +45,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     //redis 성능 테스트용
     @Query("SELECT DISTINCT b AS board, " +
             "(CASE WHEN b.writer = :member THEN TRUE ELSE FALSE END) AS isMine, " +
-            "b.writer.nickname AS writerNickname " +
+            "b.writer.nickname AS writerNickname, " +
+            "b.writer.academyGeneration AS writerAcademyGeneration " +
             "FROM Board b " +
             "WHERE (:boardType IS NULL OR b.boardType = :boardType) AND (b.id < :lastIndex OR :lastIndex IS NULL)")
     Slice<BoardInfoInterface> findBoardInfosForRedisAndIdIsLessThan(Member member, BoardType boardType, Long lastIndex, Pageable pageable);

--- a/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/board/service/BoardServiceImpl.java
@@ -68,7 +68,8 @@ public class BoardServiceImpl implements BoardService {
                                 sliceBoardInfo.getBoard(),
                                 sliceBoardInfo.getWriterNickname(),
                                 sliceBoardInfo.getIsLike(),
-                                sliceBoardInfo.getIsMine()))
+                                sliceBoardInfo.getIsMine(),
+                                sliceBoardInfo.getWriterAcademyGeneration()))
                 .toList(), lastIndex.toString(), boardCountService.getBoardCount()
         );
     }
@@ -82,7 +83,8 @@ public class BoardServiceImpl implements BoardService {
                                 sliceBoardInfo.getBoard(),
                                 sliceBoardInfo.getWriterNickname(),
                                 sliceBoardInfo.getIsLike(),
-                                sliceBoardInfo.getIsMine()))
+                                sliceBoardInfo.getIsMine(),
+                                sliceBoardInfo.getWriterAcademyGeneration()))
                 .toList(), lastIndex.toString(), null
         );
     }
@@ -102,7 +104,8 @@ public class BoardServiceImpl implements BoardService {
                             sliceBoardInfo.getWriterNickname(),
                             heartCount,
                             isLiked,
-                            sliceBoardInfo.getIsMine());
+                            sliceBoardInfo.getIsMine(),
+                            sliceBoardInfo.getWriterAcademyGeneration());
                 })
                 .toList(), lastIndex.toString(), boardCountService.getBoardCount());
     }
@@ -115,7 +118,8 @@ public class BoardServiceImpl implements BoardService {
                 boardInfo.getBoard(),
                 boardInfo.getWriterNickname(),
                 boardInfo.getIsLike(),
-                boardInfo.getIsMine()
+                boardInfo.getIsMine(),
+                boardInfo.getWriterAcademyGeneration()
         );
     }
 

--- a/src/main/java/com/server/capple/domain/boardComment/dao/BoardCommentInfoInterface.java
+++ b/src/main/java/com/server/capple/domain/boardComment/dao/BoardCommentInfoInterface.java
@@ -1,9 +1,13 @@
 package com.server.capple.domain.boardComment.dao;
 
 import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.member.entity.AcademyGeneration;
+
+import java.util.Optional;
 
 public interface BoardCommentInfoInterface {
     BoardComment getBoardComment();
     Boolean getIsLike();
     Boolean getIsMine();
+    Optional<AcademyGeneration> getWriterAcademyGeneration();
 }

--- a/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
+++ b/src/main/java/com/server/capple/domain/boardComment/dto/BoardCommentResponse.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class BoardCommentResponse {
 
@@ -27,6 +26,7 @@ public class BoardCommentResponse {
     public static class BoardCommentInfo {
         private Long boardCommentId;
         private Long writerId;
+        private String writerGeneration;
         private String content;
         private Integer heartCount;
         private Boolean isLiked;

--- a/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/boardComment/mapper/BoardCommentMapper.java
@@ -3,8 +3,11 @@ package com.server.capple.domain.boardComment.mapper;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.dto.BoardCommentResponse.BoardCommentInfo;
 import com.server.capple.domain.boardComment.entity.BoardComment;
+import com.server.capple.domain.member.entity.AcademyGeneration;
 import com.server.capple.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 public class BoardCommentMapper {
@@ -17,10 +20,11 @@ public class BoardCommentMapper {
                 .build();
     }
 
-    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked, Boolean isMine) {
+    public BoardCommentInfo toBoardCommentInfo(BoardComment comment, Boolean isLiked, Boolean isMine, Optional<AcademyGeneration> writerAcademyGeneration) {
         return BoardCommentInfo.builder()
                 .boardCommentId(comment.getId())
                 .writerId(comment.getWriter().getId())
+                .writerGeneration(writerAcademyGeneration.orElse(AcademyGeneration.UNKNOWN).getGeneration())
                 .content(comment.getContent())
                 .heartCount(comment.getHeartCount())
                 .isLiked(isLiked)

--- a/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/boardComment/repository/BoardCommentRepository.java
@@ -11,7 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
     @Query("SELECT bc AS boardComment, " +
             "(CASE WHEN bch.isLiked = TRUE THEN TRUE ELSE FALSE END) AS isLike, " +
-            "(CASE WHEN bc.writer = :member THEN TRUE ELSE FALSE END) AS isMine " +
+            "(CASE WHEN bc.writer = :member THEN TRUE ELSE FALSE END) AS isMine," +
+            "bc.writer.academyGeneration AS writerAcademyGeneration " +
             "FROM BoardComment bc " +
             "LEFT JOIN BoardCommentHeart bch ON bc = bch.boardComment AND bch.member = :member " +
             "WHERE bc.board.id = :boardId AND (bc.id > :lastIndex OR :lastIndex IS NULL)")

--- a/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/boardComment/service/BoardCommentServiceImpl.java
@@ -104,7 +104,8 @@ public class BoardCommentServiceImpl implements BoardCommentService {
                         boardCommentMapper.toBoardCommentInfo(
                                 sliceBoardCommentInfo.getBoardComment(),
                                 sliceBoardCommentInfo.getIsLike(),
-                                sliceBoardCommentInfo.getIsMine()))
+                                sliceBoardCommentInfo.getIsMine(),
+                                sliceBoardCommentInfo.getWriterAcademyGeneration()))
                 .toList(), lastIndex.toString(), null
         );
     }

--- a/src/main/java/com/server/capple/domain/member/entity/AcademyGeneration.java
+++ b/src/main/java/com/server/capple/domain/member/entity/AcademyGeneration.java
@@ -1,0 +1,28 @@
+package com.server.capple.domain.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@AllArgsConstructor
+public enum AcademyGeneration {
+    UNKNOWN("", -1),
+    GENERATION_1("1기", 22),
+    GENERATION_2("2기", 23),
+    GENERATION_3("3기", 24),
+    GENERATION_4("4기", 25),
+    GENERATION_5("5기", 26),
+    GENERATION_6("6기", 27),
+    ;
+    private final String generation;
+    private final Integer year;
+
+    private static final Map<Integer, AcademyGeneration> YEAR_TO_GENERATION = Stream.of(values()).collect(Collectors.toMap(AcademyGeneration::getYear, e -> e));
+    public static AcademyGeneration generation(Integer year) {
+        return YEAR_TO_GENERATION.getOrDefault(year, UNKNOWN);
+    }
+}

--- a/src/main/java/com/server/capple/domain/member/entity/Member.java
+++ b/src/main/java/com/server/capple/domain/member/entity/Member.java
@@ -31,6 +31,10 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column
+    @Enumerated(EnumType.STRING)
+    private AcademyGeneration academyGeneration;
+
     private String profileImage;
 
     public void updateNickname(String nickname) {

--- a/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/server/capple/domain/member/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.member.mapper;
 
 import com.server.capple.domain.member.dto.MemberResponse;
+import com.server.capple.domain.member.entity.AcademyGeneration;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.entity.Role;
 import org.springframework.stereotype.Component;
@@ -32,13 +33,14 @@ public class MemberMapper {
             .build();
     }
 
-    public Member createMember(String sub, String email, String nickName, Role role, String profileImage) {
+    public Member createMember(String sub, String email, String nickName, Role role, String profileImage, AcademyGeneration academyGeneration) {
         return Member.builder()
             .sub(sub)
             .nickname(nickName)
             .email(email)
             .role(role)
             .profileImage(profileImage)
+            .academyGeneration(academyGeneration)
             .build();
     }
 

--- a/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import com.server.capple.domain.mail.service.MailService;
 import com.server.capple.domain.mail.service.MailUtil;
 import com.server.capple.domain.member.dto.MemberRequest;
 import com.server.capple.domain.member.dto.MemberResponse;
+import com.server.capple.domain.member.entity.AcademyGeneration;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.member.mapper.MemberMapper;
@@ -118,7 +119,7 @@ public class MemberServiceImpl implements MemberService {
         String encryptedEmail = convertEmailToJwt(email);
 
         // TODO : 추후 profileImage 파라미터 수정 예정
-        Member member = memberMapper.createMember(sub, encryptedEmail, nickname, Role.ROLE_ACADEMIER, "");
+        Member member = memberMapper.createMember(sub, encryptedEmail, nickname, Role.ROLE_ACADEMIER, "", getGeneration(email));
         memberRepository.save(member);
         Long memberId = member.getId();
         String role = member.getRole().getName();
@@ -127,6 +128,15 @@ public class MemberServiceImpl implements MemberService {
         if(deviceToken != null)
             deviceTokenRedisRepository.saveDeviceToken(memberId, deviceToken);
         return tokensMapper.toTokens(accessToken, refreshToken);
+    }
+
+    protected AcademyGeneration getGeneration(String email) {
+        String nickname = email.split("@")[0];
+        try {
+            return AcademyGeneration.generation(Integer.parseInt(nickname.substring(nickname.length() - 2)));
+        } catch(NumberFormatException e) {
+            return AcademyGeneration.UNKNOWN;
+        }
     }
 
     @Override

--- a/src/test/java/com/server/capple/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/server/capple/domain/member/service/MemberServiceImplTest.java
@@ -1,0 +1,47 @@
+package com.server.capple.domain.member.service;
+
+import com.server.capple.domain.member.entity.AcademyGeneration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("MemberImpl 서비스의 ")
+@ActiveProfiles("test")
+@SpringBootTest
+class MemberServiceImplTest {
+    @Autowired
+    MemberServiceImpl memberServiceImpl;
+
+    @Test
+    @DisplayName("기수 반환 테스트")
+    void getActualGeneration() {
+        //given
+        String email = "test";
+        String domain = "@pos.idserve.net";
+
+        //when
+        AcademyGeneration generation_1 = memberServiceImpl.getGeneration(email + 22 + domain);
+        AcademyGeneration generation_2 = memberServiceImpl.getGeneration(email + 23 + domain);
+        AcademyGeneration generation_3 = memberServiceImpl.getGeneration(email + 24 + domain);
+        AcademyGeneration generation_4 = memberServiceImpl.getGeneration(email + 25 + domain);
+        AcademyGeneration generation_5 = memberServiceImpl.getGeneration(email + 26 + domain);
+        AcademyGeneration generation_6 = memberServiceImpl.getGeneration(email + 27 + domain);
+        AcademyGeneration generation_unknown = memberServiceImpl.getGeneration(email + domain);
+        AcademyGeneration generation_invalid = memberServiceImpl.getGeneration(email + 77 + domain);
+
+        //then
+        assertEquals(generation_1, AcademyGeneration.GENERATION_1);
+        assertEquals(generation_2, AcademyGeneration.GENERATION_2);
+        assertEquals(generation_3, AcademyGeneration.GENERATION_3);
+        assertEquals(generation_4, AcademyGeneration.GENERATION_4);
+        assertEquals(generation_5, AcademyGeneration.GENERATION_5);
+        assertEquals(generation_6, AcademyGeneration.GENERATION_6);
+        assertEquals(generation_unknown, AcademyGeneration.UNKNOWN);
+        assertEquals(generation_invalid, AcademyGeneration.UNKNOWN);
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#237/addAcademyGeneration -> develop

### 변경 사항
- 메일 주소 기반 기수 데이터 추가
  - 회원가입 시 메일 아이디의 어미의 두 글자 기준으로 기수를 결정하여 Member 테이블에 저장했습니다.
    - 24년도 -> 3기, 25년도 -> 4기
  - 기존의 회원의 데이터는 DB 로 직접 수정하여 3기로 일괄 수정할 예정이지만, 기수 정보가 `null` 일 경우에도 오류가 발생하지 않도록 기존의 Entity 객체로 반환받던 레포지토리 메서드를 인터페이스를 이용한 projection을 적용하여 Optional로 받을 수 있도록 하였습니다.
- 답변, 게시글, 게시글의 댓글의 작성자 데이터에 기수 정보를 추가 했습니다.
  - 다음 API 들의 반환값에 `writerGeneration`가 추가 되었습니다.
    - `GET /answers/question/{questionId}`
    - `GET /answers`
    - `GET /answers/heart`
    - `GET /boards`
    - `GET /boards/search`
    - `GET /boards/{boardId}`
    - `GET /board-comments/{boardId}`