### PR TITLE
[FEAT] 중복 이메일 가입 시 통합되도록 수정

### DIFF
--- a/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
+++ b/src/main/java/com/server/capple/config/security/jwt/service/JwtService.java
@@ -11,7 +11,7 @@ public interface JwtService {
     Authentication getAuthentication(String token);
     String getSub(String token);
     String getTokenType(String token);
-    Integer getMemberId(String token);
+    Long getMemberId(String token);
     String getRole(String token);
     Boolean isExpired(String token);
     Boolean checkJwt(String token);

--- a/src/main/java/com/server/capple/config/security/jwt/service/JwtServiceImpl.java
+++ b/src/main/java/com/server/capple/config/security/jwt/service/JwtServiceImpl.java
@@ -99,8 +99,8 @@ public class JwtServiceImpl implements JwtService {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
     }
 
-    public Integer getMemberId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Integer.class);
+    public Long getMemberId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Long.class);
     }
 
     public String getRole(String token) { //TODO 인가 관련 추가 구현 필요

--- a/src/main/java/com/server/capple/domain/member/entity/Member.java
+++ b/src/main/java/com/server/capple/domain/member/entity/Member.java
@@ -52,4 +52,8 @@ public class Member extends BaseEntity {
         this.sub = "Resign Member";
         delete();
     }
+
+    public void updateSub(String sub) {
+        this.sub = sub;
+    }
 }

--- a/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/capple/domain/member/repository/MemberRepository.java
@@ -1,11 +1,10 @@
 package com.server.capple.domain.member.repository;
 
 import com.server.capple.domain.member.entity.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -25,4 +24,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsMemberByNickname(String nickname);
 
     boolean existsMemberByEmail(String email);
+
+    Member getMemberByEmail(String email);
 }

--- a/src/test/java/com/server/capple/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/server/capple/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.server.capple.domain.member.repository;
+
+import com.server.capple.domain.member.entity.AcademyGeneration;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+import static com.server.capple.domain.member.entity.AcademyGeneration.GENERATION_3;
+import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Member 레포지토리의 ")
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class MemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private static Stream<Arguments> provideEmailAndNullable() {
+        return Stream.of(
+            Arguments.of("qapple@qapple.net", true),
+            Arguments.of("qsamsung@qsamsung.net", false)
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] : {0}을 찾으면 존재한다 -> {1}")
+    @MethodSource("provideEmailAndNullable")
+    @DisplayName("qapple@qapple.net를 가진 회원만 존재할때")
+    void getMemberByEmail(String email, Boolean isSavedMember) {
+        // given
+        String savedEmail = "qapple@qapple.net";
+        String nickname = "qapple";
+        String sub = "sub";
+        Role role = ROLE_ACADEMIER;
+        AcademyGeneration generation = GENERATION_3;
+
+        Member savedMember = Member.builder()
+            .nickname(nickname)
+            .email(savedEmail)
+            .sub(sub)
+            .role(role)
+            .academyGeneration(generation)
+            .build();
+        memberRepository.save(savedMember);
+
+        // when
+        Member memberByEmail = memberRepository.getMemberByEmail(email);
+
+        // then
+        if (isSavedMember) {
+            assertThat(memberByEmail).extracting("nickname", "email", "sub", "role", "academyGeneration")
+                .containsExactly(nickname, savedEmail, sub, role, generation);
+        } else {
+            assertThat(memberByEmail).isNull();
+        }
+    }
+}

--- a/src/test/java/com/server/capple/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/capple/domain/member/service/MemberServiceTest.java
@@ -1,7 +1,11 @@
 package com.server.capple.domain.member.service;
 
+import com.server.capple.config.security.jwt.service.JwtService;
 import com.server.capple.domain.member.dto.MemberRequest;
 import com.server.capple.domain.member.dto.MemberResponse;
+import com.server.capple.domain.member.entity.AcademyGeneration;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.entity.Role;
 import com.server.capple.support.ServiceTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,7 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-
+import static com.server.capple.domain.member.entity.AcademyGeneration.GENERATION_3;
+import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("Member 서비스의 ")
@@ -17,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MemberServiceTest extends ServiceTestConfig {
 
     @Autowired MemberService memberService;
+    @Autowired
+    JwtService jwtService;
 
     @Test
     @DisplayName("Member 프로필 조회 테스트")
@@ -50,5 +58,62 @@ public class MemberServiceTest extends ServiceTestConfig {
 //        assertEquals(memberInfo.getProfileImage(), "ari.png");
         // TODO : 추후 삭제
         assertEquals(memberInfo.getProfileImage(), "");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("회원가입 시 access토큰과 refresh 토큰을 생성한다.")
+    void signUp() {
+        // given
+        String email = "qapple@qapple.net";
+        String nickname = "qapple";
+        String sub = "sub";
+        String deviceToken = "deviceToken";
+        String signUpAccessJwt = jwtService.createSignUpAccessJwt(sub);
+
+        // when
+        MemberResponse.Tokens tokens = memberService.signUp(signUpAccessJwt, email, nickname, "", deviceToken);
+
+        // then
+        assertThat(jwtService.getMemberId(tokens.getAccessToken()))
+            .isEqualTo(jwtService.getMemberId(tokens.getRefreshToken()));
+        assertThat(tokens.getAccessToken()).isNotNull();
+        assertThat(tokens.getRefreshToken()).isNotNull();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("동일한 email로 회원가입을 시도할경우 sub만 덮어써진다.")
+    void signUpWithDuplicateEmail() {
+        // given
+        String email = "qapple@qapple.net";
+        String encryptedEmail = jwtService.createJwtFromEmail(email);
+        String nickname = "qapple";
+        String sub = "sub";
+        Role role = ROLE_ACADEMIER;
+        AcademyGeneration generation = GENERATION_3;
+        String deviceToken = "deviceToken";
+
+        Member buildedMember = Member.builder()
+            .nickname(nickname)
+            .email(encryptedEmail)
+            .sub(sub)
+            .role(role)
+            .academyGeneration(generation)
+            .build();
+        Member savedMember = memberRepository.save(buildedMember);
+
+        String newSub = "newSub";
+        String signUpAccessJwt = jwtService.createSignUpAccessJwt(newSub);
+
+        // when
+        MemberResponse.Tokens tokens = memberService.signUp(signUpAccessJwt, email, nickname, "", deviceToken);
+
+        // then
+        assertThat(memberRepository.getMemberByEmail(encryptedEmail).getSub()).isEqualTo(newSub);
+        assertThat(jwtService.getMemberId(tokens.getAccessToken())).isEqualTo(savedMember.getId());
+        assertThat(jwtService.getMemberId(tokens.getRefreshToken())).isEqualTo(savedMember.getId());
+        assertThat(tokens.getAccessToken()).isNotNull();
+        assertThat(tokens.getRefreshToken()).isNotNull();
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/245/signupWithDuplicateEmail -> develop

### 변경 사항
- 이메일 발송 시 중복 메일의 존재를 검증하는 과정을 제거했습니다.
- 회원 가입 시 동일한 이메일을 가진 회원이 이미 존재하는 경우 기존의 회원의 정보에 sub만 덮어쓰도록 변경했습니다.

### 테스트 결과
<img width="507" alt="image" src="https://github.com/user-attachments/assets/9a8f5edb-59bd-4626-a896-60e14829a9b8" />
<img width="531" alt="image" src="https://github.com/user-attachments/assets/51c4fb4c-7851-4618-ae3f-99d750eb7da3" />
