### PR TITLE
[FEAT] 답변 좋아요 알림, 답변 댓글 알림, 답변 댓글 좋아요 알림 구현

### DIFF
--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -1,6 +1,7 @@
 package com.server.capple.config.apns.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.notifiaction.entity.NotificationType;
@@ -146,6 +147,27 @@ public class ApnsClientRequest {
                     .build())
                 .build();
             this.boardId = board.getId().toString();
+        }
+    }
+
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class AnswerHeartNotificationBody {
+        private Aps aps;
+        private String answerId;
+
+        @Builder
+        public AnswerHeartNotificationBody(NotificationType type, Answer answer) {
+            this.aps = Aps.builder()
+                .threadId("answer-" + answer.getId())
+                .alert(Alert.builder()
+                    .title(type.getTitle())
+                    .body(answer.getContent())
+                    .build())
+                .build();
+            this.answerId = answer.getId().toString();
         }
     }
 }

--- a/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
+++ b/src/main/java/com/server/capple/config/apns/dto/ApnsClientRequest.java
@@ -2,6 +2,7 @@ package com.server.capple.config.apns.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.notifiaction.entity.NotificationType;
@@ -168,6 +169,28 @@ public class ApnsClientRequest {
                     .build())
                 .build();
             this.answerId = answer.getId().toString();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class AnswerCommentNotificationBody {
+        private Aps aps;
+        private String answerId;
+        private String answerCommentId;
+
+        @Builder
+        public AnswerCommentNotificationBody(NotificationType type, Answer answer, AnswerComment answerComment) {
+            this.aps = Aps.builder()
+                .threadId("answer-" + answer.getId())
+                .alert(Alert.builder()
+                    .title(type.getTitle())
+                    .body(answerComment.getContent())
+                    .build())
+                .build();
+            this.answerId = answer.getId().toString();
+            this.answerCommentId = answerComment.getId().toString();
         }
     }
 }

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -13,6 +13,7 @@ import com.server.capple.domain.answer.repository.AnswerHeartRedisRepository;
 import com.server.capple.domain.answer.repository.AnswerRepository;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.service.MemberService;
+import com.server.capple.domain.notifiaction.service.NotificationService;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.service.QuestionService;
 import com.server.capple.domain.questionSubcribeMember.service.QuestionSubscribeMemberService;
@@ -46,6 +47,7 @@ public class AnswerServiceImpl implements AnswerService {
     private final AnswerCountService answerCountService;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final QuestionSubscribeMemberService questionSubscribeMemberService;
+    private final NotificationService notificationService;
 
     @Transactional
     @Override
@@ -102,8 +104,10 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public AnswerLike toggleAnswerHeart(Member loginMember, Long answerId) {
         Member member = memberService.findMember(loginMember.getId());
-        answerRepository.findById(answerId).orElseThrow(() -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND));
+        Answer answer = answerRepository.findById(answerId).orElseThrow(() -> new RestApiException(AnswerErrorCode.ANSWER_NOT_FOUND));
         Boolean isLiked = answerHeartRedisRepository.toggleAnswerHeart(member.getId(), answerId);
+        if(isLiked)
+            notificationService.sendAnswerHeartNotification(loginMember.getId(), answer);
         return new AnswerLike(answerId, isLiked);
     }
 

--- a/src/main/java/com/server/capple/domain/answerComment/dto/AnswerCommentDBResponse.java
+++ b/src/main/java/com/server/capple/domain/answerComment/dto/AnswerCommentDBResponse.java
@@ -1,0 +1,15 @@
+package com.server.capple.domain.answerComment.dto;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.question.entity.Question;
+
+public class AnswerCommentDBResponse {
+    public interface AnswerCommentAuthorNAnswerNQuestionInfo {
+        public AnswerComment getAnswerComment();
+        public Member getAuthor();
+        public Answer getAnswer();
+        public Question getQuestion();
+    }
+}

--- a/src/main/java/com/server/capple/domain/answerComment/repository/AnswerCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/answerComment/repository/AnswerCommentRepository.java
@@ -1,12 +1,32 @@
 package com.server.capple.domain.answerComment.repository;
 
+import com.server.capple.domain.answerComment.dto.AnswerCommentDBResponse.AnswerCommentAuthorNAnswerNQuestionInfo;
 import com.server.capple.domain.answerComment.entity.AnswerComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AnswerCommentRepository extends JpaRepository<AnswerComment, Long> {
     @Query("SELECT a FROM AnswerComment a WHERE a.answer.id = :answerId ORDER BY a.createdAt")
     List<AnswerComment> findAnswerCommentByAnswerId(Long answerId);
+    @Query("""
+    SELECT
+        ac answerComment,
+        m author,
+        a answer,
+        q question
+        FROM AnswerComment ac
+        LEFT JOIN FETCH Member m
+            ON ac.member = m
+        LEFT JOIN FETCH Answer a
+            ON ac.answer = a
+        LEFT JOIN FETCH Question q
+            ON a.question = q
+        WHERE ac = :answerComment
+        ORDER BY ac.createdAt DESC
+        LIMIT 1
+    """)
+    Optional<AnswerCommentAuthorNAnswerNQuestionInfo> findAnswerCommentInfo(AnswerComment answerComment);
 }

