### PR TITLE
[FEAT] 사용자별 답변 완료/미완료 질문 리스트 조회

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -1,6 +1,5 @@
 package com.server.capple.domain.answer.repository;
 
-import com.server.capple.domain.answer.dao.AnswerRDBDao;
 import com.server.capple.domain.answer.dao.AnswerRDBDao.AnswerInfoInterface;
 import com.server.capple.domain.answer.dao.AnswerRDBDao.MemberAnswerInfoDBDto;
 import com.server.capple.domain.answer.entity.Answer;
@@ -35,7 +34,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         "a.member.id AS writerId, " +
         "a.member.profileImage AS writerProfileImage, " +
         "a.member.nickname AS writerNickname," +
-        "a.member.academyGeneration AS writerAcademyGeneration "+
+        "a.member.academyGeneration AS writerAcademyGeneration " +
         "FROM Answer a " +
         "LEFT JOIN " +
         "Report r ON r.answer = a " +
@@ -54,4 +53,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     @Query("SELECT COUNT(a) FROM Answer a WHERE a.question.id = :questionId")
     Integer getAnswerCountByQuestionId(Long questionId);
+
+    @Query("SELECT COUNT(a.id) FROM Answer a WHERE a.member = :member")
+    Integer getAnswerCountByMember(Member member);
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerCountService.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerCountService.java
@@ -1,7 +1,9 @@
 package com.server.capple.domain.answer.service;
 
 import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Async;
@@ -24,4 +26,12 @@ public class AnswerCountService {
     public CompletableFuture<Integer> updateQuestionAnswerCount(Long questionId) {
         return CompletableFuture.completedFuture(answerRepository.getAnswerCountByQuestionId(questionId));
     }
+
+    @Cacheable(value = "answerCountByMember", key = "#member.id", cacheManager = "oneDayExpireCacheManager")
+    public Integer getAnswerCountByMember(Member member) {
+        return answerRepository.getAnswerCountByMember(member);
+    }
+
+    @CacheEvict(value = "answerCountByMember", key = "#member.id", cacheManager = "oneDayExpireCacheManager")
+    public void expireMembersAnsweredCount(Member member) {}
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -122,7 +122,7 @@ public class AnswerServiceImpl implements AnswerService {
                     memberAnswer,
                     answerHeartRedisRepository.getAnswerHeartsCount(memberAnswer.getAnswer().getId()),
                     answerHeartRedisRepository.isMemberLikedAnswer(member.getId(), memberAnswer.getAnswer().getId())
-                )).toList(), lastIndex.toString(), null
+                )).toList(), lastIndex.toString(), answerCountService.getAnswerCountByMember(member)
         );
     }
 

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -57,7 +57,7 @@ public class AnswerServiceImpl implements AnswerService {
         //답변 저장
         Answer answer = answerRepository.save(answerMapper.toAnswerEntity(request, member, question));
 //        answer.getQuestion().increaseCommentCount();
-        applicationEventPublisher.publishEvent(new QuestionAnswerCountChangedEvent(questionId));
+        applicationEventPublisher.publishEvent(new AnswerCountChangedEvent(questionId, loginMember));
         return new AnswerResponse.AnswerId(answer.getId());
     }
 
