### PR TITLE
[FIX] ANSWER - isLiked 좋아요 관련 에러 수정

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/server/capple/domain/answer/mapper/AnswerMapper.java
@@ -31,7 +31,7 @@ public class AnswerMapper {
                 .content(answerInfoDto.getAnswer().getContent())
                 .isMine(answerInfoDto.getWriterId().equals(memberId))
                 .isReported(answerInfoDto.getIsReported())
-                .isLiked(answerInfoDto.getIsLiked())
+                .isLiked(answerInfoDto.getIsLiked() == null ? false : answerInfoDto.getIsLiked())
                 .writeAt(answerInfoDto.getAnswer().getCreatedAt().toString())
                 .commentCount(answerInfoDto.getAnswer().getCommentCount())
                 .heartCount(answerInfoDto.getAnswer().getHeartCount())
@@ -50,7 +50,7 @@ public class AnswerMapper {
                 .heartCount(memberAnswer.getAnswer().getHeartCount())
                 .commentCount(memberAnswer.getAnswer().getCommentCount())
                 .writeAt(memberAnswer.getAnswer().getCreatedAt().toString())
-                .isLiked(memberAnswer.getIsLiked())
+                .isLiked(memberAnswer.getIsLiked() == null ? false : memberAnswer.getIsLiked())
                 .build();
     }
 }

--- a/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answer/service/AnswerServiceTest.java
@@ -124,6 +124,7 @@ public class AnswerServiceTest extends ServiceTestConfig {
         SliceResponse<MemberAnswerInfo> memberAnswer = answerService.getMemberAnswer(member, null, PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "createdAt")));
         //then
         assertEquals(memberAnswer.getContent().get(0).getContent(), "나는 무자비한 사람이 좋아");
+        assertEquals(memberAnswer.getContent().get(0).getIsLiked(), false);
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#271/answerLikeError -> develop

### 변경 사항
- ANSWER isLiked 필드 AnswerHeart 없을 시 null로 반환되던 에러 수정 (null이면 false로 반환하게끔 수정)