--- a/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentServiceImpl.java
@@ -71,7 +71,10 @@ public class AnswerCommentServiceImpl implements AnswerCommentService{
     @Override
     @Transactional
     public AnswerCommentHeart heartAnswerComment(Member member, Long commentId) {
+        AnswerComment answerComment = findAnswerComment(commentId);
         Boolean isLiked = answerCommentHeartRedisRepository.toggleAnswerCommentHeart(commentId, member.getId());
+        if(isLiked)
+            notificationService.sendAnswerCommentHeartNotification(answerComment);
         return new AnswerCommentHeart(commentId, isLiked);
     }
 

--- a/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentServiceImpl.java
@@ -8,8 +8,10 @@ import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.answerComment.mapper.AnswerCommentMapper;
 import com.server.capple.domain.answerComment.repository.AnswerCommentHeartRedisRepository;
 import com.server.capple.domain.answerComment.repository.AnswerCommentRepository;
+import com.server.capple.domain.answerSubscribeMember.service.AnswerSubscribeMemberService;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.service.MemberService;
+import com.server.capple.domain.notifiaction.service.NotificationService;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.CommentErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,8 @@ public class AnswerCommentServiceImpl implements AnswerCommentService{
     private final AnswerCommentMapper answerCommentMapper;
     private final MemberService memberService;
     private final AnswerService answerService;
+    private final NotificationService notificationService;
+    private final AnswerSubscribeMemberService answerSubscribeMemberService;
 
     /* 댓글 작성 */
     @Override
@@ -36,6 +40,7 @@ public class AnswerCommentServiceImpl implements AnswerCommentService{
         Member loginMember = memberService.findMember(member.getId());
         Answer answer = answerService.findAnswer(answerId);
         AnswerComment answerComment = answerCommentRepository.save(answerCommentMapper.toAnswerCommentEntity(loginMember, answer, request.getAnswerComment()));
+        notificationService.sendAnswerCommentNotification(answer, answerComment);
         return new AnswerCommentId(answerComment.getId());
     }
 
@@ -46,6 +51,7 @@ public class AnswerCommentServiceImpl implements AnswerCommentService{
         AnswerComment answerComment = findAnswerComment(commentId);
         checkPermission(member, answerComment); // 유저 권한 체크
 
+        answerSubscribeMemberService.deleteAnswerSubscribeMemberByAnswerId(answerComment.getAnswer().getId());
         answerComment.delete();
         return new AnswerCommentId(answerComment.getId());
     }

--- a/src/main/java/com/server/capple/domain/answerSubscribeMember/entity/AnswerSubscribeMember.java
+++ b/src/main/java/com/server/capple/domain/answerSubscribeMember/entity/AnswerSubscribeMember.java
@@ -1,0 +1,25 @@
+package com.server.capple.domain.answerSubscribeMember.entity;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AnswerSubscribeMember extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "answer_subscribe_member_id")
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "answer_id", nullable = false)
+    private Answer answer;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/server/capple/domain/answerSubscribeMember/repository/AnswerSubscribeMemberRepository.java
+++ b/src/main/java/com/server/capple/domain/answerSubscribeMember/repository/AnswerSubscribeMemberRepository.java
@@ -1,0 +1,12 @@
+package com.server.capple.domain.answerSubscribeMember.repository;
+
+import com.server.capple.domain.answerSubscribeMember.entity.AnswerSubscribeMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnswerSubscribeMemberRepository extends JpaRepository<AnswerSubscribeMember, Long> {
+    Boolean existsByMemberIdAndAnswerId(Long memberId, Long answerId);
+    List<AnswerSubscribeMember> findAnswerSubscribeMembersByAnswerId(Long answerId);
+    void deleteAnswerSubscribeMemberByAnswerId(Long answerId);
+}

--- a/src/main/java/com/server/capple/domain/answerSubscribeMember/service/AnswerSubscribeMemberService.java
+++ b/src/main/java/com/server/capple/domain/answerSubscribeMember/service/AnswerSubscribeMemberService.java
@@ -1,0 +1,12 @@
+package com.server.capple.domain.answerSubscribeMember.service;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.Member;
+
+import java.util.List;
+
+public interface AnswerSubscribeMemberService {
+    void createAnswerSubscribeMember(Member member, Answer answer);
+    List<Member> findAnswerSubscribeMembers(Long answerId);
+    void deleteAnswerSubscribeMemberByAnswerId(Long answerId);
+}

--- a/src/main/java/com/server/capple/domain/answerSubscribeMember/service/AnswerSubscribeMemberServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answerSubscribeMember/service/AnswerSubscribeMemberServiceImpl.java
@@ -1,0 +1,34 @@
+package com.server.capple.domain.answerSubscribeMember.service;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerSubscribeMember.entity.AnswerSubscribeMember;
+import com.server.capple.domain.answerSubscribeMember.repository.AnswerSubscribeMemberRepository;
+import com.server.capple.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerSubscribeMemberServiceImpl implements AnswerSubscribeMemberService {
+    private final AnswerSubscribeMemberRepository answerSubscribeMemberRepository;
+
+    @Override
+    public void createAnswerSubscribeMember(Member member, Answer answer) {
+        if (answerSubscribeMemberRepository.existsByMemberIdAndAnswerId(member.getId(), answer.getId())) {
+            return;
+        }
+        answerSubscribeMemberRepository.save(AnswerSubscribeMember.builder().member(member).answer(answer).build());
+    }
+
+    @Override
+    public List<Member> findAnswerSubscribeMembers(Long answerId) {
+        return answerSubscribeMemberRepository.findAnswerSubscribeMembersByAnswerId(answerId).stream().map(AnswerSubscribeMember::getMember).toList();
+    }
+
+    @Override
+    public void deleteAnswerSubscribeMemberByAnswerId(Long answerId) {
+        answerSubscribeMemberRepository.deleteAnswerSubscribeMemberByAnswerId(answerId);
+    }
+}

--- a/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationDBResponse.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationDBResponse.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.notifiaction.dto;
 
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.notifiaction.entity.Notification;
 import com.server.capple.domain.notifiaction.entity.NotificationLog;
@@ -13,6 +14,7 @@ public class NotificationDBResponse {
         Question getNotificationLogQuestion();
         Answer getNotificationLogAnswer();
         Board getNotificationLogBoard();
+        AnswerComment getNotificationLogAnswerComment();
         Boolean getIsResponsedQuestion();
         Boolean getIsReportedBoard();
     }