@@ -79,7 +79,7 @@ public class AnswerServiceImpl implements AnswerService {
     @Transactional
     public AnswerResponse.AnswerId deleteAnswer(Member loginMember, Long answerId) {
         Answer answer = findAnswer(answerId);
-        applicationEventPublisher.publishEvent(new QuestionAnswerCountChangedEvent(answer.getQuestion().getId()));
+        applicationEventPublisher.publishEvent(new AnswerCountChangedEvent(answer.getQuestion().getId(), loginMember));
 
         checkPermission(loginMember, answer);
 //        answer.getQuestion().decreaseCommentCount();
@@ -169,12 +169,14 @@ public class AnswerServiceImpl implements AnswerService {
 
     @Getter
     @AllArgsConstructor
-    static class QuestionAnswerCountChangedEvent {
+    static class AnswerCountChangedEvent {
         private Long questionId;
+        private Member member;
     }
 
-    @TransactionalEventListener(classes = QuestionAnswerCountChangedEvent.class, phase = TransactionPhase.AFTER_COMPLETION)
-    public void handleQuestionCreatedEvent(QuestionAnswerCountChangedEvent event) {
+    @TransactionalEventListener(classes = AnswerCountChangedEvent.class, phase = TransactionPhase.AFTER_COMPLETION)
+    public void handleQuestionCreatedEvent(AnswerCountChangedEvent event) {
         answerCountService.updateQuestionAnswerCount(event.getQuestionId());
+        answerCountService.expireMembersAnsweredCount(event.getMember());
     }
 }

--- a/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/server/capple/domain/question/controller/QuestionController.java
@@ -51,6 +51,28 @@ public class QuestionController {
         return BaseResponse.onSuccess(questionService.getQuestions(member, lastDateTime, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
     }
 
+    @Operation(summary = "사용자가 답변한 질문 리스트 조회")
+    @GetMapping("/answered")
+    public BaseResponse<SliceResponse<QuestionInfo>> getAnsweredQuestion(
+        @AuthMember Member member,
+        @Parameter(description = "이전 조회의 마지막 데이터의 시각")
+        @RequestParam(required = false, name = "threshold") LocalDateTime lastDateTime,
+        @RequestParam(defaultValue = "1000", required = false) Integer pageSize
+    ) {
+        return BaseResponse.onSuccess(questionService.getAnsweredQuestions(member, lastDateTime, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
+    }
+
+    @Operation(summary = "사용자가 답변하지 않은 질문 리스트 조회")
+    @GetMapping("/notAnswered")
+    public BaseResponse<SliceResponse<QuestionInfo>> getNotAnsweredQuestion(
+        @AuthMember Member member,
+        @Parameter(description = "이전 조회의 마지막 데이터의 시각")
+        @RequestParam(required = false, name = "threshold") LocalDateTime lastDateTime,
+        @RequestParam(defaultValue = "1000", required = false) Integer pageSize
+    ) {
+        return BaseResponse.onSuccess(questionService.getNotAnsweredQuestions(member, lastDateTime, PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))));
+    }
+
     @Operation(summary = "질문 좋아요/취소 API", description = " 질문 좋아요/취소 API 입니다." +
         "pathvariable 으로 questionId를 주세요.")
     @PostMapping("/{questionId}/heart")

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -38,6 +38,15 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
         """)
     Slice<QuestionInfoInterface> findAnswerdQuestionsByLivedAtBefore(@Param("member") Member member, @Param("lastDateTime") LocalDateTime lastDateTime, Pageable pageable);
 
+    @Query("""
+        SELECT q AS question, (a IS NOT NULL) AS isAnsweredByMember
+        FROM Question q
+        LEFT JOIN Answer a
+        ON q = a.question AND a.deletedAt is NULL AND a.member = :member
+        WHERE (a IS NULL) AND (q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE') AND q.livedAt < :lastDateTime
+        """)
+    Slice<QuestionInfoInterface> findNotAnswerdQuestionsByLivedAtBefore(@Param("member") Member member, @Param("lastDateTime") LocalDateTime lastDateTime, Pageable pageable);
+
     @Query("SELECT COUNT(q) FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE'")
     Integer getLiveOrOldQuestionCount();
 }

--- a/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/server/capple/domain/question/repository/QuestionRepository.java
@@ -29,6 +29,15 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
         "WHERE (q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE') AND q.livedAt < :lastDateTime")
     Slice<QuestionInfoInterface> findQuestionsByLivedAtBefore(@Param("member") Member member, @Param("lastDateTime") LocalDateTime lastDateTime, Pageable pageable);
 
+    @Query("""
+        SELECT q AS question, (a IS NOT NULL) AS isAnsweredByMember
+        FROM Question q
+        LEFT JOIN Answer a
+        ON q = a.question AND a.deletedAt is NULL AND a.member = :member
+        WHERE (a IS NOT NULL) AND (q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE') AND q.livedAt < :lastDateTime
+        """)
+    Slice<QuestionInfoInterface> findAnswerdQuestionsByLivedAtBefore(@Param("member") Member member, @Param("lastDateTime") LocalDateTime lastDateTime, Pageable pageable);
+
     @Query("SELECT COUNT(q) FROM Question q WHERE q.questionStatus = 'OLD' OR q.questionStatus = 'LIVE'")
     Integer getLiveOrOldQuestionCount();
 }

--- a/src/main/java/com/server/capple/domain/question/service/QuestionService.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionService.java
@@ -17,5 +17,7 @@ public interface QuestionService {
 
     SliceResponse<QuestionInfo> getQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable);
 
+    SliceResponse<QuestionInfo> getAnsweredQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable);
+
     QuestionResponse.QuestionToggleHeart toggleQuestionHeart(Member member, Long questionId);
 }

--- a/src/main/java/com/server/capple/domain/question/service/QuestionService.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionService.java
@@ -19,5 +19,8 @@ public interface QuestionService {
 
     SliceResponse<QuestionInfo> getAnsweredQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable);
 
+    SliceResponse<QuestionInfo> getNotAnsweredQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable);
+
     QuestionResponse.QuestionToggleHeart toggleQuestionHeart(Member member, Long questionId);
+
 }

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.question.service;
 
 import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.answer.service.AnswerCountService;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.question.dao.QuestionInfoInterface;
 import com.server.capple.domain.question.dto.response.QuestionResponse;
@@ -30,6 +31,7 @@ public class QuestionServiceImpl implements QuestionService {
     private final QuestionMapper questionMapper;
     private final QuestionHeartRedisRepository questionHeartRepository;
     private final QuestionCountService questionCountService;
+    private final AnswerCountService answerCountService;
 
     @Override
     public Question findQuestion(Long questionId) {
@@ -55,6 +57,16 @@ public class QuestionServiceImpl implements QuestionService {
         return SliceResponse.toSliceResponse(questionSlice, questionSlice.getContent().stream()
             .map(questionInfoInterface -> questionMapper.toQuestionInfo(questionInfoInterface.getQuestion(), questionInfoInterface.getIsAnsweredByMember())
             ).toList(), lastDateTime.toString(), questionCountService.getLiveOrOldQuestionCount());
+    }
+
+    @Override
+    public SliceResponse<QuestionInfo> getAnsweredQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable) {
+        lastDateTime = getThresholdDate(lastDateTime);
+        Slice<QuestionInfoInterface> questionSlice = questionRepository.findAnswerdQuestionsByLivedAtBefore(member, lastDateTime, pageable);
+        lastDateTime = getThresholdDateFromQuestionInfoInterface(questionSlice);
+        return SliceResponse.toSliceResponse(questionSlice, questionSlice.getContent().stream()
+            .map(questionInfoInterface -> questionMapper.toQuestionInfo(questionInfoInterface.getQuestion(), questionInfoInterface.getIsAnsweredByMember())
+            ).toList(), lastDateTime.toString(), answerCountService.getAnswerCountByMember(member));
     }
 
     @Override

--- a/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/question/service/QuestionServiceImpl.java
@@ -70,6 +70,16 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    public SliceResponse<QuestionInfo> getNotAnsweredQuestions(Member member, LocalDateTime lastDateTime, Pageable pageable) {
+        lastDateTime = getThresholdDate(lastDateTime);
+        Slice<QuestionInfoInterface> questionSlice = questionRepository.findNotAnswerdQuestionsByLivedAtBefore(member, lastDateTime, pageable);
+        lastDateTime = getThresholdDateFromQuestionInfoInterface(questionSlice);
+        return SliceResponse.toSliceResponse(questionSlice, questionSlice.getContent().stream()
+            .map(questionInfoInterface -> questionMapper.toQuestionInfo(questionInfoInterface.getQuestion(), questionInfoInterface.getIsAnsweredByMember())
+            ).toList(), lastDateTime.toString(), questionCountService.getLiveOrOldQuestionCount() - answerCountService.getAnswerCountByMember(member));
+    }
+
+    @Override
     public QuestionResponse.QuestionToggleHeart toggleQuestionHeart(Member member, Long questionId) {
         Question question = findQuestion(questionId);
 

--- a/src/test/java/com/server/capple/domain/answer/repository/AnswerRepositoryTest.java
+++ b/src/test/java/com/server/capple/domain/answer/repository/AnswerRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.server.capple.domain.answer.repository;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
+import com.server.capple.domain.member.repository.MemberRepository;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
+import com.server.capple.domain.question.repository.QuestionRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Answer 레포지토리의 ")
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class AnswerRepositoryTest {
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @BeforeEach
+    void setUp() {
+        member1 = Member.builder().role(Role.ROLE_ACADEMIER).nickname("").email("").sub("").build();
+        memberRepository.save(member1);
+
+        question1 = Question.builder().content("").questionStatus(QuestionStatus.OLD).build();
+        question2 = Question.builder().content("").questionStatus(QuestionStatus.OLD).build();
+        question3 = Question.builder().content("").questionStatus(QuestionStatus.OLD).build();
+        questionRepository.saveAll(List.of(question1, question2, question3));
+    }
+
+    static Member member1;
+    static Question question1;
+    static Question question2;
+    static Question question3;
+
+    @AfterEach
+    void tearDown() {
+        answerRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        questionRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("사용자가 작성한 답변이 없을 경우 답변의 개수를 0으로 반환한다.")
+    @Test
+    void getAnswerCountMemberIdZero() {
+        // given
+        int expected = 0;
+
+        // when
+        Integer count = answerRepository.getAnswerCountByMember(member1);
+
+        // then
+        assertEquals(expected, count);
+
+    }
+
+    @DisplayName("사용자가 작성한 답변의 개수를 조회한다.")
+    @Test
+    void getAnswerCountByMemberId() {
+        // given
+        Answer answer1 = createAnswer(question1);
+        Answer answer2 = createAnswer(question2);
+        List<Answer> answerList = List.of(answer1, answer2);
+        answerRepository.saveAll(answerList);
+
+        // when
+        Integer count = answerRepository.getAnswerCountByMember(member1);
+
+        // then
+        assertEquals(answerList.size(), count);
+    }
+
+    private static Answer createAnswer(Question question1) {
+        return Answer.builder()
+            .member(member1)
+            .question(question1)
+            .content("")
+            .build();
+    }
+}

--- a/src/test/java/com/server/capple/domain/answer/service/AnswerCountServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answer/service/AnswerCountServiceTest.java
@@ -1,0 +1,130 @@
+package com.server.capple.domain.answer.service;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
+import com.server.capple.domain.member.repository.MemberRepository;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
+import com.server.capple.domain.question.repository.QuestionRepository;
+import com.server.capple.support.ServiceTestConfig;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("AnswerCount 서비스의 ")
+@ActiveProfiles("test")
+@SpringBootTest
+class AnswerCountServiceTest {
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private AnswerCountService answerCountService;
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @BeforeEach
+    void setup() {
+        member = Member.builder()
+            .nickname("").email("").role(Role.ROLE_ACADEMIER).sub("")
+            .build();
+        memberRepository.save(member);
+        liveQuestion = Question.builder()
+            .content("").questionStatus(QuestionStatus.LIVE)
+            .build();
+        oldQuestion1 = Question.builder()
+            .content("").questionStatus(QuestionStatus.OLD)
+            .build();
+        oldQuestion2 = Question.builder()
+            .content("").questionStatus(QuestionStatus.OLD)
+            .build();
+        questionRepository.saveAll(List.of(liveQuestion,oldQuestion1,oldQuestion2));
+    }
+
+    @AfterEach
+    void tearDown() {
+        answerRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        questionRepository.deleteAllInBatch();
+        redisTemplate.delete(String.format("answerCountByMember::%d", member.getId()));
+    }
+
+    private static Member member;
+    private static Question liveQuestion;
+    private static Question oldQuestion1;
+    private static Question oldQuestion2;
+
+    @DisplayName("사용자가 작성한 답변의 개수를 조회한다.")
+    @Test
+    void getAnswerCountByMember() {
+        // given
+        Answer answer1 = createAnswer(liveQuestion);
+        Answer answer2 = createAnswer(oldQuestion1);
+        List<Answer> answerList = List.of(answer1, answer2);
+        answerRepository.saveAll(answerList);
+
+        // when
+        Integer count = answerCountService.getAnswerCountByMember(member);
+
+        // then
+        assertEquals(answerList.size(), count);
+    }
+
+    @DisplayName("사용자가 작성한 답변의 개수가 메서드 사용시 캐싱된다.")
+    @Test
+    void getAnswerCountByMemberIsCacheable() {
+        // given
+        Answer answer1 = createAnswer(liveQuestion);
+        Answer answer2 = createAnswer(oldQuestion1);
+        List<Answer> answerList = List.of(answer1, answer2);
+        answerRepository.saveAll(answerList);
+
+        answerCountService.getAnswerCountByMember(member);
+
+        // when
+        Integer count = (Integer) redisTemplate.opsForValue().get(String.format("answerCountByMember::%d", member.getId()));
+
+        // then
+        assertEquals(answerList.size(), count);
+    }
+
+
+    @DisplayName("사용자가 작성한 답변의 개수의 캐시를 만료시킬 수 있다.")
+    @Test
+    void getAnswerCountByMemberIsCacheEvictable() {
+        // given
+        Answer answer1 = createAnswer(liveQuestion);
+        Answer answer2 = createAnswer(oldQuestion1);
+        List<Answer> answerList = List.of(answer1, answer2);
+        answerRepository.saveAll(answerList);
+
+        answerCountService.getAnswerCountByMember(member);
+        answerCountService.expireMembersAnsweredCount(member);
+
+
+        // when
+        Object count = redisTemplate.opsForValue().get(String.format("answerCountByMember::%d", member.getId()));
+
+        // then
+        assertNull(count);
+    }
+
+    private Answer createAnswer(Question liveQuestion1) {
+        return Answer.builder()
+            .member(member)
+            .question(liveQuestion1)
+            .content("")
+            .build();
+    }
+}

--- a/src/test/java/com/server/capple/domain/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/server/capple/domain/question/repository/QuestionRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.server.capple.domain.question.repository;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
+import com.server.capple.domain.member.repository.MemberRepository;
+import com.server.capple.domain.question.dao.QuestionInfoInterface;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.entity.QuestionStatus;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@DisplayName("Question 레포지토리의 ")
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class QuestionRepositoryTest {
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        member1 = Member.builder().role(Role.ROLE_ACADEMIER).nickname("사용자1").email("").sub("").build();
+        member2 = Member.builder().role(Role.ROLE_ACADEMIER).nickname("사용자2").email("").sub("").build();
+        memberRepository.saveAll(List.of(member1, member2));
+
+        questions.add(Question.builder().content("질문1").livedAt(LocalDateTime.now().minusDays(7)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문2").livedAt(LocalDateTime.now().minusDays(6)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문3").livedAt(LocalDateTime.now().minusDays(5)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문4").livedAt(LocalDateTime.now().minusDays(4)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문5").livedAt(LocalDateTime.now().minusDays(3)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문6").livedAt(LocalDateTime.now().minusDays(2)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문7").livedAt(LocalDateTime.now().minusHours(1)).questionStatus(QuestionStatus.LIVE).build());
+        questionRepository.saveAll(questions);
+    }
+
+    Member member1;
+    Member member2;
+    List<Question> questions = new ArrayList<>();
+
+    @DisplayName("사용자가 답변한 질문을 조회한다.")
+    @TestFactory
+    Collection<DynamicTest> findAnswerdQuestionsByLivedAtBefore() {
+        // given
+        answerRepository.save(createAnswer(member1, questions.get(0)));
+        answerRepository.save(createAnswer(member1, questions.get(1)));
+        answerRepository.save(createAnswer(member1, questions.get(2)));
+        answerRepository.save(createAnswer(member1, questions.get(5)));
+        answerRepository.save(createAnswer(member1, questions.get(6)));
+        answerRepository.save(createAnswer(member2, questions.get(1)));
+        answerRepository.save(createAnswer(member2, questions.get(2)));
+
+        return List.of(
+            DynamicTest.dynamicTest("첫 페이지 조회", () -> {
+                // when
+                Slice<QuestionInfoInterface> returnedQuestions = questionRepository.findAnswerdQuestionsByLivedAtBefore(
+                    member1,
+                    LocalDateTime.now(),
+                    PageRequest.of(0, 3, Sort.by(Sort.Direction.DESC, "livedAt"))
+                );
+
+                // then
+                assertThat(returnedQuestions.getContent()).hasSize(3)
+                    .extracting("question.content", "question.questionStatus", "isAnsweredByMember")
+                    .containsExactlyInAnyOrder(
+                        tuple(questions.get(6).getContent(), questions.get(6).getQuestionStatus(), true),
+                        tuple(questions.get(5).getContent(), questions.get(5).getQuestionStatus(), true),
+                        tuple(questions.get(2).getContent(), questions.get(2).getQuestionStatus(), true)
+                    );
+            }),
+            DynamicTest.dynamicTest("마지막 페이지 조회", () -> {
+                // when
+                Slice<QuestionInfoInterface> returnedQuestions = questionRepository.findAnswerdQuestionsByLivedAtBefore(
+                    member1,
+                    questions.get(2).getLivedAt(),
+                    PageRequest.of(0, 3, Sort.by(Sort.Direction.DESC, "livedAt"))
+                );
+
+                // then
+                assertThat(returnedQuestions.getContent()).hasSize(2)
+                    .extracting("question.content", "question.questionStatus", "isAnsweredByMember")
+                    .containsExactlyInAnyOrder(
+                        tuple(questions.get(1).getContent(), questions.get(1).getQuestionStatus(), true),
+                        tuple(questions.get(0).getContent(), questions.get(0).getQuestionStatus(), true)
+                    );
+            })
+        );
+    }
+
+    private Answer createAnswer(Member member, Question question) {
+        return Answer.builder()
+            .member(member)
+            .question(question)
+            .content("content")
+            .build();
+    }
+}

--- a/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/server/capple/domain/question/service/QuestionServiceTest.java
@@ -1,18 +1,29 @@
 package com.server.capple.domain.question.service;
 
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
 import com.server.capple.domain.question.dto.response.QuestionResponse.QuestionInfo;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.entity.QuestionStatus;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("Question 서비스의 ")
@@ -62,6 +73,102 @@ public class QuestionServiceTest extends ServiceTestConfig {
         assertEquals(questionInfos.get(0).getQuestionStatus(), QuestionStatus.LIVE);
         assertEquals(questionInfos.get(0).getIsAnswered(), true);
         assertEquals(questionInfos.get(1).getIsAnswered(), false);
+    }
+
+    @DisplayName("사용자가 답변한 질문을 조회한다.")
+    @Transactional
+    @TestFactory
+    public Collection<DynamicTest> getAnsweredQuestions() {
+        // given
+        LocalDateTime thresholdDateTime = LocalDateTime.now().minusYears(20);
+        int pageSize = 3;
+        Member member1 = createQuestionMember("사용자1");
+        memberRepository.save(member1);
+        List<Question> questions = createQuestions(thresholdDateTime);
+        List<Answer> answers = List.of(
+            createAnswer(member1, questions.get(0)),
+            createAnswer(member1, questions.get(1)),
+            createAnswer(member1, questions.get(2)),
+            createAnswer(member1, questions.get(5)),
+            createAnswer(member1, questions.get(6)));
+        answerRepository.saveAll(answers);
+
+        return List.of(
+            DynamicTest.dynamicTest("첫 페이지 조회", () -> {
+                // when
+                SliceResponse<QuestionInfo> response = questionService.getAnsweredQuestions(
+                    member1,
+                    thresholdDateTime,
+                    PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))
+                );
+
+                // then
+                assertThat(response.getTotal()).isEqualTo(answers.size());
+                assertThat(response.getNumberOfElements()).isEqualTo(pageSize);
+                assertThat(response.getSize()).isEqualTo(pageSize);
+                assertThat(response.getThreshold()).isEqualTo(questions.get(2).getLivedAt().toString());
+                assertThat(response.isHasNext()).isEqualTo(true);
+                assertThat(response.getContent()).hasSize(3)
+                    .extracting("content", "questionStatus", "livedAt", "isAnswered")
+                    .containsExactlyInAnyOrder(
+                        tuple(questions.get(6).getContent(), questions.get(6).getQuestionStatus(), questions.get(6).getLivedAt(), true),
+                        tuple(questions.get(5).getContent(), questions.get(5).getQuestionStatus(), questions.get(5).getLivedAt(), true),
+                        tuple(questions.get(2).getContent(), questions.get(2).getQuestionStatus(), questions.get(2).getLivedAt(), true)
+                    );
+            }),
+            DynamicTest.dynamicTest("마지막 페이지 조회", () -> {
+                // when
+                SliceResponse<QuestionInfo> response = questionService.getAnsweredQuestions(
+                    member1,
+                    questions.get(2).getLivedAt(),
+                    PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "livedAt"))
+                );
+
+                // then
+                assertThat(response.getTotal()).isEqualTo(answers.size());
+                assertThat(response.getNumberOfElements()).isEqualTo(2);
+                assertThat(response.getSize()).isEqualTo(pageSize);
+                assertThat(response.getThreshold()).isEqualTo(questions.get(0).getLivedAt().toString());
+                assertThat(response.isHasNext()).isEqualTo(false);
+                assertThat(response.getContent()).hasSize(2)
+                    .extracting("content", "questionStatus", "livedAt", "isAnswered")
+                    .containsExactlyInAnyOrder(
+                        tuple(questions.get(1).getContent(), questions.get(1).getQuestionStatus(), questions.get(1).getLivedAt(), true),
+                        tuple(questions.get(0).getContent(), questions.get(0).getQuestionStatus(), questions.get(0).getLivedAt(), true)
+                    );
+            })
+        );
+    }
+
+    private Member createQuestionMember(String userName) {
+        return Member.builder()
+            .role(Role.ROLE_ACADEMIER)
+            .nickname(userName)
+            .email("")
+            .sub("")
+            .build();
+    }
+
+    private List<Question> createQuestions(LocalDateTime thresholdDateTime) {
+        List<Question> questions = new ArrayList<>();
+        questions.add(Question.builder().content("질문1").livedAt(thresholdDateTime.minusDays(7)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문2").livedAt(thresholdDateTime.minusDays(6)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문3").livedAt(thresholdDateTime.minusDays(5)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문4").livedAt(thresholdDateTime.minusDays(4)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문5").livedAt(thresholdDateTime.minusDays(3)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문6").livedAt(thresholdDateTime.minusDays(2)).questionStatus(QuestionStatus.OLD).build());
+        questions.add(Question.builder().content("질문7").livedAt(thresholdDateTime.minusHours(1)).questionStatus(QuestionStatus.LIVE).build());
+        questions.add(Question.builder().content("질문8").questionStatus(QuestionStatus.PENDING).build());
+        questionRepository.saveAll(questions);
+        return questions;
+    }
+
+    private Answer createAnswer(Member member, Question question) {
+        return Answer.builder()
+            .member(member)
+            .question(question)
+            .content("content")
+            .build();
     }
 
 /*


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#240/answerQuestionCount -> develop

### 변경 사항
- 사용자별 답변 개수의 캐싱
  - 사용자별 답변 완료 질문 조회 시와 미완료 질문 조회 시 전체 개수 반환에 사용합니다.
  - 사용자별 답변 개수의 캐싱 TTL 은 1일으로 설정했으며, 사용자가 답변을 작성 또는 삭제할 경우 캐시된 데이터를 제거합니다.
    - 사용자가 답변을 작성 또는 삭제할 경우 `AnswerCountChangedEvent` 이벤트를 통해 트랜젝션이 성공적으로 완료가 될 시에 캐시 데이터를 제거합니다.
- 사용자별 답변 완료 질문 조회 API (`GET /questions/answered`)
  - 기존의 답변 리스트 조회 API와 같은 DTO를 사용하여 일관된 인터페이스를 사용했습니다.
  - 캐싱된 사용자별 답변의 개수를 답변시 페이지의 정보와 함께 반환합니다.
- 사용자별 답변 미완료 질문 조회 API (`GET /questions/notAnswered`)
  - 기존의 답변 리스트 조회 API와 같은 DTO를 사용하여 일관된 인터페이스를 사용했습니다.
  - 캐싱된 사용자별 답변의 개수와 전체 질문의 개수로 사용자의 미완료 질문의 개수를 계산해 반환합니다.
- 기존에는 사용자의 답변 조회시 사용자가 작성한 답변의 개수를 반환하지 않았지만 캐싱된 데이터를 활용해 함께 반환합니다.

### 테스트 결과
<img width="350" alt="image" src="https://github.com/user-attachments/assets/ea89746f-9056-4f1d-9c9f-035637629674" />
<br>
<img width="350" alt="image" src="https://github.com/user-attachments/assets/d659ce74-4cdc-4e1f-a802-ab82e5d8e1d6" />
<br>
<img width="350" alt="image" src="https://github.com/user-attachments/assets/170f605d-df5f-4dcc-b6ad-09a33a708268" />
<br>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bce1ed68-c012-4f49-bd82-cfbf10218118" />
