### PR TITLE
[FIX] 답변 / 댓글 isLiked 오류 수정

### DIFF
--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -30,17 +30,33 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     boolean existsByQuestionAndMember(Question question, Member member);
 
+//    @Query("SELECT a AS answer, " +
+//        "(r IS NOT NULL) AS isReported, " +
+//        "a.member.id AS writerId, " +
+//        "a.member.profileImage AS writerProfileImage, " +
+//        "a.member.nickname AS writerNickname," +
+//        "a.member.academyGeneration AS writerAcademyGeneration " +
+//        "FROM Answer a " +
+//        "LEFT JOIN " +
+//        "Report r ON r.answer = a " +
+//        "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
+//    Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, Long lastIndex, Pageable pageable);
+    
     @Query("SELECT a AS answer, " +
-        "(r IS NOT NULL) AS isReported, " +
-        "a.member.id AS writerId, " +
-        "a.member.profileImage AS writerProfileImage, " +
-        "a.member.nickname AS writerNickname," +
-        "a.member.academyGeneration AS writerAcademyGeneration " +
-        "FROM Answer a " +
-        "LEFT JOIN " +
-        "Report r ON r.answer = a " +
-        "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
-    Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, Long lastIndex, Pageable pageable);
+            "(r IS NOT NULL) AS isReported, " +
+            "a.member.id AS writerId, " +
+            "a.member.profileImage AS writerProfileImage, " +
+            "a.member.nickname AS writerNickname, " +
+            "a.member.academyGeneration AS writerAcademyGeneration, " +
+            "CASE WHEN ah.id IS NOT NULL THEN TRUE ELSE FALSE END AS isLiked " +
+            "FROM Answer a " +
+            "LEFT JOIN Report r ON r.answer = a " +
+            "LEFT JOIN AnswerHeart ah ON ah.answer = a AND ah.member = :member AND ah.isLiked = TRUE " +
+            "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
+    Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId,
+                                              @Param("lastIndex") Long lastIndex,
+                                              @Param("member") Member member,
+                                              Pageable pageable);
 
     @Query("""
         SELECT

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -41,7 +41,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 //        "Report r ON r.answer = a " +
 //        "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
 //    Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, Long lastIndex, Pageable pageable);
-    
+
     @Query("SELECT a AS answer, " +
             "(r IS NOT NULL) AS isReported, " +
             "a.member.id AS writerId, " +
@@ -53,10 +53,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             "LEFT JOIN Report r ON r.answer = a " +
             "LEFT JOIN AnswerHeart ah ON ah.answer = a AND ah.member = :member AND ah.isLiked = TRUE " +
             "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
-    Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId,
-                                              @Param("lastIndex") Long lastIndex,
-                                              @Param("member") Member member,
-                                              Pageable pageable);
+    Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, @Param("lastIndex") Long lastIndex, @Param("member") Member member, Pageable pageable);
 
     @Query("""
         SELECT

--- a/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/server/capple/domain/answer/repository/AnswerRepository.java
@@ -30,18 +30,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     boolean existsByQuestionAndMember(Question question, Member member);
 
-//    @Query("SELECT a AS answer, " +
-//        "(r IS NOT NULL) AS isReported, " +
-//        "a.member.id AS writerId, " +
-//        "a.member.profileImage AS writerProfileImage, " +
-//        "a.member.nickname AS writerNickname," +
-//        "a.member.academyGeneration AS writerAcademyGeneration " +
-//        "FROM Answer a " +
-//        "LEFT JOIN " +
-//        "Report r ON r.answer = a " +
-//        "WHERE (a.id < :lastIndex OR :lastIndex IS NULL) AND a.question.id = :questionId")
-//    Slice<AnswerInfoInterface> findByQuestion(@Param("questionId") Long questionId, Long lastIndex, Pageable pageable);
-
     @Query("SELECT a AS answer, " +
             "(r IS NOT NULL) AS isReported, " +
             "a.member.id AS writerId, " +

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -107,8 +107,6 @@ public class AnswerServiceImpl implements AnswerService {
         return new AnswerResponse.AnswerId(answerId);
     }
 
-
-    //답변 좋아요 / 취소
     @Override
     @Transactional
     public AnswerLike toggleAnswerHeart(Member loginMember, Long answerId) {
@@ -135,7 +133,7 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public SliceResponse<AnswerInfo> getAnswerList(Long memberId, Long questionId, Long lastIndex, Pageable pageable) {
 
-        Member member = memberServiceImpl.findMember(memberId);
+        Member member = memberService.findMember(memberId);
         Slice<AnswerInfoInterface> answerInfoSliceInterface = answerRepository.findByQuestion(questionId, lastIndex, member, pageable);
         lastIndex = getLastIndexFromAnswerInfoInterface(answerInfoSliceInterface);
         return SliceResponse.toSliceResponse(answerInfoSliceInterface, answerInfoSliceInterface.getContent().stream().map(

--- a/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answer/service/AnswerServiceImpl.java
@@ -16,6 +16,7 @@ import com.server.capple.domain.answer.repository.AnswerHeartRepository;
 import com.server.capple.domain.answer.repository.AnswerRepository;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.service.MemberService;
+import com.server.capple.domain.member.service.MemberServiceImpl;
 import com.server.capple.domain.notifiaction.service.NotificationService;
 import com.server.capple.domain.question.entity.Question;
 import com.server.capple.domain.question.service.QuestionService;
@@ -54,6 +55,7 @@ public class AnswerServiceImpl implements AnswerService {
     private final AnswerHeartRepository answerHeartRepository;
     private final AnswerHeartMapper answerHeartMapper;
     private final AnswerConcurrentService answerConcurrentService;
+    private final MemberServiceImpl memberServiceImpl;
 
     @Transactional
     @Override
@@ -133,7 +135,8 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public SliceResponse<AnswerInfo> getAnswerList(Long memberId, Long questionId, Long lastIndex, Pageable pageable) {
 
-        Slice<AnswerInfoInterface> answerInfoSliceInterface = answerRepository.findByQuestion(questionId, lastIndex, pageable);
+        Member member = memberServiceImpl.findMember(memberId);
+        Slice<AnswerInfoInterface> answerInfoSliceInterface = answerRepository.findByQuestion(questionId, lastIndex, member, pageable);
         lastIndex = getLastIndexFromAnswerInfoInterface(answerInfoSliceInterface);
         return SliceResponse.toSliceResponse(answerInfoSliceInterface, answerInfoSliceInterface.getContent().stream().map(
             answerInfoDto -> answerMapper.toAnswerInfo(

--- a/src/main/java/com/server/capple/domain/answerComment/dao/AnswerCommentRDBDao.java
+++ b/src/main/java/com/server/capple/domain/answerComment/dao/AnswerCommentRDBDao.java
@@ -1,0 +1,16 @@
+package com.server.capple.domain.answerComment.dao;
+
+import com.server.capple.domain.answerComment.entity.AnswerComment;
+import com.server.capple.domain.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+public class AnswerCommentRDBDao {
+    public interface AnswerCommentInfoInterface {
+        public AnswerComment getAnswerComment();
+        public Member getWriter();
+        public String getContent();
+        public LocalDateTime getCreatedAt();
+        public Boolean getIsLiked();
+    }
+}

--- a/src/main/java/com/server/capple/domain/answerComment/dto/AnswerCommentResponse.java
+++ b/src/main/java/com/server/capple/domain/answerComment/dto/AnswerCommentResponse.java
@@ -31,7 +31,6 @@ public class AnswerCommentResponse {
         private String content;
         private Integer heartCount;
         private Boolean isLiked;
-        @JsonProperty("isMine")
         private Boolean isMine;
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/server/capple/domain/answerComment/dto/AnswerCommentResponse.java
+++ b/src/main/java/com/server/capple/domain/answerComment/dto/AnswerCommentResponse.java
@@ -1,5 +1,6 @@
 package com.server.capple.domain.answerComment.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,20 +17,23 @@ public class AnswerCommentResponse {
 
     @Getter
     @AllArgsConstructor
-    public static class AnswerCommentHeart {
+    public static class AnswerCommentLike {
         private Long answerCommentId;
         private Boolean isLiked;
     }
 
     @Getter
+    @AllArgsConstructor
     @Builder
     public static class AnswerCommentInfo {
         private Long answerCommentId;
         private Long writerId;
         private String content;
         private Integer heartCount;
+        private Boolean isLiked;
+        @JsonProperty("isMine")
+        private Boolean isMine;
         private LocalDateTime createdAt;
-
     }
 
     @Getter

--- a/src/main/java/com/server/capple/domain/answerComment/entity/AnswerCommentHeart.java
+++ b/src/main/java/com/server/capple/domain/answerComment/entity/AnswerCommentHeart.java
@@ -1,0 +1,35 @@
+package com.server.capple.domain.answerComment.entity;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SQLRestriction("deleted_at is null")
+public class AnswerCommentHeart extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answerComment_id", nullable = false)
+    private AnswerComment answerComment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private boolean isLiked;
+
+    public boolean toggleHeart() {
+        this.isLiked = !this.isLiked;
+        return isLiked;
+    }
+}

--- a/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentHeartMapper.java
+++ b/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentHeartMapper.java
@@ -1,0 +1,20 @@
+package com.server.capple.domain.answerComment.mapper;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answer.entity.AnswerHeart;
+import com.server.capple.domain.answerComment.dto.AnswerCommentResponse;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
+import com.server.capple.domain.answerComment.entity.AnswerCommentHeart;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnswerCommentHeartMapper {
+    public AnswerCommentHeart toAnswerCommentHeart(AnswerComment answerComment, Member member) {
+        return AnswerCommentHeart.builder()
+                .answerComment(answerComment)
+                .member(member)
+                .isLiked(false)
+                .build();
+    }
+}

--- a/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentMapper.java
@@ -18,16 +18,6 @@ public class AnswerCommentMapper {
                 .build();
     }
 
-//    public AnswerCommentInfo toAnswerCommentInfo(AnswerComment comment) {
-//        return AnswerCommentInfo.builder()
-//                .answerCommentId(comment.getId())
-//                .writerId(comment.getMember().getId())
-//                .content(comment.getContent())
-//                .heartCount(comment.getHeartCount())
-//                .createdAt(comment.getCreatedAt())
-//                .build();
-//    }
-
     public AnswerCommentInfo toAnswerCommentInfo(AnswerCommentRDBDao.AnswerCommentInfoInterface answerCommentInfoDto, Long memberId) {
         return AnswerCommentInfo.builder()
                 .answerCommentId(answerCommentInfoDto.getAnswerComment().getId())

--- a/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentMapper.java
+++ b/src/main/java/com/server/capple/domain/answerComment/mapper/AnswerCommentMapper.java
@@ -1,6 +1,7 @@
 package com.server.capple.domain.answerComment.mapper;
 
 import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answerComment.dao.AnswerCommentRDBDao;
 import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.*;
 import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.member.entity.Member;
@@ -17,14 +18,25 @@ public class AnswerCommentMapper {
                 .build();
     }
 
-    public AnswerCommentInfo toAnswerCommentInfo(AnswerComment comment) {
+//    public AnswerCommentInfo toAnswerCommentInfo(AnswerComment comment) {
+//        return AnswerCommentInfo.builder()
+//                .answerCommentId(comment.getId())
+//                .writerId(comment.getMember().getId())
+//                .content(comment.getContent())
+//                .heartCount(comment.getHeartCount())
+//                .createdAt(comment.getCreatedAt())
+//                .build();
+//    }
+
+    public AnswerCommentInfo toAnswerCommentInfo(AnswerCommentRDBDao.AnswerCommentInfoInterface answerCommentInfoDto, Long memberId) {
         return AnswerCommentInfo.builder()
-                .answerCommentId(comment.getId())
-                .writerId(comment.getMember().getId())
-                .content(comment.getContent())
-                .heartCount(comment.getHeartCount())
-                .createdAt(comment.getCreatedAt())
+                .answerCommentId(answerCommentInfoDto.getAnswerComment().getId())
+                .writerId(answerCommentInfoDto.getWriter().getId())
+                .content(answerCommentInfoDto.getAnswerComment().getContent())
+                .heartCount(answerCommentInfoDto.getAnswerComment().getHeartCount())
+                .isMine(answerCommentInfoDto.getWriter().getId().equals(memberId))
+                .isLiked(answerCommentInfoDto.getIsLiked() == null ? false : answerCommentInfoDto.getIsLiked())
+                .createdAt(answerCommentInfoDto.getAnswerComment().getCreatedAt())
                 .build();
     }
-
 }

--- a/src/main/java/com/server/capple/domain/answerComment/repository/AnswerCommentHeartRepository.java
+++ b/src/main/java/com/server/capple/domain/answerComment/repository/AnswerCommentHeartRepository.java
@@ -1,0 +1,15 @@
+package com.server.capple.domain.answerComment.repository;
+
+import com.server.capple.domain.answer.entity.Answer;
+import com.server.capple.domain.answer.entity.AnswerHeart;
+import com.server.capple.domain.answerComment.entity.AnswerComment;
+import com.server.capple.domain.answerComment.entity.AnswerCommentHeart;
+import com.server.capple.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AnswerCommentHeartRepository extends JpaRepository<AnswerCommentHeart, Long> {
+
+    Optional<AnswerCommentHeart> findByMemberAndAnswerComment(Member member, AnswerComment answerComment);
+}

--- a/src/main/java/com/server/capple/domain/answerComment/repository/AnswerCommentRepository.java
+++ b/src/main/java/com/server/capple/domain/answerComment/repository/AnswerCommentRepository.java
@@ -15,8 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerCommentRepository extends JpaRepository<AnswerComment, Long> {
-//    @Query("SELECT ac FROM AnswerComment ac WHERE ac.answer.id = :answerId ORDER BY ac.createdAt")
-//    Slice<AnswerCommentRDBDao.AnswerCommentInfoInterface> findAnswerCommentByAnswerId(@Param("answerId") Long answerId, @Param("member") Member member, @Param("lastIndex") Long lastIndex, Pageable pageable);
+
 @Query("SELECT ac AS answerComment, " +
         "ac.member AS writer, " +
         "ac.content AS content, " +

--- a/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentCountService.java
+++ b/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentCountService.java
@@ -27,10 +27,4 @@ public class AnswerCommentCountService {
     public CompletableFuture<Integer> updateAnswerCommentCount(Long answerId) {
         return CompletableFuture.completedFuture(answerCommentRepository.getAnswerCommentCountByAnswerId(answerId));
     }
-
-    @Cacheable(value = "answerCommentCountByMember", key = "#member.id", cacheManager = "oneDayExpireCacheManager")
-    public Integer getAnswerCommentCountByMember(Member member) { return answerCommentRepository.getAnswerCommentCountByMember(member);}
-
-    @CacheEvict(value = "answerCommentCountByMember", key = "#member.id", cacheManager = "oneDayExpireCacheManager")
-    public void expireMembersAnswerCommentedCount(Member member) {}
 }

--- a/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentCountService.java
+++ b/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentCountService.java
@@ -1,0 +1,36 @@
+package com.server.capple.domain.answerComment.service;
+
+import com.server.capple.domain.answer.repository.AnswerRepository;
+import com.server.capple.domain.answerComment.repository.AnswerCommentRepository;
+import com.server.capple.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerCommentCountService {
+    private final AnswerCommentRepository answerCommentRepository;
+
+    @Cacheable(value = "answerComment", key = "#answerId", cacheManager = "oneDayExpireCacheManager")
+    public Integer getAnswerCommentCount(Long answerId) {
+        return answerCommentRepository.getAnswerCommentCountByAnswerId(answerId);
+    }
+
+    @Async
+    @CachePut(value = "answerComment", key = "#answerId", cacheManager = "oneDayExpireCacheManager")
+    public CompletableFuture<Integer> updateAnswerCommentCount(Long answerId) {
+        return CompletableFuture.completedFuture(answerCommentRepository.getAnswerCommentCountByAnswerId(answerId));
+    }
+
+    @Cacheable(value = "answerCommentCountByMember", key = "#member.id", cacheManager = "oneDayExpireCacheManager")
+    public Integer getAnswerCommentCountByMember(Member member) { return answerCommentRepository.getAnswerCommentCountByMember(member);}
+
+    @CacheEvict(value = "answerCommentCountByMember", key = "#member.id", cacheManager = "oneDayExpireCacheManager")
+    public void expireMembersAnswerCommentedCount(Member member) {}
+}

--- a/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentService.java
+++ b/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentService.java
@@ -14,7 +14,6 @@ public interface AnswerCommentService {
     AnswerCommentId deleteAnswerComment(Member member, Long commentId);
     AnswerCommentId updateAnswerComment(Member member, Long commentId, AnswerCommentRequest request);
     AnswerCommentLike toggleAnswerCommentHeart(Member member, Long commentId);
-//    SliceResponse<AnswerCommentInfos> getAnswerCommentInfos(Long answerId);
     SliceResponse<AnswerCommentInfo> getAnswerCommentInfos(Long answerId, Long memberId, Long lastIndex, Pageable pageable);
 
 }

--- a/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentService.java
+++ b/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentService.java
@@ -4,12 +4,17 @@ import com.server.capple.domain.answerComment.dto.AnswerCommentRequest;
 import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.*;
 import com.server.capple.domain.answerComment.entity.AnswerComment;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.SliceResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface AnswerCommentService {
+
     AnswerComment findAnswerComment(Long answerCommentId);
     AnswerCommentId createAnswerComment(Member member, Long answerId, AnswerCommentRequest request);
     AnswerCommentId deleteAnswerComment(Member member, Long commentId);
     AnswerCommentId updateAnswerComment(Member member, Long commentId, AnswerCommentRequest request);
-    AnswerCommentHeart heartAnswerComment(Member member, Long commentId);
-    AnswerCommentInfos getAnswerCommentInfos(Long answerId);
+    AnswerCommentLike toggleAnswerCommentHeart(Member member, Long commentId);
+//    SliceResponse<AnswerCommentInfos> getAnswerCommentInfos(Long answerId);
+    SliceResponse<AnswerCommentInfo> getAnswerCommentInfos(Long answerId, Long memberId, Long lastIndex, Pageable pageable);
+
 }

--- a/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentServiceImpl.java
+++ b/src/main/java/com/server/capple/domain/answerComment/service/AnswerCommentServiceImpl.java
@@ -1,25 +1,36 @@
 package com.server.capple.domain.answerComment.service;
 
+import com.server.capple.domain.answer.dao.AnswerRDBDao;
 import com.server.capple.domain.answer.entity.Answer;
 import com.server.capple.domain.answer.service.AnswerConcurrentService;
 import com.server.capple.domain.answer.service.AnswerService;
+import com.server.capple.domain.answer.service.AnswerServiceImpl;
+import com.server.capple.domain.answerComment.dao.AnswerCommentRDBDao;
 import com.server.capple.domain.answerComment.dto.AnswerCommentRequest;
 import com.server.capple.domain.answerComment.dto.AnswerCommentResponse.*;
 import com.server.capple.domain.answerComment.entity.AnswerComment;
+import com.server.capple.domain.answerComment.entity.AnswerCommentHeart;
+import com.server.capple.domain.answerComment.mapper.AnswerCommentHeartMapper;
 import com.server.capple.domain.answerComment.mapper.AnswerCommentMapper;
 import com.server.capple.domain.answerComment.repository.AnswerCommentHeartRedisRepository;
+import com.server.capple.domain.answerComment.repository.AnswerCommentHeartRepository;
 import com.server.capple.domain.answerComment.repository.AnswerCommentRepository;
 import com.server.capple.domain.answerSubscribeMember.service.AnswerSubscribeMemberService;
 import com.server.capple.domain.member.entity.Member;
 import com.server.capple.domain.member.service.MemberService;
 import com.server.capple.domain.notifiaction.service.NotificationService;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.global.exception.RestApiException;
 import com.server.capple.global.exception.errorCode.CommentErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 
 @Service
@@ -27,7 +38,7 @@ import java.util.List;
 public class AnswerCommentServiceImpl implements AnswerCommentService{
 
     private final AnswerCommentRepository answerCommentRepository;
-    private final AnswerCommentHeartRedisRepository answerCommentHeartRedisRepository;
+    private final AnswerCommentHeartRepository answerCommentHeartRepository;
     private final AnswerCommentMapper answerCommentMapper;
     private final MemberService memberService;
     private final AnswerService answerService;
@@ -35,6 +46,8 @@ public class AnswerCommentServiceImpl implements AnswerCommentService{
     private final AnswerSubscribeMemberService answerSubscribeMemberService;
     private final AnswerCommentConcurrentService answerCommentConcurrentService;
     private final AnswerConcurrentService answerConcurrentService;
+    private final AnswerCommentCountService answerCommentCountService;
+    private final AnswerCommentHeartMapper answerCommentHeartMapper;
 
     /* 댓글 작성 */
     @Override
@@ -76,28 +89,47 @@ public class AnswerCommentServiceImpl implements AnswerCommentService{
         return new AnswerCommentId(commentId);
     }
 
-    /* 댓글 좋아요/취소 */
     @Override
     @Transactional
-    public AnswerCommentHeart heartAnswerComment(Member member, Long commentId) {
+    public AnswerCommentLike toggleAnswerCommentHeart(Member loginMember, Long commentId) {
+        Member member = memberService.findMember(loginMember.getId());
         AnswerComment answerComment = findAnswerComment(commentId);
-        Boolean isLiked = answerCommentHeartRedisRepository.toggleAnswerCommentHeart(commentId, member.getId());
-        if(isLiked)
-            notificationService.sendAnswerCommentHeartNotification(answerComment);
-        if (!answerCommentConcurrentService.setHeartCount(answerComment, isLiked)) { // 댓글 좋아요 heartCount 감소
+
+        // 좋아요 여부 확인 (없으면 새로 저장)
+        AnswerCommentHeart answerCommentHeart = answerCommentHeartRepository.findByMemberAndAnswerComment(member, answerComment)
+                .orElseGet(() -> {
+                    AnswerCommentHeart newHeart = answerCommentHeartMapper.toAnswerCommentHeart(answerComment, member);
+                    return answerCommentHeartRepository.save(newHeart);
+                });
+
+        boolean isLiked = answerCommentHeart.toggleHeart();
+
+        if (!answerCommentConcurrentService.setHeartCount(answerComment, isLiked)) {
             throw new RestApiException(CommentErrorCode.COMMENT_HEART_CHANGE_FAILED);
         }
-        return new AnswerCommentHeart(commentId, isLiked);
+
+        if (isLiked) {
+            notificationService.sendAnswerCommentHeartNotification(answerComment);
+        }
+
+        return new AnswerCommentLike(commentId, isLiked);
     }
 
-    /* 답변에 대한 댓글 조회 */
     @Override
-    public AnswerCommentInfos getAnswerCommentInfos(Long answerId) {
-        List<AnswerCommentInfo> commentInfos = answerCommentRepository.findAnswerCommentByAnswerId(answerId).stream()
-                .map(answerCommentMapper::toAnswerCommentInfo)
-                .toList();
+    public SliceResponse<AnswerCommentInfo> getAnswerCommentInfos(Long answerId, Long memberId, Long lastIndex, Pageable pageable) {
 
-        return new AnswerCommentInfos(commentInfos);
+        Member member = memberService.findMember(memberId);
+        Slice<AnswerCommentRDBDao.AnswerCommentInfoInterface> answerCommentSliceInterfaces = answerCommentRepository.findAnswerCommentByAnswerId(answerId, member, lastIndex, pageable);
+
+        lastIndex = getLastIndexFromAnswerCommentInfoInterface(answerCommentSliceInterfaces);
+
+        return SliceResponse.toSliceResponse(answerCommentSliceInterfaces, answerCommentSliceInterfaces.getContent().stream().map(
+                answerCommentInfoDto -> answerCommentMapper.toAnswerCommentInfo(
+                        answerCommentInfoDto,
+                        memberId
+                )
+        ).toList(), lastIndex.toString(), answerCommentCountService.getAnswerCommentCount(answerId));
+
     }
 
     private void checkPermission(Member member, AnswerComment answerComment) {
@@ -112,5 +144,24 @@ public class AnswerCommentServiceImpl implements AnswerCommentService{
         return answerCommentRepository.findById(answerCommentId).orElseThrow(
                 () -> new RestApiException(CommentErrorCode.COMMENT_NOT_FOUND)
         );
+    }
+
+    private Long getLastIndexFromAnswerCommentInfoInterface(Slice<AnswerCommentRDBDao.AnswerCommentInfoInterface> answerCommentInfoSliceInterface) {
+        if(answerCommentInfoSliceInterface.hasContent())
+            return answerCommentInfoSliceInterface.stream().map(AnswerCommentRDBDao.AnswerCommentInfoInterface::getAnswerComment).map(AnswerComment::getId).min(Long::compareTo).get();
+        return -1L;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class AnswerCommentCountChangedEvent {
+        private Long answerId;
+        private Member member;
+    }
+
+    @TransactionalEventListener(classes = AnswerCommentServiceImpl.AnswerCommentCountChangedEvent.class, phase = TransactionPhase.AFTER_COMPLETION)
+    public void handleQuestionCreatedEvent(AnswerCommentServiceImpl.AnswerCommentCountChangedEvent event) {
+        answerCommentCountService.updateAnswerCommentCount(event.getAnswerId());
+        answerCommentCountService.expireMembersAnswerCommentedCount(event.getMember());
     }
 }

--- a/src/test/java/com/server/capple/domain/answerComment/controller/AnswerCommentControllerTest.java
+++ b/src/test/java/com/server/capple/domain/answerComment/controller/AnswerCommentControllerTest.java
@@ -3,15 +3,21 @@ package com.server.capple.domain.answerComment.controller;
 import com.server.capple.domain.answerComment.dto.AnswerCommentRequest;
 import com.server.capple.domain.answerComment.dto.AnswerCommentResponse;
 import com.server.capple.domain.member.entity.Member;
+import com.server.capple.global.common.BaseResponse;
+import com.server.capple.global.common.SliceResponse;
 import com.server.capple.support.ControllerTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -103,9 +109,9 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
     public void heartAnswerCommentTest() throws Exception {
         //given
         final String url = "/answer-comments/heart/{commentId}";
-        AnswerCommentResponse.AnswerCommentHeart response = new AnswerCommentResponse.AnswerCommentHeart(1L, Boolean.TRUE);
+        AnswerCommentResponse.AnswerCommentLike response = new AnswerCommentResponse.AnswerCommentLike(1L, Boolean.TRUE);
 
-        doReturn(response).when(answerCommentService).heartAnswerComment(any(Member.class), any(Long.class));
+        doReturn(response).when(answerCommentService).toggleAnswerCommentHeart(any(Member.class), any(Long.class));
 
         //when
         ResultActions resultActions = this.mockMvc.perform(patch(url, 1L)
@@ -125,28 +131,30 @@ public class AnswerCommentControllerTest extends ControllerTestConfig {
     @Test
     @DisplayName("답변에 대한 댓글 조회 API 테스트")
     public void getAnswerCommentInfosTest() throws Exception {
-        //given
+        // given
         final String url = "/answer-comments/{answerId}";
-        AnswerCommentResponse.AnswerCommentInfos response = getAnswerCommentInfos();
+        SliceResponse<AnswerCommentResponse.AnswerCommentInfo> response = getSliceAnswerCommentInfos();
+        given(answerCommentService.getAnswerCommentInfos(any(Long.class), any(Long.class), isNull(), any(Pageable.class))).willReturn(response);
 
-        doReturn(response).when(answerCommentService).getAnswerCommentInfos(any(Long.class));
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get(url, 1L)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwt)
+        );
 
-        //when
-        ResultActions resultActions = this.mockMvc.perform(get(url, 1L)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", "Bearer " + jwt));
-
-        //then
-        resultActions.
-                andDo(print())
+        // then
+        resultActions
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("COMMON200"))
                 .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
-                .andExpect(jsonPath("$.result.answerCommentInfos[0].answerCommentId").value(1L))
-                .andExpect(jsonPath("$.result.answerCommentInfos[0].writerId").value(1L))
-                .andExpect(jsonPath("$.result.answerCommentInfos[0].content").value("댓글 1"))
-                .andExpect(jsonPath("$.result.answerCommentInfos[0].heartCount").value(3))
-                .andExpect(jsonPath("$.result.answerCommentInfos[0].createdAt").value("2022-11-01T12:02:00"));
-
+                .andExpect(jsonPath("$.result.content[0].answerCommentId").value(1L))
+                .andExpect(jsonPath("$.result.content[0].writerId").value(1L))
+                .andExpect(jsonPath("$.result.content[0].content").value("댓글 1"))
+                .andExpect(jsonPath("$.result.content[0].heartCount").value(3))
+                .andExpect(jsonPath("$.result.content[0].createdAt").value("2022-11-01T12:02:00"))
+                .andExpect(jsonPath("$.result.content[0].isLiked").value(true))
+                .andExpect(jsonPath("$.result.content[0].isMine").value(true));
     }
 }

--- a/src/test/java/com/server/capple/domain/answerComment/service/AnswerCommentConcurrentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answerComment/service/AnswerCommentConcurrentServiceTest.java
@@ -66,6 +66,7 @@ public class AnswerCommentConcurrentServiceTest extends ConcurrentTestsConfig {
 
     @AfterEach
     void tearDown() {
+        answercommentHeartRepository.deleteAllInBatch();
         answerCommentRepository.deleteAllInBatch();
         answerRepository.deleteAllInBatch();
         questionRepository.deleteAllInBatch();

--- a/src/test/java/com/server/capple/domain/answerComment/service/AnswerCommentConcurrentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answerComment/service/AnswerCommentConcurrentServiceTest.java
@@ -79,7 +79,7 @@ public class AnswerCommentConcurrentServiceTest extends ConcurrentTestsConfig {
     void answerCommentSetHeartCountTest() {
         // given
         // when
-        answerCommentService.heartAnswerComment(writer, answerComment.getId());
+        answerCommentService.toggleAnswerCommentHeart(writer, answerComment.getId());
 
         // then
         answerComment = answerCommentRepository.findById(answerComment.getId()).get();
@@ -117,7 +117,7 @@ public class AnswerCommentConcurrentServiceTest extends ConcurrentTestsConfig {
             int finalI = i;
             executorService.submit(() -> {
                 try {
-                    answerCommentService.heartAnswerComment(members.get(finalI), answerComment.getId());
+                    answerCommentService.toggleAnswerCommentHeart(members.get(finalI), answerComment.getId());
                 } catch (RestApiException e) {
                     increaseHeartFailedCnt.incrementAndGet();
                 } finally {

--- a/src/test/java/com/server/capple/domain/answerComment/service/AnswerCommentConcurrentServiceTest.java
+++ b/src/test/java/com/server/capple/domain/answerComment/service/AnswerCommentConcurrentServiceTest.java
@@ -66,7 +66,7 @@ public class AnswerCommentConcurrentServiceTest extends ConcurrentTestsConfig {
 
     @AfterEach
     void tearDown() {
-        answercommentHeartRepository.deleteAllInBatch();
+        answerCommentHeartRepository.deleteAllInBatch();
         answerCommentRepository.deleteAllInBatch();
         answerRepository.deleteAllInBatch();
         questionRepository.deleteAllInBatch();

--- a/src/test/java/com/server/capple/support/ConcurrentTestsConfig.java
+++ b/src/test/java/com/server/capple/support/ConcurrentTestsConfig.java
@@ -3,6 +3,7 @@ package com.server.capple.support;
 import com.server.capple.domain.answer.repository.AnswerRepository;
 import com.server.capple.domain.answer.service.AnswerConcurrentService;
 import com.server.capple.domain.answer.service.AnswerService;
+import com.server.capple.domain.answerComment.repository.AnswerCommentHeartRepository;
 import com.server.capple.domain.answerComment.repository.AnswerCommentRepository;
 import com.server.capple.domain.answerComment.service.AnswerCommentConcurrentService;
 import com.server.capple.domain.answerComment.service.AnswerCommentService;
@@ -53,6 +54,8 @@ public abstract class ConcurrentTestsConfig {
     protected AnswerRepository answerRepository;
     @Autowired
     protected AnswerCommentRepository answerCommentRepository;
+    @Autowired
+    protected AnswerCommentHeartRepository answercommentHeartRepository;
     @Autowired
     protected AnswerCommentConcurrentService answerCommentConcurrentService;
     @Autowired

--- a/src/test/java/com/server/capple/support/ConcurrentTestsConfig.java
+++ b/src/test/java/com/server/capple/support/ConcurrentTestsConfig.java
@@ -55,7 +55,7 @@ public abstract class ConcurrentTestsConfig {
     @Autowired
     protected AnswerCommentRepository answerCommentRepository;
     @Autowired
-    protected AnswerCommentHeartRepository answercommentHeartRepository;
+    protected AnswerCommentHeartRepository answerCommentHeartRepository;
     @Autowired
     protected AnswerCommentConcurrentService answerCommentConcurrentService;
     @Autowired

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -164,15 +164,34 @@ public abstract class ControllerTestConfig {
             .build();
     }
 
-    protected AnswerCommentInfos getAnswerCommentInfos() {
-        List<AnswerCommentInfo> answerCommentInfos = List.of(AnswerCommentInfo.builder()
-            .answerCommentId(1L)
-            .writerId(member.getId())
-            .content("댓글 1")
-            .createdAt(LocalDateTime.of(2022, 11, 1, 12, 02))
-            .heartCount(3)
-            .build());
+//    protected AnswerCommentInfos getAnswerCommentInfos() {
+//        List<AnswerCommentInfo> answerCommentInfos = List.of(AnswerCommentInfo.builder()
+//            .answerCommentId(1L)
+//            .writerId(member.getId())
+//            .content("댓글 1")
+//            .createdAt(LocalDateTime.of(2022, 11, 1, 12, 02))
+//            .heartCount(3)
+//            .build());
+//
+//        return new AnswerCommentInfos(answerCommentInfos);
+//    }
 
-        return new AnswerCommentInfos(answerCommentInfos);
+    protected SliceResponse<AnswerCommentInfo> getSliceAnswerCommentInfos() {
+        List<AnswerCommentInfo> answerCommentInfos = List.of(AnswerCommentInfo.builder()
+                .answerCommentId(1L)
+                .writerId(member.getId())
+                .content("댓글 1")
+                .createdAt(LocalDateTime.of(2022, 11, 1, 12, 2))
+                .heartCount(3)
+                .isLiked(true)
+                .isMine(true)
+                .build());
+
+        return SliceResponse.<AnswerCommentInfo>builder()
+                .size(10)
+                .content(answerCommentInfos)
+                .numberOfElements(1)
+                .hasNext(FALSE)
+                .build();
     }
 }

--- a/src/test/java/com/server/capple/support/ControllerTestConfig.java
+++ b/src/test/java/com/server/capple/support/ControllerTestConfig.java
@@ -164,18 +164,6 @@ public abstract class ControllerTestConfig {
             .build();
     }
 
-//    protected AnswerCommentInfos getAnswerCommentInfos() {
-//        List<AnswerCommentInfo> answerCommentInfos = List.of(AnswerCommentInfo.builder()
-//            .answerCommentId(1L)
-//            .writerId(member.getId())
-//            .content("댓글 1")
-//            .createdAt(LocalDateTime.of(2022, 11, 1, 12, 02))
-//            .heartCount(3)
-//            .build());
-//
-//        return new AnswerCommentInfos(answerCommentInfos);
-//    }
-
     protected SliceResponse<AnswerCommentInfo> getSliceAnswerCommentInfos() {
         List<AnswerCommentInfo> answerCommentInfos = List.of(AnswerCommentInfo.builder()
                 .answerCommentId(1L)

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -87,6 +87,7 @@ public abstract class ServiceTestConfig {
         jdbcTemplate.execute("DELETE FROM notification_log");
         jdbcTemplate.execute("DELETE FROM answer_subscribe_member");
         jdbcTemplate.execute("DELETE FROM answer_comment");
+        jdbcTemplate.execute("DELETE FROM answer_comment_heart");
         jdbcTemplate.execute("DELETE FROM answer_heart");
         jdbcTemplate.execute("DELETE FROM answer");
         jdbcTemplate.execute("DELETE FROM board_subscribe_member");

--- a/src/test/java/com/server/capple/support/ServiceTestConfig.java
+++ b/src/test/java/com/server/capple/support/ServiceTestConfig.java
@@ -86,8 +86,8 @@ public abstract class ServiceTestConfig {
         jdbcTemplate.execute("DELETE FROM notification");
         jdbcTemplate.execute("DELETE FROM notification_log");
         jdbcTemplate.execute("DELETE FROM answer_subscribe_member");
-        jdbcTemplate.execute("DELETE FROM answer_comment");
         jdbcTemplate.execute("DELETE FROM answer_comment_heart");
+        jdbcTemplate.execute("DELETE FROM answer_comment");
         jdbcTemplate.execute("DELETE FROM answer_heart");
         jdbcTemplate.execute("DELETE FROM answer");
         jdbcTemplate.execute("DELETE FROM board_subscribe_member");


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#283/isLikedError -> develop

### 변경 사항
- 답변 댓글 목록 조회 API
  - 기존 AnswerCommentInofs 리스트 반환 형식에서  SliceResponse<AnswerCommentInfo>를 반환하도록 변경하였습니다.
  - 좋아요 여부(isLiked), 본인 작성 여부(isMine) 필드를 Response에 추가하였습니다.
  - 답변 댓글 수 카운트를 캐싱하는 로직을 추가하였습니다.
  - SliceResponse<> 도입에 따른 인터페이를 추가하였습니다.
  - 기존의 코드 
    ```java
    public AnswerCommentInfos getAnswerCommentInfos(Long answerId) {
        List<AnswerCommentInfo> commentInfos = answerCommentRepository.findAnswerCommentByAnswerId(answerId).stream()
                .map(answerCommentMapper::toAnswerCommentInfo)
                .toList();

        return new AnswerCommentInfos(commentInfos);
    }
    ```
  - 변경된 코드
    ```java
      public SliceResponse<AnswerCommentInfo> getAnswerCommentInfos(Long answerId, Long memberId, Long lastIndex, Pageable pageable) {

        Member member = memberService.findMember(memberId);
        Slice<AnswerCommentRDBDao.AnswerCommentInfoInterface> answerCommentSliceInterfaces = answerCommentRepository.findAnswerCommentByAnswerId(answerId, member, lastIndex, pageable);

        lastIndex = getLastIndexFromAnswerCommentInfoInterface(answerCommentSliceInterfaces);

        return SliceResponse.toSliceResponse(answerCommentSliceInterfaces, answerCommentSliceInterfaces.getContent().stream().map(
                answerCommentInfoDto -> answerCommentMapper.toAnswerCommentInfo(
                        answerCommentInfoDto,
                        memberId
                )
        ).toList(), lastIndex.toString(), answerCommentCountService.getAnswerCommentCount(answerId));

    }
    ```

- 답변 댓글 좋아요 API
  - 답변 댓글 좋아요 API를 위한 AnswerCommentHeart 엔티티를 추가하였습니다.
  - 답변 댓글 좋아요를 토글하는 로직틀 추가하였습니다.

### 테스트 결과
- 답변 댓글 조회 및 좋아요 토글 API
![image](https://github.com/user-attachments/assets/71d74aa1-9b93-4c6d-93d7-f000b5499ee1)