--- a/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationDBResponse.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationDBResponse.java
@@ -1,10 +1,18 @@
 package com.server.capple.domain.notifiaction.dto;
 
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.notifiaction.entity.Notification;
+import com.server.capple.domain.notifiaction.entity.NotificationLog;
+import com.server.capple.domain.question.entity.Question;
 
 public class NotificationDBResponse {
     public interface NotificationDBInfo {
         Notification getNotification();
+        NotificationLog getNotificationLog();
+        Question getNotificationLogQuestion();
+        Answer getNotificationLogAnswer();
+        Board getNotificationLogBoard();
         Boolean getIsResponsedQuestion();
         Boolean getIsReportedBoard();
     }

--- a/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/dto/NotificationResponse.java
@@ -20,6 +20,7 @@ public class NotificationResponse {
         private Boolean isReportedBoard;
         private String questionId;
         private String answerId;
+        private String answerCommentId;
         private Boolean isResponsedQuestion;
         private String boardCommentId;
         private LocalDateTime createdAt;

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationLog.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationLog.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.notifiaction.entity;
 
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.question.entity.Question;
@@ -31,4 +32,7 @@ public class NotificationLog extends BaseEntity {
     @JoinColumn(name = "answer_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Answer answer;
+    @JoinColumn(name = "answer_comment_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private AnswerComment answerComment;
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/entity/NotificationType.java
@@ -14,6 +14,10 @@ public enum NotificationType {
     TODAY_QUESTION_CLOSED("오늘의 질문 답변 마감!", null),
     LIVE_QUESTION_ANSWER_ADDED("오늘의 질문", "새로운 답변이 달렸어요!"),
     NEW_FREE_BOARD("자유 게시판", "새로운 게시글이 올라왔어요!"),
+    ANSWER_HEART("누군가 내 답변에 좋아요를 눌렀어요", null),
+    ANSWER_COMMENT("누군가 내 답변에 댓글을 달았어요", null),
+    ANSWER_COMMENT_DUPLICATE("누군가 답변에 댓글을 달았어요", null),
+    ANSWER_COMMENT_HEART("누군가 내 답변의 댓글에 좋아요를 눌렀어요", null),
     ;
     private final String title;
     private final String body;

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -74,6 +74,8 @@ public class NotificationMapper {
             case TODAY_QUESTION_PUBLISHED, TODAY_QUESTION_CLOSED -> toQuestionNotificationInfo(notificationDBInfo);
             case LIVE_QUESTION_ANSWER_ADDED -> toQuestionLiveAnswerAddedNotificationInfo(notificationDBInfo);
             case NEW_FREE_BOARD -> toNewBoardNotificationInfo(notificationDBInfo);
+            case ANSWER_HEART  -> toAnswerNotificationInfo(notificationDBInfo);
+            case ANSWER_COMMENT, ANSWER_COMMENT_DUPLICATE, ANSWER_COMMENT_HEART -> null;
         };
     }
 
@@ -126,6 +128,17 @@ public class NotificationMapper {
             .boardId(notificationDBInfo.getNotification().getNotificationLog().getBoard().getId().toString())
             .isReportedBoard(notificationDBInfo.getIsReportedBoard())
             .createdAt(notificationDBInfo.getNotification().getCreatedAt())
+            .build();
+    }
+
+    private NotificationInfo toAnswerNotificationInfo(NotificationDBInfo notificationDBInfo) {
+        return NotificationInfo.builder()
+            .title(notificationDBInfo.getNotification().getType().getTitle())
+            .content(notificationDBInfo.getNotification().getNotificationLog().getAnswer().getContent())
+            .questionId(notificationDBInfo.getNotification().getNotificationLog().getQuestion().getId().toString())
+            .answerId(notificationDBInfo.getNotification().getNotificationLog().getAnswer().getId().toString())
+            .createdAt(notificationDBInfo.getNotification().getCreatedAt())
+            .isResponsedQuestion(notificationDBInfo.getIsResponsedQuestion())
             .build();
     }
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/mapper/NotificationMapper.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.notifiaction.mapper;
 
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
@@ -62,6 +63,14 @@ public class NotificationMapper {
             .build();
     }
 
+    public NotificationLog toNotificationLog(Question question, Answer answer, AnswerComment answerComment) {
+        return NotificationLog.builder()
+            .question(question)
+            .answer(answer)
+            .answerComment(answerComment)
+            .build();
+    }
+
     public SliceResponse<NotificationInfo> toNotificationInfoSlice(Slice<NotificationDBInfo> notificationDBInfo, Long lastIndex) {
         return SliceResponse.toSliceResponse(notificationDBInfo, notificationDBInfo.stream().map(this::toNotificationInfo).toList(), lastIndex.toString(), null);
     }
@@ -75,7 +84,7 @@ public class NotificationMapper {
             case LIVE_QUESTION_ANSWER_ADDED -> toQuestionLiveAnswerAddedNotificationInfo(notificationDBInfo);
             case NEW_FREE_BOARD -> toNewBoardNotificationInfo(notificationDBInfo);
             case ANSWER_HEART  -> toAnswerNotificationInfo(notificationDBInfo);
-            case ANSWER_COMMENT, ANSWER_COMMENT_DUPLICATE, ANSWER_COMMENT_HEART -> null;
+            case ANSWER_COMMENT, ANSWER_COMMENT_DUPLICATE, ANSWER_COMMENT_HEART -> toAnswerCommentNotificationInfo(notificationDBInfo);
         };
     }
 
@@ -137,6 +146,18 @@ public class NotificationMapper {
             .content(notificationDBInfo.getNotification().getNotificationLog().getAnswer().getContent())
             .questionId(notificationDBInfo.getNotification().getNotificationLog().getQuestion().getId().toString())
             .answerId(notificationDBInfo.getNotification().getNotificationLog().getAnswer().getId().toString())
+            .createdAt(notificationDBInfo.getNotification().getCreatedAt())
+            .isResponsedQuestion(notificationDBInfo.getIsResponsedQuestion())
+            .build();
+    }
+
+    private NotificationInfo toAnswerCommentNotificationInfo(NotificationDBInfo notificationDBInfo) {
+        return NotificationInfo.builder()
+            .title(notificationDBInfo.getNotification().getType().getTitle())
+            .content(notificationDBInfo.getNotification().getNotificationLog().getAnswerComment().getContent())
+            .questionId(notificationDBInfo.getNotification().getNotificationLog().getQuestion().getId().toString())
+            .answerId(notificationDBInfo.getNotification().getNotificationLog().getAnswer().getId().toString())
+            .answerCommentId(notificationDBInfo.getNotification().getNotificationLog().getAnswerComment().getId().toString())
             .createdAt(notificationDBInfo.getNotification().getCreatedAt())
             .isResponsedQuestion(notificationDBInfo.getIsResponsedQuestion())
             .build();

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -5,41 +5,52 @@ import com.server.capple.domain.notifiaction.dto.NotificationDBResponse.Notifica
 import com.server.capple.domain.notifiaction.entity.Notification;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    @EntityGraph(attributePaths = {"notificationLog", "notificationLog.question", "notificationLog.answer"})
-    @Query("SELECT " +
-        "n notification" +
-        ", CASE WHEN n.notificationLog.question IS NULL THEN NULL " +
-        "   ELSE (a.member IS NOT NULL) " +
-        "   END AS isResponsedQuestion " +
-        ", CASE WHEN n.notificationLog.board IS NULL THEN NULL " +
-        "   ELSE (br.board IS NOT NULL) " +
-        "   END AS isReportedBoard " +
-        "FROM Notification n " +
-        "LEFT JOIN Answer a " +
-        "   ON (a.question = n.notificationLog.question and a.member = :member) " +
-        "LEFT JOIN BoardReport br " +
-        "   on (br.board = n.notificationLog.board) " +
-        "WHERE " +
-        "(n.id < :lastIndex OR :lastIndex IS NULL) AND " +
-        "(" +
-        "(n.type <> com.server.capple.domain.notifiaction.entity.NotificationType.NEW_FREE_BOARD AND n.member = :member) " +
-        "OR " +
-        "((n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_PUBLISHED " +
-        "OR " +
-        "n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_CLOSED " +
-        "OR " +
-        "(n.type = com.server.capple.domain.notifiaction.entity.NotificationType.NEW_FREE_BOARD AND n.member <> :member) " +
-        ") " +
-        "AND n.createdAt > (select m.createdAt from Member m where m = :member))" +
-        ")"
-    )
+    @Query("""
+        SELECT
+        n notification
+        , nl notificationLog
+        , nlq notificationLogQuestion
+        , nla notificationLogAnswer
+        , nlb notificationLogBoard
+        , CASE WHEN n.notificationLog.question IS NULL THEN NULL
+           ELSE (a.member IS NOT NULL)
+           END AS isResponsedQuestion
+        , CASE WHEN n.notificationLog.board IS NULL THEN NULL
+           ELSE (br.board IS NOT NULL)
+           END AS isReportedBoard
+        FROM Notification n
+        LEFT JOIN FETCH NotificationLog nl
+           ON n.notificationLog = nl
+        LEFT JOIN FETCH Question nlq
+           ON nl.question = nlq
+        LEFT JOIN FETCH Answer nla
+           ON nl.answer = nla
+        LEFT JOIN FETCH Board nlb
+           ON nl.board = nlb
+        LEFT JOIN Answer a
+           ON (a.question = n.notificationLog.question and a.member = :member)
+        LEFT JOIN BoardReport br
+           on (br.board = n.notificationLog.board)
+        WHERE
+        (n.id < :lastIndex OR :lastIndex IS NULL) AND
+        (
+        (n.type <> com.server.capple.domain.notifiaction.entity.NotificationType.NEW_FREE_BOARD AND n.member = :member)
+        OR
+        ((n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_PUBLISHED
+        OR
+        n.type = com.server.capple.domain.notifiaction.entity.NotificationType.TODAY_QUESTION_CLOSED
+        OR
+        (n.type = com.server.capple.domain.notifiaction.entity.NotificationType.NEW_FREE_BOARD AND n.member <> :member)
+        )
+        AND n.createdAt > (select m.createdAt from Member m where m = :member))
+        )
+    """)
     Slice<NotificationDBInfo> findByMemberId(Member member, Long lastIndex, Pageable pageable);
     void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDateTime;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    @EntityGraph(attributePaths = {"notificationLog"})
+    @EntityGraph(attributePaths = {"notificationLog", "notificationLog.question", "notificationLog.answer"})
     @Query("SELECT " +
         "n notification" +
         ", CASE WHEN n.notificationLog.question IS NULL THEN NULL " +

--- a/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/repository/NotificationRepository.java
@@ -18,6 +18,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         , nlq notificationLogQuestion
         , nla notificationLogAnswer
         , nlb notificationLogBoard
+        , nlac notificationLogAnswerComment
         , CASE WHEN n.notificationLog.question IS NULL THEN NULL
            ELSE (a.member IS NOT NULL)
            END AS isResponsedQuestion
@@ -33,6 +34,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
            ON nl.answer = nla
         LEFT JOIN FETCH Board nlb
            ON nl.board = nlb
+        LEFT JOIN FETCH AnswerComment nlac
+           ON nl.answerComment = nlac
         LEFT JOIN Answer a
            ON (a.question = n.notificationLog.question and a.member = :member)
         LEFT JOIN BoardReport br

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.notifiaction.service;
 
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.board.entity.Board;
 import com.server.capple.domain.boardComment.entity.BoardComment;
 import com.server.capple.domain.member.entity.Member;
@@ -23,4 +24,5 @@ public interface NotificationService {
     void sendLiveAnswerAddedNotification(List<Member> subscriber, Question question, Answer answer);
     void sendNewBoardNotificationExceptAuthor(Board board, Member member);
     void sendAnswerHeartNotification(Long actorId, Answer answer);
+    void sendAnswerCommentNotification(Answer answer, AnswerComment answerComment);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
@@ -25,4 +25,5 @@ public interface NotificationService {
     void sendNewBoardNotificationExceptAuthor(Board board, Member member);
     void sendAnswerHeartNotification(Long actorId, Answer answer);
     void sendAnswerCommentNotification(Answer answer, AnswerComment answerComment);
+    void sendAnswerCommentHeartNotification(AnswerComment answerComment);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationService.java
@@ -22,4 +22,5 @@ public interface NotificationService {
     void deleteNotificationsByCreatedAtBefore(LocalDateTime targetTime);
     void sendLiveAnswerAddedNotification(List<Member> subscriber, Question question, Answer answer);
     void sendNewBoardNotificationExceptAuthor(Board board, Member member);
+    void sendAnswerHeartNotification(Long actorId, Answer answer);
 }

--- a/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/notifiaction/service/NotificationServiceImpl.java
@@ -182,4 +182,18 @@ public class NotificationServiceImpl implements NotificationService {
         Notification notification = notificationMapper.toNotification(member, notificationMapper.toNotificationLog(board), NEW_FREE_BOARD);
         notificationRepository.save(notification);
     }
+
+    @Async
+    @Override
+    public void sendAnswerHeartNotification(Long actorId, Answer answer) {
+        if(actorId.equals(answer.getMember().getId())) return;
+        AnswerHeartNotificationBody answerHeartNotificationBody = AnswerHeartNotificationBody.builder()
+            .type(ANSWER_HEART)
+            .answer(answer)
+            .build();
+        apnsService.sendApnsToMembers(answerHeartNotificationBody, answer.getMember().getId());
+
+        Notification notification = notificationMapper.toNotification(answer.getMember(), notificationMapper.toNotificationLog(answer.getQuestion(), answer), ANSWER_HEART);
+        notificationRepository.save(notification);
+    }
 }

--- a/src/test/java/com/server/capple/domain/answerSubscribeMember/repository/AnswerSubscribeMemberRepositoryTest.java
+++ b/src/test/java/com/server/capple/domain/answerSubscribeMember/repository/AnswerSubscribeMemberRepositoryTest.java
@@ -1,0 +1,190 @@
+package com.server.capple.domain.answerSubscribeMember.repository;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.answerSubscribeMember.entity.AnswerSubscribeMember;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.repository.MemberRepository;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.repository.QuestionRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
+import static com.server.capple.domain.question.entity.QuestionStatus.LIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("AnswerSubscribeMemberRepository 로 ")
+class AnswerSubscribeMemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private AnswerSubscribeMemberRepository answerSubscribeMemberRepository;
+
+    @Test
+    @Transactional
+    @DisplayName("사용자가 특정 답변에 댓글을 작성했는지 확인할 수 있다.")
+    void existsByMemberIdAndAnswerId() {
+        // given
+        Member member1 = Member.builder()
+            .nickname("member1")
+            .email("member1")
+            .sub("member1")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member member2 = Member.builder()
+            .nickname("member2")
+            .email("member2")
+            .sub("member2")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member member3 = Member.builder()
+            .nickname("member3")
+            .email("member3")
+            .sub("member3")
+            .role(ROLE_ACADEMIER)
+            .build();
+        memberRepository.saveAll(List.of(member1, member2, member3));
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(question)
+            .member(member1)
+            .build();
+        answerRepository.save(answer);
+        AnswerSubscribeMember answerSubscribeMember1 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member1)
+            .build();
+        AnswerSubscribeMember answerSubscribeMember2 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member2)
+            .build();
+        answerSubscribeMemberRepository.saveAll(List.of(answerSubscribeMember1, answerSubscribeMember2));
+
+        // when
+        Boolean result1 = answerSubscribeMemberRepository.existsByMemberIdAndAnswerId(member1.getId(), answer.getId());
+        Boolean result2 = answerSubscribeMemberRepository.existsByMemberIdAndAnswerId(member2.getId(), answer.getId());
+        Boolean result3 = answerSubscribeMemberRepository.existsByMemberIdAndAnswerId(member3.getId(), answer.getId());
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isTrue();
+        assertThat(result3).isFalse();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("특정 답변의 추가 댓글 구독자를 확인할 수 있다.")
+    void findAnswerSubscribeMembersByAnswerId() {
+        // given
+        Member member1 = Member.builder()
+            .nickname("member1")
+            .email("member1")
+            .sub("member1")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member member2 = Member.builder()
+            .nickname("member2")
+            .email("member2")
+            .sub("member2")
+            .role(ROLE_ACADEMIER)
+            .build();
+        memberRepository.saveAll(List.of(member1, member2));
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(question)
+            .member(member1)
+            .build();
+        answerRepository.save(answer);
+        AnswerSubscribeMember answerSubscribeMember1 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member1)
+            .build();
+        AnswerSubscribeMember answerSubscribeMember2 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member2)
+            .build();
+        answerSubscribeMemberRepository.saveAll(List.of(answerSubscribeMember1, answerSubscribeMember2));
+
+        // when
+        List<AnswerSubscribeMember> result = answerSubscribeMemberRepository.findAnswerSubscribeMembersByAnswerId(answer.getId());
+
+        // then
+        assertThat(result).hasSize(2)
+            .extracting("answer.id", "member.id")
+            .containsExactlyInAnyOrder(
+                tuple(answer.getId(), member1.getId()),
+                tuple(answer.getId(), member2.getId())
+            );
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("특정 답변의 구독자 리스트를 지울 수 있다.")
+    void deleteAnswerSubscribeMemberByAnswerId() {
+        // given
+        Member member1 = Member.builder()
+            .nickname("member1")
+            .email("member1")
+            .sub("member1")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member member2 = Member.builder()
+            .nickname("member2")
+            .email("member2")
+            .sub("member2")
+            .role(ROLE_ACADEMIER)
+            .build();
+        memberRepository.saveAll(List.of(member1, member2));
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(question)
+            .member(member1)
+            .build();
+        answerRepository.save(answer);
+        AnswerSubscribeMember answerSubscribeMember1 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member1)
+            .build();
+        AnswerSubscribeMember answerSubscribeMember2 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member2)
+            .build();
+        answerSubscribeMemberRepository.saveAll(List.of(answerSubscribeMember1, answerSubscribeMember2));
+
+        // when
+        answerSubscribeMemberRepository.deleteAnswerSubscribeMemberByAnswerId(answer.getId());
+
+        // then
+        List<AnswerSubscribeMember> result = answerSubscribeMemberRepository.findAnswerSubscribeMembersByAnswerId(answer.getId());
+        assertThat(result).hasSize(0);
+    }
+}

--- a/src/test/java/com/server/capple/domain/answerSubscribeMember/service/AnswerSubscribeMemberServiceImplTest.java
+++ b/src/test/java/com/server/capple/domain/answerSubscribeMember/service/AnswerSubscribeMemberServiceImplTest.java
@@ -1,0 +1,191 @@
+package com.server.capple.domain.answerSubscribeMember.service;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.answerSubscribeMember.entity.AnswerSubscribeMember;
+import com.server.capple.domain.answerSubscribeMember.repository.AnswerSubscribeMemberRepository;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.repository.MemberRepository;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.repository.QuestionRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
+import static com.server.capple.domain.question.entity.QuestionStatus.LIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("AnswerSubscribeMemberServiceImpl 로 ")
+class AnswerSubscribeMemberServiceImplTest {
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private AnswerRepository answerRepository;
+    @SpyBean
+    private AnswerSubscribeMemberRepository answerSubscribeMemberRepository;
+    @Autowired
+    private AnswerSubscribeMemberServiceImpl answerSubscribeMemberService;
+
+    @DisplayName("답변의 댓글의 구독자를 추가할 때 ")
+    @Transactional
+    @TestFactory
+    Collection<DynamicTest> createAnswerSubscribeMember() {
+        // given
+        Member member1 = Member.builder()
+            .nickname("member1")
+            .email("member1")
+            .sub("member1")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member member2 = Member.builder()
+            .nickname("member2")
+            .email("member2")
+            .sub("member2")
+            .role(ROLE_ACADEMIER)
+            .build();
+        memberRepository.saveAll(List.of(member1, member2));
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(question)
+            .member(member1)
+            .build();
+        answerRepository.save(answer);
+
+
+        return List.of(
+            DynamicTest.dynamicTest("기존에 존재하지 않는 경우 추가한다.", () -> {
+                // when
+                answerSubscribeMemberService.createAnswerSubscribeMember(member2, answer);
+
+                // then
+                verify(answerSubscribeMemberRepository, times(1)).save(any(AnswerSubscribeMember.class));
+            }),
+            DynamicTest.dynamicTest("기존에 존재하는 경우 추가 하지 않는다.", () -> {
+                // when
+                answerSubscribeMemberService.createAnswerSubscribeMember(member2, answer);
+
+                // then
+                verify(answerSubscribeMemberRepository, times(1)).save(any(AnswerSubscribeMember.class));
+            })
+        );
+    }
+
+    @Test
+    @DisplayName("답변의 구독자를 Member 엔티티로 조회할 수 있다.")
+    @Transactional
+    void findAnswerSubscribeMembers() {
+        // given
+        Member member1 = Member.builder()
+            .nickname("member1")
+            .email("member1")
+            .sub("member1")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member member2 = Member.builder()
+            .nickname("member2")
+            .email("member2")
+            .sub("member2")
+            .role(ROLE_ACADEMIER)
+            .build();
+        memberRepository.saveAll(List.of(member1, member2));
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(question)
+            .member(member1)
+            .build();
+        answerRepository.save(answer);
+        AnswerSubscribeMember answerSubscribeMember1 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member1)
+            .build();
+        AnswerSubscribeMember answerSubscribeMember2 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member2)
+            .build();
+        answerSubscribeMemberRepository.saveAll(List.of(answerSubscribeMember1, answerSubscribeMember2));
+
+        // when
+        List<Member> result = answerSubscribeMemberService.findAnswerSubscribeMembers(answer.getId());
+
+        // then
+        assertThat(result).hasSize(2)
+            .extracting("id", "nickname")
+            .containsExactlyInAnyOrder(
+                tuple(member1.getId(), member1.getNickname()),
+                tuple(member2.getId(), member2.getNickname())
+            );
+    }
+
+    @Test
+    @DisplayName("답변의 구독자 리스트를 제거할 수 있다.")
+    @Transactional
+    void deleteAnswerSubscribeMemberByAnswerId() {
+        // given
+        Member member1 = Member.builder()
+            .nickname("member1")
+            .email("member1")
+            .sub("member1")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member member2 = Member.builder()
+            .nickname("member2")
+            .email("member2")
+            .sub("member2")
+            .role(ROLE_ACADEMIER)
+            .build();
+        memberRepository.saveAll(List.of(member1, member2));
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(question)
+            .member(member1)
+            .build();
+        answerRepository.save(answer);
+        AnswerSubscribeMember answerSubscribeMember1 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member1)
+            .build();
+        AnswerSubscribeMember answerSubscribeMember2 = AnswerSubscribeMember.builder()
+            .answer(answer)
+            .member(member2)
+            .build();
+        answerSubscribeMemberRepository.saveAll(List.of(answerSubscribeMember1, answerSubscribeMember2));
+
+        // when
+        answerSubscribeMemberService.deleteAnswerSubscribeMemberByAnswerId(answer.getId());
+
+        // then
+        List<Member> result = answerSubscribeMemberService.findAnswerSubscribeMembers(answer.getId());
+        assertThat(result).hasSize(0);
+    }
+}

--- a/src/test/java/com/server/capple/domain/notifiaction/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/server/capple/domain/notifiaction/service/NotificationServiceImplTest.java
@@ -3,6 +3,9 @@ package com.server.capple.domain.notifiaction.service;
 import com.server.capple.config.apns.service.ApnsService;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
+import com.server.capple.domain.answerComment.repository.AnswerCommentRepository;
+import com.server.capple.domain.answerSubscribeMember.repository.AnswerSubscribeMemberRepository;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.repository.MemberRepository;
 import com.server.capple.domain.notifiaction.dto.NotificationDBResponse.NotificationDBInfo;
@@ -10,9 +13,7 @@ import com.server.capple.domain.notifiaction.repository.NotificationRepository;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.repository.QuestionRepository;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,14 +24,15 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 
 import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
-import static com.server.capple.domain.notifiaction.entity.NotificationType.ANSWER_HEART;
+import static com.server.capple.domain.notifiaction.entity.NotificationType.*;
 import static com.server.capple.domain.question.entity.QuestionStatus.LIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -49,11 +51,17 @@ class NotificationServiceImplTest {
     @Autowired
     private AnswerRepository answerRepository;
     @Autowired
+    private AnswerCommentRepository answerCommentRepository;
+    @Autowired
+    private AnswerSubscribeMemberRepository answerSubscribeMemberRepository;
+    @Autowired
     private NotificationRepository notificationRepository;
 
     @AfterEach
     void tearDown() {
         notificationRepository.deleteAll();
+        answerSubscribeMemberRepository.deleteAllInBatch();
+        answerCommentRepository.deleteAllInBatch();
         answerRepository.deleteAllInBatch();
         questionRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
@@ -144,5 +152,102 @@ class NotificationServiceImplTest {
                 verify(apnsService, times(0)).sendApnsToMembers(any(), anyLong());
                 assertThat(infoSlice.getContent()).hasSize(0);
             });
+    }
+
+    @DisplayName("답변의 댓글이 생길경우 ")
+    @TestFactory
+    Collection<DynamicTest> sendAnswerCommentNotification() {
+        // given
+        Member answerAuthor = Member.builder()
+            .nickname("answerAuthor")
+            .email("answerAuthor")
+            .sub("answerAuthor")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member prevCommenter = Member.builder()
+            .nickname("prevCommenter")
+            .email("prevCommenter")
+            .sub("prevCommenter")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member actor = Member.builder()
+            .nickname("actor")
+            .email("actor")
+            .sub("actor")
+            .role(ROLE_ACADEMIER)
+            .build();
+        memberRepository.saveAll(List.of(answerAuthor, prevCommenter, actor));
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(question)
+            .member(answerAuthor)
+            .build();
+        answerRepository.save(answer);
+        AnswerComment answerComment = AnswerComment.builder()
+            .content("answerComment")
+            .answer(answer)
+            .member(prevCommenter)
+            .build();
+        AnswerComment newAnswerComment = AnswerComment.builder()
+            .content("answerComment")
+            .answer(answer)
+            .member(actor)
+            .build();
+        answerCommentRepository.saveAll(List.of(answerComment, newAnswerComment));
+
+        Mockito.doReturn(true).when(apnsService).sendApnsToMembers(any(), eq(answerAuthor.getId()));
+        Mockito.doReturn(true).when(apnsService).sendApnsToMembers(any(), eq(List.of(prevCommenter.getId())));
+
+        return List.of(
+            DynamicTest.dynamicTest("댓글이 없더라도 답변의 작성자에게 알림을 발송한다.", () -> {
+                // when
+                notificationServiceImpl.sendAnswerCommentNotification(answer, answerComment);
+
+                // then
+                Awaitility.await()
+                    .atMost(Duration.ofSeconds(4))
+                    .untilAsserted(() -> {
+                        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+                        Slice<NotificationDBInfo> answerAuthorNotification = notificationRepository.findByMemberId(answerAuthor, null, pageRequest);
+                        Slice<NotificationDBInfo> prevCommentAuthorNotification = notificationRepository.findByMemberId(prevCommenter, null, pageRequest);
+                        verify(apnsService, times(1)).sendApnsToMembers(any(), eq(answerAuthor.getId()));
+                        assertThat(answerAuthorNotification.getContent()).hasSize(1)
+                            .extracting("isResponsedQuestion", "notification.type.title", "notification.notificationLog.answer.content", "notification.notificationLog.answerComment.content")
+                            .containsExactlyInAnyOrder(
+                                tuple(true, ANSWER_COMMENT.getTitle(), answer.getContent(), answerComment.getContent())
+                            );
+                        assertThat(prevCommentAuthorNotification.getContent()).hasSize(0);
+                    });
+            }),
+            DynamicTest.dynamicTest("답변의 작성자와 기존 댓글 작성자에게 모두 알림을 발송한다.", () -> {
+                // when
+                notificationServiceImpl.sendAnswerCommentNotification(answer, newAnswerComment);
+
+                // then
+                Awaitility.await()
+                    .atMost(Duration.ofSeconds(4))
+                    .untilAsserted(() -> {
+                        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+                        Slice<NotificationDBInfo> answerAuthorNotification = notificationRepository.findByMemberId(answerAuthor, null, pageRequest);
+                        Slice<NotificationDBInfo> prevCommentAuthorNotification = notificationRepository.findByMemberId(prevCommenter, null, pageRequest);
+                        verify(apnsService, times(2)).sendApnsToMembers(any(), eq(answerAuthor.getId()));
+                        verify(apnsService, times(1)).sendApnsToMembers(any(), eq(List.of(prevCommenter.getId())));
+                        assertThat(answerAuthorNotification.getContent()).hasSize(2)
+                            .extracting("isResponsedQuestion", "notification.type.title", "notification.notificationLog.answer.content", "notification.notificationLog.answerComment.content")
+                            .containsExactlyInAnyOrder(
+                                tuple(true, ANSWER_COMMENT.getTitle(), answer.getContent(), newAnswerComment.getContent()),
+                                tuple(true, ANSWER_COMMENT.getTitle(), answer.getContent(), answerComment.getContent())
+                            );
+                        assertThat(prevCommentAuthorNotification.getContent()).hasSize(1)
+                            .extracting("isResponsedQuestion", "notification.type.title", "notification.notificationLog.answer.content", "notification.notificationLog.answerComment.content")
+                            .containsExactlyInAnyOrder(tuple(false, ANSWER_COMMENT_DUPLICATE.getTitle(), answer.getContent(), newAnswerComment.getContent()));
+                    });
+            })
+        );
     }
 }

--- a/src/test/java/com/server/capple/domain/notifiaction/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/server/capple/domain/notifiaction/service/NotificationServiceImplTest.java
@@ -1,0 +1,148 @@
+package com.server.capple.domain.notifiaction.service;
+
+import com.server.capple.config.apns.service.ApnsService;
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.domain.member.repository.MemberRepository;
+import com.server.capple.domain.notifiaction.dto.NotificationDBResponse.NotificationDBInfo;
+import com.server.capple.domain.notifiaction.repository.NotificationRepository;
+import com.server.capple.domain.question.entity.Question;
+import com.server.capple.domain.question.repository.QuestionRepository;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+
+import static com.server.capple.domain.member.entity.Role.ROLE_ACADEMIER;
+import static com.server.capple.domain.notifiaction.entity.NotificationType.ANSWER_HEART;
+import static com.server.capple.domain.question.entity.QuestionStatus.LIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("NotificationService 로 ")
+class NotificationServiceImplTest {
+    @Autowired
+    private NotificationServiceImpl notificationServiceImpl;
+    @MockBean
+    private ApnsService apnsService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @AfterEach
+    void tearDown() {
+        notificationRepository.deleteAll();
+        answerRepository.deleteAllInBatch();
+        questionRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("사용자의 답변이 아닌 답변에 좋아요를 누를 경우 알림을 보낸다.")
+    void sendAnswerHeartNotification() {
+        // given
+        Member actor = Member.builder()
+            .nickname("actor")
+            .email("actor")
+            .sub("actor")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member savedActor = memberRepository.save(actor);
+        Member author = Member.builder()
+            .nickname("author")
+            .email("author")
+            .sub("author")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member savedAuthor = memberRepository.save(author);
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        Question saveQuestion = questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(saveQuestion)
+            .member(savedAuthor)
+            .build();
+        Answer saveAnswer = answerRepository.save(answer);
+
+        Mockito.doReturn(true).when(apnsService).sendApnsToMembers(any(), anyLong());
+
+        // when
+        notificationServiceImpl.sendAnswerHeartNotification(savedActor.getId(), saveAnswer);
+
+        // then
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(2))
+            .untilAsserted(() -> {
+                PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+                Slice<NotificationDBInfo> infoSlice = notificationRepository.findByMemberId(author, null, pageRequest);
+                verify(apnsService, times(1)).sendApnsToMembers(any(), anyLong());
+                assertThat(infoSlice.getContent()).hasSize(1)
+                    .extracting("isResponsedQuestion", "notification.type.title", "notification.notificationLog.answer.content")
+                    .containsExactlyInAnyOrder(tuple(true, ANSWER_HEART.getTitle(), saveAnswer.getContent()));
+            });
+    }
+
+    @Test
+    @DisplayName("자신의 답변에 좋아요를 누를 경우 알림을 보내지 않는다.")
+    void sendAnswerHeartNotification2() {
+        // given
+        Member author = Member.builder()
+            .nickname("author")
+            .email("author")
+            .sub("author")
+            .role(ROLE_ACADEMIER)
+            .build();
+        Member savedAuthor = memberRepository.save(author);
+        Question question = Question.builder()
+            .content("question")
+            .questionStatus(LIVE)
+            .build();
+        Question saveQuestion = questionRepository.save(question);
+        Answer answer = Answer.builder()
+            .content("answer")
+            .question(saveQuestion)
+            .member(savedAuthor)
+            .build();
+        Answer saveAnswer = answerRepository.save(answer);
+
+        Mockito.doReturn(true).when(apnsService).sendApnsToMembers(any(), anyLong());
+
+        // when
+        notificationServiceImpl.sendAnswerHeartNotification(savedAuthor.getId(), saveAnswer);
+
+        // then
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(2))
+            .untilAsserted(() -> {
+                PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+                Slice<NotificationDBInfo> infoSlice = notificationRepository.findByMemberId(author, null, pageRequest);
+                verify(apnsService, times(0)).sendApnsToMembers(any(), anyLong());
+                assertThat(infoSlice.getContent()).hasSize(0);
+            });
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#252/answerNotification -> develop

### 변경 사항
- 답변의 새로운 댓글 알림 발송
  - event : 답변의 새로운 댓글 작성
  - subscriber : 해당 답변의 작성자, 해당 답변에 댓글을 이미 남긴 사람
  - apns 알림 그룹을 `answer-{answerId}`로 설정하여 답변 별로 알림그룹이 형성되도록 했습니다.
  - 앱 내 notification 조회 시 `questionId`, `answerId`, `answerCommentId`, `isResponsedQuestion` 을 함께 보내줍니다.
  - APNs 알림 객체에 `answerId`(답변 id)와 `answerCommentId`(답변의 댓글 id) 를 함께 보냅니다.
- 답변의 좋아요 알림 발송
  - event : 답변의 좋아요 누르기
  - subscriber : 답변의 작성자
  - apns 알림 그룹을 `answer-{answerId}`로 설정하여 답변 별로 알림그룹이 형성되도록 했습니다.
  - 앱 내 notification 조회 시 `questionId`, `answerId`, `isResponsedQuestion` 을 함께 보내줍니다.
  - APNs 알림 객체에 `answerId` 를 함께 보냅니다.
- 답변의 댓글 좋아요 알림 발송
  - event : 답변의 댓글 좋아요 누르기
  - subscriber : 답변의 댓글 작성자
  - apns 알림 그룹을 `answer-{answerId}`로 설정하여 답변 별로 알림그룹이 형성되도록 했습니다.
  - 앱 내 notification 조회 시 `questionId`, `answerId`, `answerCommentId`, `isResponsedQuestion` 을 함께 보내줍니다.
  - APNs 알림 객체에 `answerId`(답변 id)와 `answerCommentId`(답변의 댓글 id) 를 함께 보냅니다.

### 테스트 결과
<img width="556" alt="image" src="https://github.com/user-attachments/assets/74fe3749-1c4f-4405-99b3-7c2da3a200d7" />
<img width="555" alt="image" src="https://github.com/user-attachments/assets/82019760-c091-410b-8456-40132027e1e6" />
<img width="556" alt="image" src="https://github.com/user-attachments/assets/9a9e5b36-0adc-45e9-ad68-ae4654b0f146" />

